### PR TITLE
Add flex-ax CLI with API discovery and self-healing crawler

### DIFF
--- a/apps/flex-cli/.env.example
+++ b/apps/flex-cli/.env.example
@@ -1,7 +1,7 @@
-# 인증 모드: "credentials" (이메일/비밀번호) 또는 "sso" (Google SSO 등 기존 브라우저 세션 사용)
+# 인증 모드: "credentials" (이메일/비밀번호) 또는 "sso" (기존 브라우저 세션 사용)
 # AUTH_MODE=credentials
 
-# Chrome 프로필 경로 (AUTH_MODE=sso일 때 사용, 기본값: OS별 Chrome 기본 경로)
+# Chrome 프로필 경로 (AUTH_MODE=sso일 때, 기본값: OS별 Chrome 기본 경로)
 # CHROME_USER_DATA_DIR=~/Library/Application Support/Google/Chrome
 
 # flex 로그인 정보 (AUTH_MODE=credentials일 때 필수)
@@ -14,14 +14,20 @@ FLEX_PASSWORD=your-password
 # 수집 데이터 저장 경로 (기본값: ./output)
 # OUTPUT_DIR=./output
 
+# API 카탈로그 파일 경로 (기본값: ./output/api-catalog.json)
+# CATALOG_PATH=./output/api-catalog.json
+
 # 요청 간 딜레이 (밀리초, 기본값: 1000)
 # REQUEST_DELAY_MS=1000
 
 # 요청 실패 시 최대 재시도 횟수 (기본값: 3)
 # MAX_RETRIES=3
 
+# 디스커버리 타임아웃 (밀리초, 기본값: 60000)
+# DISCOVERY_TIMEOUT_MS=60000
+
 # 첨부파일 다운로드 여부 (기본값: true)
 # DOWNLOAD_ATTACHMENTS=true
 
-# 브라우저 headless 모드 (기본값: true)
+# 브라우저 headless 모드 (기본값: true, SSO 모드에서는 무시됨)
 # HEADLESS=true

--- a/apps/flex-cli/package.json
+++ b/apps/flex-cli/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "flex-ax",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "description": "flex HR SaaS AX CLI - discover, crawl, and manage flex data",
+  "bin": {
+    "flex-ax": "./dist/cli.js"
+  },
+  "scripts": {
+    "start": "tsx src/cli.ts",
+    "discover": "tsx src/cli.ts discover",
+    "crawl": "tsx src/cli.ts crawl",
+    "install-skills": "tsx src/cli.ts install-skills",
+    "build": "tsc",
+    "lint": "tsc --noEmit",
+    "clean": "rimraf output dist"
+  },
+  "dependencies": {
+    "dotenv": "^16.4.7",
+    "playwright": "^1.50.1",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.13.5",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.3",
+    "rimraf": "^6.0.1"
+  }
+}

--- a/apps/flex-cli/skills/flex-crawl.md
+++ b/apps/flex-cli/skills/flex-crawl.md
@@ -1,0 +1,36 @@
+# /flex-crawl
+
+Flex 데이터 크롤링을 실행하고, 실패 시 원인을 분석하여 코드를 수정한다.
+
+## Trigger
+
+- 사용자가 `/flex-crawl` 입력
+- "크롤러 실행", "flex 데이터 수집" 등 요청
+
+## Workflow
+
+1. `cd apps/flex-cli && AUTH_MODE=sso pnpm crawl` 실행
+   - CLI 출력에 `[FLEX-AX:AUTH] 브라우저에서 로그인을 완료해 주세요` 가 나오면 사용자에게 안내: "브라우저가 열렸습니다. flex.team에 로그인해 주세요."
+   - 타임아웃(5분) 시 사용자에게 재시도 요청
+2. 성공 시:
+   - `[FLEX-AX:CRAWL]` 출력에서 수집 결과 요약
+   - `output/` 디렉토리의 파일 수 확인
+3. 실패 시 (exit code 2 또는 에러):
+   a. `[FLEX-AX:ERROR]` 출력에서 실패한 엔드포인트와 에러 메시지 파싱
+   b. `output/api-catalog.json` 읽기 (있으면)
+   c. 에러 유형별 대응:
+      - **404 / URL 변경**: `/flex-discover` 실행하여 카탈로그 갱신 → URL 업데이트
+      - **응답 파싱 에러**: 카탈로그의 `responseBodySample`과 크롤러의 타입/매핑 코드 비교 → 수정
+      - **401 / 인증 만료**: 사용자에게 재로그인 요청
+      - **500 / 서버 에러**: 사용자에게 보고, 재시도 제안
+   d. 코드 수정 후 `tsc --noEmit`으로 타입 체크
+   e. `pnpm crawl`로 재실행하여 수정 검증
+
+## Key Files
+
+- `apps/flex-cli/src/crawlers/template.ts` — 양식 크롤러
+- `apps/flex-cli/src/crawlers/instance.ts` — 인스턴스 크롤러
+- `apps/flex-cli/src/crawlers/attendance.ts` — 근태/휴가 크롤러
+- `apps/flex-cli/src/crawlers/shared.ts` — 공유 유틸 (flexFetch, resolveUrl)
+- `apps/flex-cli/output/api-catalog.json` — API 카탈로그
+- `apps/flex-cli/output/crawl-report.json` — 크롤 리포트

--- a/apps/flex-cli/skills/flex-discover.md
+++ b/apps/flex-cli/skills/flex-discover.md
@@ -1,0 +1,30 @@
+# /flex-discover
+
+Flex API 디스커버리를 실행하고 카탈로그를 분석한다.
+
+## Trigger
+
+- 사용자가 `/flex-discover` 입력
+- "flex API 변경사항 확인", "새 워크플로우 발견" 등 요청
+
+## Workflow
+
+1. `cd apps/flex-cli && AUTH_MODE=sso pnpm discover` 실행
+   - CLI 출력에 `[FLEX-AX:AUTH] 브라우저에서 로그인을 완료해 주세요` 가 나오면 사용자에게 안내: "브라우저가 열렸습니다. flex.team에 로그인해 주세요."
+   - 타임아웃(5분) 시 사용자에게 재시도 요청
+2. CLI 완료 후 `output/api-catalog.json` 읽기
+3. 결과 분석:
+   - `entries`: 알려진 엔드포인트 목록과 URL 패턴 확인
+   - `unclassified`: 새로 발견된 미분류 API 목록 확인
+   - 이전 카탈로그와 차이가 있으면 변경사항 리포트
+4. 액션 제안:
+   - URL 변경 → `discovery/catalog.ts`의 `ENDPOINT_PATTERNS` 업데이트
+   - 응답 스키마 변경 → `responseBodySample`을 참고해 크롤러 매핑 코드 수정
+   - 새 API 발견 → 새 크롤러 모듈 작성 제안
+5. 변경사항이 있으면 코드 수정 후 `tsc --noEmit`으로 타입 체크
+
+## Key Files
+
+- `apps/flex-cli/src/discovery/catalog.ts` — ENDPOINT_PATTERNS 매핑
+- `apps/flex-cli/src/crawlers/` — 크롤러 모듈들
+- `apps/flex-cli/output/api-catalog.json` — 생성된 카탈로그

--- a/apps/flex-cli/src/auth/index.ts
+++ b/apps/flex-cli/src/auth/index.ts
@@ -1,5 +1,5 @@
 import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
-import type { CrawlerConfig } from "../config/index.js";
+import type { Config } from "../config/index.js";
 import type { Logger } from "../logger/index.js";
 
 export interface AuthContext {
@@ -10,7 +10,7 @@ export interface AuthContext {
 }
 
 export async function authenticate(
-  config: CrawlerConfig,
+  config: Config,
   logger: Logger,
 ): Promise<AuthContext> {
   if (config.authMode === "sso") {
@@ -19,14 +19,10 @@ export async function authenticate(
   return authenticateCredentials(config, logger);
 }
 
-async function launchBrowser(
-  config: CrawlerConfig,
-): Promise<{ browser: Browser; context: BrowserContext; page: Page; authHeaders: Record<string, string> }> {
-  const browser = await chromium.launch({ headless: config.headless });
-  const context = await browser.newContext();
-  const page = await context.newPage();
-  const authHeaders: Record<string, string> = {};
-
+function setupHeaderCapture(
+  page: Page,
+  authHeaders: Record<string, string>,
+): void {
   page.on("request", (request) => {
     const url = request.url();
     if (url.includes("flex.team") && url.includes("/api/")) {
@@ -38,8 +34,6 @@ async function launchBrowser(
       }
     }
   });
-
-  return { browser, context, page, authHeaders };
 }
 
 async function collectCookies(
@@ -53,29 +47,30 @@ async function collectCookies(
 }
 
 async function authenticateCredentials(
-  config: CrawlerConfig,
+  config: Config,
   logger: Logger,
 ): Promise<AuthContext> {
   logger.info("브라우저 시작...");
-  const { browser, context, page, authHeaders } = await launchBrowser(config);
+  const browser = await chromium.launch({ headless: config.headless });
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  const authHeaders: Record<string, string> = {};
+  setupHeaderCapture(page, authHeaders);
 
   logger.info("flex 로그인 페이지 이동...");
   await page.goto(`${config.flexBaseUrl}/login`, { waitUntil: "networkidle" });
 
-  // Step 1: 이메일 입력 후 Enter (다음 단계 전환)
   logger.info("이메일 입력...");
   const emailInput = page.locator('input[type="email"]');
   await emailInput.fill(config.flexEmail);
   await emailInput.press("Enter");
 
-  // Step 2: 비밀번호 필드 나타남 → 입력 → 로그인하기 클릭
   logger.info("비밀번호 입력...");
   const passwordInput = page.locator('input[type="password"]');
   await passwordInput.waitFor({ state: "visible", timeout: 10000 });
   await passwordInput.fill(config.flexPassword);
   await page.locator('button[type="submit"]').click();
 
-  // 로그인 완료 대기
   logger.info("로그인 완료 대기...");
   await page.waitForURL((url) => !url.toString().includes("/auth/login"), {
     timeout: 30000,
@@ -84,64 +79,44 @@ async function authenticateCredentials(
   await page.waitForLoadState("networkidle");
   await collectCookies(context, authHeaders);
 
-  logger.info("로그인 성공", { url: page.url() });
+  console.log("[FLEX-AX:AUTH] 로그인 성공");
   return { browser, context, page, authHeaders };
 }
 
 async function authenticateSSO(
-  config: CrawlerConfig,
+  config: Config,
   logger: Logger,
 ): Promise<AuthContext> {
-  const userDataDir = config.chromeUserDataDir || getDefaultChromeUserDataDir();
-  logger.info("SSO 모드: 기존 Chrome 프로필의 세션을 사용합니다.", { userDataDir });
+  logger.info("SSO 모드: 브라우저를 열어 수동 로그인을 진행합니다.");
 
+  const browser = await chromium.launch({ headless: false });
+  const context = await browser.newContext();
+  const page = await context.newPage();
   const authHeaders: Record<string, string> = {};
-  const context = await chromium.launchPersistentContext(userDataDir, {
-    headless: false, // SSO 모드에서는 항상 브라우저 표시
-    channel: "chrome", // 설치된 Chrome 사용
-  });
+  setupHeaderCapture(page, authHeaders);
 
-  const page = context.pages()[0] ?? await context.newPage();
+  await page.goto(`${config.flexBaseUrl}/login`, { waitUntil: "domcontentloaded", timeout: 30000 });
 
-  page.on("request", (request) => {
-    const url = request.url();
-    if (url.includes("flex.team") && url.includes("/api/")) {
-      const headers = request.headers();
-      for (const key of ["authorization", "cookie", "x-csrf-token"]) {
-        if (headers[key]) {
-          authHeaders[key] = headers[key];
-        }
-      }
-    }
-  });
+  console.log("[FLEX-AX:AUTH] 브라우저에서 로그인을 완료해 주세요");
 
-  // flex.team으로 이동 — 이미 로그인되어 있으면 바로 대시보드로 감
-  await page.goto(`${config.flexBaseUrl}`, { waitUntil: "networkidle" });
+  // 로그인 완료 대기 (최대 5분)
+  await page.waitForURL(
+    (url) => {
+      const s = url.toString();
+      return (
+        !s.includes("/login") &&
+        !s.includes("/auth/") &&
+        !s.includes("accounts.google.com")
+      );
+    },
+    { timeout: 300_000 },
+  );
 
-  // 로그인 페이지로 리다이렉트된 경우 수동 로그인 대기
-  const currentUrl = page.url();
-  if (currentUrl.includes("/login") || currentUrl.includes("/auth/") || currentUrl.includes("accounts.google.com")) {
-    logger.info("로그인이 필요합니다. 브라우저에서 로그인을 완료해 주세요. (최대 5분 대기)");
-    await page.waitForURL(
-      (url) => {
-        const s = url.toString();
-        return (
-          !s.includes("/login") &&
-          !s.includes("/auth/") &&
-          !s.includes("accounts.google.com")
-        );
-      },
-      { timeout: 300_000 },
-    );
-  }
-
-  await page.waitForLoadState("networkidle");
+  await page.waitForLoadState("networkidle").catch(() => {});
   await collectCookies(context, authHeaders);
 
-  logger.info("SSO 로그인 성공", { url: page.url() });
-
-  // launchPersistentContext는 Browser 객체가 없으므로 더미로 처리
-  return { browser: context.browser()!, context, page, authHeaders };
+  console.log("[FLEX-AX:AUTH] 로그인 성공");
+  return { browser, context, page, authHeaders };
 }
 
 function getDefaultChromeUserDataDir(): string {
@@ -153,17 +128,15 @@ function getDefaultChromeUserDataDir(): string {
   if (platform === "win32") {
     return `${process.env.LOCALAPPDATA}\\Google\\Chrome\\User Data`;
   }
-  // linux
   return `${home}/.config/google-chrome`;
 }
 
 export async function ensureAuthenticated(
   authCtx: AuthContext,
-  config: CrawlerConfig,
+  config: Config,
   logger: Logger,
 ): Promise<void> {
   try {
-    // 간단한 API 호출로 세션 유효성 확인
     const response = await authCtx.page.goto(`${config.flexBaseUrl}/api/v2/core/me`, {
       waitUntil: "domcontentloaded",
       timeout: 10000,
@@ -173,19 +146,13 @@ export async function ensureAuthenticated(
       logger.warn("세션 만료 감지, 재인증 시도...");
       await cleanup(authCtx);
       const newCtx = await authenticate(config, logger);
-      authCtx.browser = newCtx.browser;
-      authCtx.context = newCtx.context;
-      authCtx.page = newCtx.page;
-      authCtx.authHeaders = newCtx.authHeaders;
+      Object.assign(authCtx, newCtx);
     }
   } catch {
     logger.warn("세션 확인 실패, 재인증 시도...");
     await cleanup(authCtx);
     const newCtx = await authenticate(config, logger);
-    authCtx.browser = newCtx.browser;
-    authCtx.context = newCtx.context;
-    authCtx.page = newCtx.page;
-    authCtx.authHeaders = newCtx.authHeaders;
+    Object.assign(authCtx, newCtx);
   }
 }
 

--- a/apps/flex-cli/src/cli.ts
+++ b/apps/flex-cli/src/cli.ts
@@ -1,0 +1,38 @@
+import "dotenv/config";
+
+const command = process.argv[2];
+
+switch (command) {
+  case "discover": {
+    const { runDiscover } = await import("./commands/discover.js");
+    await runDiscover();
+    break;
+  }
+  case "crawl": {
+    const { runCrawl } = await import("./commands/crawl.js");
+    await runCrawl();
+    break;
+  }
+  case "install-skills": {
+    const { runInstallSkills } = await import("./commands/install-skills.js");
+    await runInstallSkills();
+    break;
+  }
+  case "check-apis": {
+    const { runCheckApis } = await import("./commands/check-apis.js");
+    await runCheckApis();
+    break;
+  }
+  default:
+    if (command && command !== "help") {
+      console.error(`[FLEX-AX:ERROR] Unknown command: ${command}`);
+    }
+    console.log(`Usage: flex-ax <command>
+
+Commands:
+  discover        API 디스커버리 → api-catalog.json 생성
+  crawl           카탈로그 기반 크롤링 → output/ 저장
+  check-apis      하드코딩된 API 엔드포인트 상태 확인
+  install-skills  에이전트 스킬을 .claude/skills/에 설치`);
+    process.exit(command === "help" ? 0 : 1);
+}

--- a/apps/flex-cli/src/commands/check-apis.ts
+++ b/apps/flex-cli/src/commands/check-apis.ts
@@ -1,0 +1,75 @@
+import { loadConfig } from "../config/index.js";
+import { createLogger } from "../logger/index.js";
+import { authenticate, cleanup } from "../auth/index.js";
+
+const APIS_TO_CHECK = [
+  { label: "template-list", method: "GET", path: "/api/v3/approval-document-template/templates" },
+  { label: "instance-search", method: "POST", path: "/action/v3/approval-document/user-boxes/search" },
+  { label: "core-me", method: "GET", path: "/api/v2/core/me" },
+  // 수정된 근태 API (userId는 core/me에서 가져와야 하므로 여기선 me로 테스트)
+  { label: "time-off-uses (old: 404)", method: "GET", path: "/api/v2/time-off/users/me/time-off-requests" },
+  { label: "time-off-uses (new)", method: "GET", path: "/api/v2/time-off/users/me/time-off-uses" },
+];
+
+export async function runCheckApis(): Promise<void> {
+  const logger = createLogger("CHECK");
+
+  let config;
+  try {
+    config = loadConfig();
+  } catch (error) {
+    logger.error("설정 로딩 실패", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    process.exit(1);
+  }
+
+  const authCtx = await authenticate(config, logger);
+
+  try {
+    console.log("\n  API 엔드포인트 상태 확인\n");
+    console.log("  " + "-".repeat(56));
+
+    for (const api of APIS_TO_CHECK) {
+      const url = `${config.flexBaseUrl}${api.path}`;
+
+      try {
+        const result = await authCtx.page.evaluate(
+          async ([fetchUrl, headers, method]) => {
+            const opts: RequestInit = {
+              method: method as string,
+              headers: headers as Record<string, string>,
+            };
+            if (method === "POST") {
+              (opts.headers as Record<string, string>)["content-type"] = "application/json";
+              opts.body = JSON.stringify({});
+            }
+            const res = await fetch(fetchUrl, opts);
+            const text = await res.text().catch(() => "");
+            let preview = "";
+            try {
+              const json = JSON.parse(text);
+              const keys = Object.keys(json);
+              preview = keys.slice(0, 3).join(", ");
+            } catch {
+              preview = text.slice(0, 50);
+            }
+            return { status: res.status, preview };
+          },
+          [url, authCtx.authHeaders, api.method] as const,
+        );
+
+        const icon = result.status >= 200 && result.status < 300 ? "OK" : result.status === 404 ? "NOT FOUND" : `ERR ${result.status}`;
+        console.log(`  ${api.method.padEnd(5)} ${api.path}`);
+        console.log(`    → ${icon}  ${result.preview ? `(${result.preview})` : ""}`);
+      } catch (error) {
+        console.log(`  ${api.method.padEnd(5)} ${api.path}`);
+        console.log(`    → FAIL  ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
+
+    console.log("\n  " + "-".repeat(56));
+  } finally {
+    await cleanup(authCtx);
+  }
+}

--- a/apps/flex-cli/src/commands/crawl.ts
+++ b/apps/flex-cli/src/commands/crawl.ts
@@ -1,0 +1,85 @@
+import { loadConfig } from "../config/index.js";
+import { createLogger } from "../logger/index.js";
+import { authenticate, cleanup } from "../auth/index.js";
+import { createStorageWriter, type CrawlReport } from "../storage/index.js";
+import { loadCatalog } from "../discovery/catalog.js";
+import { crawlTemplates } from "../crawlers/template.js";
+import { crawlInstances } from "../crawlers/instance.js";
+import { crawlAttendanceApprovals } from "../crawlers/attendance.js";
+import type { CrawlError } from "../types/common.js";
+import type { CrawlResult } from "../crawlers/shared.js";
+
+export async function runCrawl(): Promise<void> {
+  const logger = createLogger("CRAWL");
+
+  let config;
+  try {
+    config = loadConfig();
+  } catch (error) {
+    logger.error("설정 로딩 실패", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    process.exit(1);
+  }
+
+  // 카탈로그 로드 (없으면 하드코딩 폴백)
+  const catalog = await loadCatalog(config.catalogPath);
+  if (catalog) {
+    logger.info("카탈로그 로드 완료", {
+      entries: catalog.entries.length,
+      unclassified: catalog.unclassified.length,
+    });
+  } else {
+    logger.warn("카탈로그 없음 — 하드코딩 엔드포인트로 폴백합니다");
+  }
+
+  // 인증
+  const authCtx = await authenticate(config, logger);
+
+  const storage = createStorageWriter(config.outputDir, config.catalogPath);
+  const startedAt = new Date().toISOString();
+  const startTime = Date.now();
+  let templateResult: CrawlResult = { totalCount: 0, successCount: 0, failureCount: 0, errors: [], durationMs: 0 };
+  let instanceResult: CrawlResult = { totalCount: 0, successCount: 0, failureCount: 0, errors: [], durationMs: 0 };
+  let attendanceResult: CrawlResult = { totalCount: 0, successCount: 0, failureCount: 0, errors: [], durationMs: 0 };
+
+  try {
+    templateResult = await crawlTemplates(authCtx, config, catalog, storage, logger);
+    const instanceCrawlResult = await crawlInstances(authCtx, config, catalog, storage, logger);
+    instanceResult = instanceCrawlResult;
+    attendanceResult = await crawlAttendanceApprovals(
+      authCtx, config, catalog, storage, logger, instanceCrawlResult.collectedKeys,
+    );
+  } finally {
+    await cleanup(authCtx);
+  }
+
+  const completedAt = new Date().toISOString();
+  const totalErrors: CrawlError[] = [
+    ...templateResult.errors,
+    ...instanceResult.errors,
+    ...attendanceResult.errors,
+  ];
+
+  const report: CrawlReport = {
+    startedAt,
+    completedAt,
+    durationMs: Date.now() - startTime,
+    templates: templateResult,
+    instances: instanceResult,
+    attendance: attendanceResult,
+    totalErrors,
+  };
+
+  await storage.saveReport(report);
+
+  // 구조화된 출력
+  console.log(`[FLEX-AX:CRAWL] 크롤링 완료: templates=${templateResult.successCount}, instances=${instanceResult.successCount}, attendance=${attendanceResult.successCount}`);
+
+  if (totalErrors.length > 0) {
+    for (const err of totalErrors) {
+      console.log(`[FLEX-AX:ERROR] ${err.target}: ${err.message}`);
+    }
+    process.exit(2);
+  }
+}

--- a/apps/flex-cli/src/commands/discover.ts
+++ b/apps/flex-cli/src/commands/discover.ts
@@ -1,0 +1,96 @@
+import { loadConfig } from "../config/index.js";
+import { createLogger } from "../logger/index.js";
+import { authenticate, cleanup } from "../auth/index.js";
+import { createTrafficCapture } from "../discovery/traffic-capture.js";
+import { navigateForDiscovery } from "../discovery/navigator.js";
+import { buildCatalog, loadCatalog } from "../discovery/catalog.js";
+import { createStorageWriter } from "../storage/index.js";
+
+export async function runDiscover(): Promise<void> {
+  const logger = createLogger("DISCOVER");
+
+  let config;
+  try {
+    config = loadConfig();
+  } catch (error) {
+    logger.error("설정 로딩 실패", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    process.exit(1);
+  }
+
+  // 이전 카탈로그 로드 (diff용)
+  const previousCatalog = await loadCatalog(config.catalogPath);
+
+  // 인증
+  const authCtx = await authenticate(config, logger);
+
+  try {
+    // 트래픽 캡처 시작
+    const capture = createTrafficCapture(authCtx.page);
+    capture.start();
+
+    // 페이지 탐색
+    const discoveredPages = await navigateForDiscovery(authCtx.page, config, logger);
+
+    // 캡처 종료 + 카탈로그 생성
+    const captured = capture.stop();
+    logger.info(`${captured.length}개 API 요청 캡처됨`);
+
+    const catalog = buildCatalog(captured, discoveredPages, config.flexBaseUrl);
+
+    // 저장
+    const storage = createStorageWriter(config.outputDir, config.catalogPath);
+    await storage.saveCatalog(catalog);
+
+    // 결과 출력
+    console.log(`[FLEX-AX:DISCOVER] 카탈로그 생성 완료: ${config.catalogPath}`);
+    console.log(`[FLEX-AX:DISCOVER] entries: ${catalog.entries.length}, unclassified: ${catalog.unclassified.length}, pages: ${discoveredPages.length}`);
+
+    // 이전 카탈로그와 비교
+    if (previousCatalog) {
+      printDiff(previousCatalog, catalog, logger);
+    }
+
+    // 미분류 항목 출력
+    if (catalog.unclassified.length > 0) {
+      console.log("\n[FLEX-AX:DISCOVER] 미분류 엔드포인트:");
+      for (const entry of catalog.unclassified) {
+        console.log(`  ${entry.method} ${entry.urlPattern} (from: ${entry.discoveredFrom})`);
+      }
+    }
+  } finally {
+    await cleanup(authCtx);
+  }
+}
+
+function printDiff(
+  prev: { entries: Array<{ id: string | null; urlPattern: string }>; unclassified: Array<{ urlPattern: string }> },
+  curr: { entries: Array<{ id: string | null; urlPattern: string }>; unclassified: Array<{ urlPattern: string }> },
+  logger: ReturnType<typeof createLogger>,
+): void {
+  const prevIds = new Set(prev.entries.map((e) => e.id).filter(Boolean));
+  const currIds = new Set(curr.entries.map((e) => e.id).filter(Boolean));
+
+  const added = [...currIds].filter((id) => !prevIds.has(id));
+  const removed = [...prevIds].filter((id) => !currIds.has(id));
+
+  const changed: string[] = [];
+  for (const entry of curr.entries) {
+    if (!entry.id) continue;
+    const prevEntry = prev.entries.find((e) => e.id === entry.id);
+    if (prevEntry && prevEntry.urlPattern !== entry.urlPattern) {
+      changed.push(`${entry.id}: ${prevEntry.urlPattern} → ${entry.urlPattern}`);
+    }
+  }
+
+  if (added.length === 0 && removed.length === 0 && changed.length === 0) {
+    logger.info("이전 카탈로그와 변경 없음");
+    return;
+  }
+
+  console.log("\n[FLEX-AX:DISCOVER] 카탈로그 변경사항:");
+  for (const id of added) console.log(`  + 추가: ${id}`);
+  for (const id of removed) console.log(`  - 삭제: ${id}`);
+  for (const c of changed) console.log(`  ~ 변경: ${c}`);
+}

--- a/apps/flex-cli/src/commands/install-skills.ts
+++ b/apps/flex-cli/src/commands/install-skills.ts
@@ -1,0 +1,35 @@
+import { accessSync } from "node:fs";
+import { cp, mkdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export async function runInstallSkills(): Promise<void> {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const skillsSource = path.resolve(__dirname, "../../skills");
+  const projectRoot = findProjectRoot(process.cwd());
+  const skillsTarget = path.join(projectRoot, ".claude", "skills");
+
+  await mkdir(skillsTarget, { recursive: true });
+
+  await cp(skillsSource, skillsTarget, { recursive: true });
+
+  console.log(`[FLEX-AX:INSTALL] 스킬이 ${skillsTarget}에 설치되었습니다`);
+  console.log("[FLEX-AX:INSTALL] 설치된 스킬:");
+  console.log("  /flex-discover  — API 디스커버리 실행 + 카탈로그 비교");
+  console.log("  /flex-crawl     — 크롤링 실행 + 에러 분석/수정");
+}
+
+function findProjectRoot(cwd: string): string {
+  let dir = cwd;
+  while (dir !== path.dirname(dir)) {
+    // .git 파일 또는 디렉토리가 있으면 프로젝트 루트
+    try {
+      accessSync(path.join(dir, ".git"));
+      return dir;
+    } catch {
+      // .git 없음 → 상위로
+    }
+    dir = path.dirname(dir);
+  }
+  return cwd;
+}

--- a/apps/flex-cli/src/config/index.ts
+++ b/apps/flex-cli/src/config/index.ts
@@ -1,4 +1,3 @@
-import "dotenv/config";
 import { z } from "zod";
 
 const configSchema = z
@@ -9,8 +8,10 @@ const configSchema = z
     flexPassword: z.string().default(""),
     flexBaseUrl: z.string().url().default("https://flex.team"),
     outputDir: z.string().default("./output"),
+    catalogPath: z.string().default("./output/api-catalog.json"),
     requestDelayMs: z.coerce.number().int().min(0).default(1000),
     maxRetries: z.coerce.number().int().min(0).default(3),
+    discoveryTimeoutMs: z.coerce.number().int().min(0).default(60000),
     downloadAttachments: z
       .enum(["true", "false"])
       .transform((v) => v === "true")
@@ -30,9 +31,9 @@ const configSchema = z
     },
   );
 
-export type CrawlerConfig = z.infer<typeof configSchema>;
+export type Config = z.infer<typeof configSchema>;
 
-export function loadConfig(): CrawlerConfig {
+export function loadConfig(): Config {
   return configSchema.parse({
     authMode: process.env.AUTH_MODE || undefined,
     chromeUserDataDir: process.env.CHROME_USER_DATA_DIR || undefined,
@@ -40,8 +41,10 @@ export function loadConfig(): CrawlerConfig {
     flexPassword: process.env.FLEX_PASSWORD || undefined,
     flexBaseUrl: process.env.FLEX_BASE_URL || undefined,
     outputDir: process.env.OUTPUT_DIR || undefined,
+    catalogPath: process.env.CATALOG_PATH || undefined,
     requestDelayMs: process.env.REQUEST_DELAY_MS || undefined,
     maxRetries: process.env.MAX_RETRIES || undefined,
+    discoveryTimeoutMs: process.env.DISCOVERY_TIMEOUT_MS || undefined,
     downloadAttachments: process.env.DOWNLOAD_ATTACHMENTS || undefined,
     headless: process.env.HEADLESS || undefined,
   });

--- a/apps/flex-cli/src/crawlers/attendance.ts
+++ b/apps/flex-cli/src/crawlers/attendance.ts
@@ -1,0 +1,200 @@
+import type { AuthContext } from "../auth/index.js";
+import type { Config } from "../config/index.js";
+import type { Logger } from "../logger/index.js";
+import type { StorageWriter } from "../storage/index.js";
+import type { ApiCatalog } from "../types/catalog.js";
+import type { AttendanceApproval } from "../types/attendance.js";
+import {
+  type CrawlResult,
+  delay,
+  emptyCrawlResult,
+  nowISO,
+  withRetry,
+  flexFetch,
+} from "./shared.js";
+
+/**
+ * 근태/휴가 승인 수집.
+ *
+ * 디스커버리 결과, 기존 하드코딩 API는 404:
+ *   - /api/v2/time-off/users/me/time-off-requests
+ *   - /api/v2/time-tracking/users/me/overtime-requests
+ *   - /api/v2/time-tracking/users/me/work-change-requests
+ *
+ * 실제 API (카탈로그에서 발견):
+ *   - GET /api/v2/time-off/users/{userId}/time-off-uses/by-use-date-range/{from}..{to}
+ *     → timeOffUses[] 배열 반환
+ */
+export async function crawlAttendanceApprovals(
+  authCtx: AuthContext,
+  config: Config,
+  _catalog: ApiCatalog | null,
+  storage: StorageWriter,
+  logger: Logger,
+  collectedInstanceKeys: Set<string>,
+): Promise<CrawlResult> {
+  const startTime = Date.now();
+  const result = emptyCrawlResult();
+
+  logger.info("근태/휴가 승인 수집 시작");
+
+  // 현재 사용자 ID를 먼저 확인
+  const userId = await getUserId(authCtx, config, logger);
+  if (!userId) {
+    logger.error("사용자 ID를 확인할 수 없습니다");
+    result.durationMs = Date.now() - startTime;
+    return result;
+  }
+
+  // 최근 1년 범위로 휴가 사용 내역 조회
+  const now = Date.now();
+  const oneYearAgo = now - 365 * 24 * 60 * 60 * 1000;
+  const url = `${config.flexBaseUrl}/api/v2/time-off/users/${userId}/time-off-uses/by-use-date-range/${oneYearAgo}..${now}`;
+
+  try {
+    const data = await withRetry(
+      () => flexFetch<TimeOffUsesResponse>(authCtx, url),
+      { maxRetries: config.maxRetries, delayMs: config.requestDelayMs },
+    );
+
+    const uses = data.timeOffUses ?? [];
+    logger.info(`휴가 사용 내역: ${uses.length}건 발견`);
+
+    for (const use of uses) {
+      const id = use.userTimeOffRegisterEventId;
+      if (!id) continue;
+
+      if (collectedInstanceKeys.has(id)) {
+        logger.info(`중복 스킵: ${id} (인스턴스에서 이미 수집)`);
+        continue;
+      }
+
+      result.totalCount++;
+
+      try {
+        const approval: AttendanceApproval = {
+          id,
+          type: use.timeOffPolicyType ?? "TIME_OFF",
+          applicant: {
+            id: use.userIdHash,
+            name: use.userIdHash ?? "unknown", // 이름은 별도 API 필요
+          },
+          appliedAt: use.timeOffRegisterDateFrom ?? "",
+          details: {
+            dateFrom: use.timeOffRegisterDateFrom,
+            dateTo: use.timeOffRegisterDateTo,
+            days: use.useTime?.timeOffDays,
+            minutes: use.useTime?.timeOffMinutes,
+            policyType: use.timeOffPolicyType,
+            canceled: use.canceled,
+          },
+          status: mapStatus(use.timeOffUseStatus, use.approvalStatus?.status),
+          processedAt: use.timeOffRegisteredAt
+            ? new Date(use.timeOffRegisteredAt).toISOString()
+            : undefined,
+          _raw: use,
+        };
+
+        await storage.saveAttendanceApproval(approval);
+        result.successCount++;
+      } catch (error) {
+        result.failureCount++;
+        result.errors.push({
+          target: `attendance:${id}`,
+          phase: "detail",
+          message: error instanceof Error ? error.message : String(error),
+          timestamp: nowISO(),
+        });
+      }
+
+      await delay(config.requestDelayMs);
+    }
+  } catch (error) {
+    logger.warn("휴가 사용 내역 수집 실패", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    result.errors.push({
+      target: "time-off-uses",
+      phase: "list",
+      message: error instanceof Error ? error.message : String(error),
+      timestamp: nowISO(),
+    });
+  }
+
+  result.durationMs = Date.now() - startTime;
+  logger.info(`\n근태/휴가 수집 완료: 성공 ${result.successCount}, 실패 ${result.failureCount}`);
+  return result;
+}
+
+// --- 사용자 ID 조회 ---
+
+async function getUserId(
+  authCtx: AuthContext,
+  config: Config,
+  logger: Logger,
+): Promise<string | null> {
+  try {
+    // /api/v2/core/me는 404이므로, workspace-users에서 currentUser를 가져옴
+    const data = await flexFetch<{
+      currentUser?: { userIdHash?: string };
+    }>(
+      authCtx,
+      `${config.flexBaseUrl}/api/v2/core/users/me/workspace-users-corp-group-affiliates`,
+    );
+    const userId = data.currentUser?.userIdHash ?? null;
+    if (userId) {
+      logger.info(`사용자 ID 확인: ${userId}`);
+    }
+    return userId;
+  } catch (error) {
+    logger.warn("사용자 정보 조회 실패", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}
+
+// --- flex API 응답 타입 ---
+
+interface TimeOffUsesResponse {
+  timeOffUses?: Array<{
+    userTimeOffRegisterEventId: string;
+    timeOffUseStatus: string;
+    customerIdHash: string;
+    userIdHash: string;
+    timeOffRegisterDateFrom?: string;
+    timeOffRegisterDateTo?: string;
+    timeOffPolicyId?: string;
+    timeOffPolicyType?: string;
+    useTime?: {
+      timeOffDays: number;
+      timeOffMinutes: number;
+      timeOffTimeAmount?: {
+        days: number;
+        hours: number;
+        minutes: number;
+      };
+    };
+    approvalStatus?: {
+      status: string;
+      taskKey?: string;
+    };
+    cancelApprovalInProgress?: boolean;
+    timeOffRegisteredAt?: number;
+    canceled?: boolean;
+  }>;
+  hasNext?: boolean;
+}
+
+function mapStatus(useStatus?: string, approvalStatus?: string): string {
+  const status = approvalStatus ?? useStatus ?? "unknown";
+  const statusMap: Record<string, string> = {
+    APPROVED: "approved",
+    APPROVAL_COMPLETED: "approved",
+    REJECTED: "rejected",
+    CANCELED: "canceled",
+    IN_PROGRESS: "in_progress",
+    PENDING: "pending",
+  };
+  return statusMap[status] ?? status.toLowerCase();
+}

--- a/apps/flex-cli/src/crawlers/instance.ts
+++ b/apps/flex-cli/src/crawlers/instance.ts
@@ -1,0 +1,311 @@
+import type { AuthContext } from "../auth/index.js";
+import type { Config } from "../config/index.js";
+import type { Logger } from "../logger/index.js";
+import type { StorageWriter } from "../storage/index.js";
+import type { ApiCatalog } from "../types/catalog.js";
+import type { WorkflowInstance } from "../types/instance.js";
+import type { ApprovalStep, AttachmentInfo, FieldValue } from "../types/common.js";
+import {
+  type CrawlResult,
+  delay,
+  emptyCrawlResult,
+  nowISO,
+  withRetry,
+  flexFetch,
+  flexPost,
+  resolveUrl,
+} from "./shared.js";
+
+export async function crawlInstances(
+  authCtx: AuthContext,
+  config: Config,
+  catalog: ApiCatalog | null,
+  storage: StorageWriter,
+  logger: Logger,
+): Promise<CrawlResult & { collectedKeys: Set<string> }> {
+  const startTime = Date.now();
+  const result = emptyCrawlResult();
+  const collectedKeys = new Set<string>();
+
+  logger.info("인스턴스(결재 문서) 수집 시작");
+
+  const searchUrl = resolveUrl(
+    config.flexBaseUrl, catalog, "instance-search",
+    "/action/v3/approval-document/user-boxes/search",
+  );
+
+  try {
+    const statuses = ["IN_PROGRESS", "DONE", "DECLINED", "CANCELED"];
+    let lastDocumentKey: string | undefined;
+    let hasMore = true;
+
+    while (hasMore) {
+      const searchBody = {
+        filter: {
+          statuses,
+          templateKeys: [],
+          writerHashedIds: [],
+          approverTargets: [],
+          referrerTargets: [],
+          starred: false,
+        },
+        search: { keyword: "", type: "ALL" },
+        ...(lastDocumentKey ? { lastDocumentKey } : {}),
+      };
+
+      const page = await withRetry(
+        () => flexPost<SearchResponse>(
+          authCtx,
+          `${searchUrl}?size=20&sortType=LAST_UPDATED_AT&direction=DESC`,
+          searchBody,
+        ),
+        { maxRetries: config.maxRetries, delayMs: config.requestDelayMs },
+      );
+
+      const docs = page.documents ?? [];
+      if (result.totalCount === 0) {
+        logger.info(`총 ${page.total}건의 문서 발견`);
+      }
+
+      for (const doc of docs) {
+        result.totalCount++;
+        const docKey = doc.document.documentKey;
+
+        try {
+          logger.progress("인스턴스 수집", result.successCount + result.failureCount + 1, page.total);
+
+          const detailPath = `/api/v3/approval-document/approval-documents/${docKey}`;
+          const detailUrl = `${config.flexBaseUrl}${detailPath}`;
+
+          const detail = await withRetry(
+            () => flexFetch<DocumentDetailResponse>(authCtx, detailUrl),
+            { maxRetries: config.maxRetries, delayMs: config.requestDelayMs },
+          );
+
+          const attachments = await processAttachments(
+            authCtx, config, docKey, detail.document.attachments ?? [], storage, logger,
+          );
+
+          const instance = mapInstance(detail, attachments);
+          await storage.saveInstance(instance);
+          collectedKeys.add(docKey);
+          result.successCount++;
+        } catch (error) {
+          result.failureCount++;
+          result.errors.push({
+            target: `instance:${docKey}`,
+            phase: "detail",
+            message: error instanceof Error ? error.message : String(error),
+            timestamp: nowISO(),
+          });
+          logger.error(`인스턴스 수집 실패: ${docKey}`, {
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+
+        await delay(config.requestDelayMs);
+      }
+
+      hasMore = page.hasNext && docs.length > 0;
+      if (hasMore) {
+        lastDocumentKey = docs[docs.length - 1].document.documentKey;
+      }
+    }
+  } catch (error) {
+    logger.error("인스턴스 목록 수집 중 치명적 오류", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    result.errors.push({
+      target: "instance-list",
+      phase: "list",
+      message: error instanceof Error ? error.message : String(error),
+      timestamp: nowISO(),
+    });
+  }
+
+  result.durationMs = Date.now() - startTime;
+  logger.info(`\n인스턴스 수집 완료: 성공 ${result.successCount}, 실패 ${result.failureCount}`);
+  return { ...result, collectedKeys };
+}
+
+// --- flex API 응답 타입 ---
+
+interface SearchResponse {
+  hasNext: boolean;
+  total: number;
+  documents: Array<{
+    document: {
+      documentKey: string;
+      code: string;
+      templateKey: string;
+      status: string;
+      emoji?: string;
+      title: string;
+      simpleContent?: string;
+      writer: { idHash: string; name: string; profileImageUrl?: string };
+      writtenAt: string;
+      lastUpdatedAt?: string;
+      inputFields?: Array<{
+        idHash: string;
+        value: string;
+        inputField: { idHash: string; name: string; type: string; data?: string };
+      }>;
+    };
+    approvalProcess?: {
+      status: string;
+      lines: Array<{
+        step: number;
+        status: string;
+        actors: Array<{
+          resolvedTarget: { type: string; displayName: string; userIdHashes?: string[] };
+          status: string;
+          actedUserIdHash?: string;
+          actedAt?: string;
+        }>;
+      }>;
+    };
+  }>;
+}
+
+interface DocumentDetailResponse {
+  document: {
+    documentKey: string;
+    code: string;
+    templateKey: string;
+    status: string;
+    emoji?: string;
+    title: string;
+    writer: { idHash: string; name: string; profileImageUrl?: string };
+    writtenAt: string;
+    inputs: Array<{
+      idHash: string;
+      value: string;
+      inputField: {
+        idHash: string;
+        name: string;
+        displayOrder: number;
+        type: string;
+        data?: string;
+        required?: boolean;
+      };
+    }>;
+    attachments?: Array<{
+      idHash: string;
+      file: {
+        fileKey: string;
+        fileName: string;
+        downloadUrl: string;
+      };
+    }>;
+    content?: string;
+    comments?: Array<{
+      idHash: string;
+      writer: { idHash: string; name: string };
+      type: string;
+      title?: string;
+      content?: string;
+      writtenBySystem?: boolean;
+      createdAt: string;
+    }>;
+    createdAt?: string;
+    updatedAt?: string;
+  };
+  approvalProcess?: {
+    status: string;
+    lines: Array<{
+      step: number;
+      status: string;
+      actors: Array<{
+        resolvedTarget: { type: string; displayName: string; userIdHashes?: string[] };
+        status: string;
+        actedUserIdHash?: string;
+        actedAt?: string;
+      }>;
+    }>;
+    referrers?: Array<{
+      resolvedTarget: { type: string; displayName: string };
+    }>;
+    requestedAt?: string;
+    terminatedAt?: string;
+  };
+}
+
+function mapInstance(detail: DocumentDetailResponse, attachments: AttachmentInfo[]): WorkflowInstance {
+  const doc = detail.document;
+  const process = detail.approvalProcess;
+
+  const fields: FieldValue[] = (doc.inputs ?? []).map((input) => ({
+    fieldName: input.inputField.name,
+    fieldType: input.inputField.type,
+    value: input.value,
+  }));
+
+  const approvalLine: ApprovalStep[] = (process?.lines ?? []).flatMap((line) =>
+    line.actors.map((actor) => ({
+      order: line.step,
+      type: actor.resolvedTarget.type,
+      approver: { name: actor.resolvedTarget.displayName },
+      status: actor.status,
+      processedAt: actor.actedAt,
+    })),
+  );
+
+  return {
+    id: doc.documentKey,
+    documentNumber: doc.code,
+    templateId: doc.templateKey,
+    templateName: doc.title,
+    drafter: { id: doc.writer.idHash, name: doc.writer.name },
+    draftedAt: doc.writtenAt,
+    status: doc.status,
+    approvalLine,
+    fields,
+    attachments,
+    modificationHistory: doc.comments?.filter((c) => !c.writtenBySystem).map((c) => ({
+      modifiedBy: { id: c.writer.idHash, name: c.writer.name },
+      modifiedAt: c.createdAt,
+      description: c.content || c.title,
+    })),
+    _raw: detail,
+  };
+}
+
+async function processAttachments(
+  authCtx: AuthContext,
+  config: Config,
+  instanceId: string,
+  rawAttachments: Array<{ idHash: string; file: { fileKey: string; fileName: string; downloadUrl: string } }>,
+  storage: StorageWriter,
+  logger: Logger,
+): Promise<AttachmentInfo[]> {
+  const results: AttachmentInfo[] = [];
+
+  for (const att of rawAttachments) {
+    const info: AttachmentInfo = { fileName: att.file.fileName };
+
+    if (config.downloadAttachments) {
+      try {
+        const buffer = await authCtx.page.evaluate(
+          async ([url, headers]) => {
+            const res = await fetch(url, { headers: headers as Record<string, string> });
+            const ab = await res.arrayBuffer();
+            return Array.from(new Uint8Array(ab));
+          },
+          [att.file.downloadUrl, authCtx.authHeaders] as const,
+        );
+
+        const savedPath = await storage.saveAttachment(
+          instanceId, att.file.fileName, Buffer.from(buffer),
+        );
+        info.localPath = savedPath;
+      } catch (error) {
+        info.downloadError = error instanceof Error ? error.message : String(error);
+        logger.warn(`첨부파일 다운로드 실패: ${att.file.fileName}`, { instanceId });
+      }
+    }
+
+    results.push(info);
+  }
+
+  return results;
+}

--- a/apps/flex-cli/src/crawlers/shared.ts
+++ b/apps/flex-cli/src/crawlers/shared.ts
@@ -1,0 +1,155 @@
+import type { CrawlError } from "../types/common.js";
+import type { AuthContext } from "../auth/index.js";
+import type { ApiCatalog, CatalogEntry } from "../types/catalog.js";
+
+/** 수집 결과 */
+export interface CrawlResult {
+  totalCount: number;
+  successCount: number;
+  failureCount: number;
+  errors: CrawlError[];
+  durationMs: number;
+}
+
+/** 페이지네이션 헬퍼 */
+export async function paginatedFetch<T>(
+  fetchPage: (page: number) => Promise<{ items: T[]; hasMore: boolean }>,
+  options: {
+    delayMs: number;
+    maxRetries: number;
+    onItem: (item: T) => Promise<void>;
+  },
+): Promise<void> {
+  let page = 1;
+  let hasMore = true;
+
+  while (hasMore) {
+    const result = await withRetry(() => fetchPage(page), {
+      maxRetries: options.maxRetries,
+      delayMs: options.delayMs,
+    });
+
+    for (const item of result.items) {
+      await options.onItem(item);
+    }
+
+    hasMore = result.hasMore;
+    page++;
+
+    if (hasMore) {
+      await delay(options.delayMs);
+    }
+  }
+}
+
+/** 재시도 래퍼 */
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  options: {
+    maxRetries: number;
+    delayMs: number;
+    shouldRetry?: (error: unknown) => boolean;
+  },
+): Promise<T> {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= options.maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+
+      if (options.shouldRetry && !options.shouldRetry(error)) {
+        throw error;
+      }
+
+      if (attempt < options.maxRetries) {
+        const backoff = options.delayMs * Math.pow(2, attempt);
+        await delay(backoff);
+      }
+    }
+  }
+
+  throw lastError;
+}
+
+/** 요청 간 딜레이 */
+export function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** 현재 시각 ISO 문자열 */
+export function nowISO(): string {
+  return new Date().toISOString();
+}
+
+/** CrawlResult 초기값 생성 */
+export function emptyCrawlResult(): CrawlResult {
+  return {
+    totalCount: 0,
+    successCount: 0,
+    failureCount: 0,
+    errors: [],
+    durationMs: 0,
+  };
+}
+
+/** 인증된 브라우저 컨텍스트에서 flex API GET 호출 */
+export async function flexFetch<T>(authCtx: AuthContext, url: string): Promise<T> {
+  const result = await authCtx.page.evaluate(
+    async ([fetchUrl, headers]) => {
+      const res = await fetch(fetchUrl, {
+        headers: headers as Record<string, string>,
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}: ${fetchUrl}`);
+      return await res.json();
+    },
+    [url, authCtx.authHeaders] as const,
+  );
+  return result as T;
+}
+
+/** 인증된 브라우저 컨텍스트에서 flex API POST 호출 */
+export async function flexPost<T>(authCtx: AuthContext, url: string, body: unknown): Promise<T> {
+  const result = await authCtx.page.evaluate(
+    async ([fetchUrl, headers, bodyStr]) => {
+      const res = await fetch(fetchUrl, {
+        method: "POST",
+        headers: {
+          ...(headers as Record<string, string>),
+          "content-type": "application/json",
+        },
+        body: bodyStr as string,
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}: ${fetchUrl}`);
+      return await res.json();
+    },
+    [url, authCtx.authHeaders, JSON.stringify(body)] as const,
+  );
+  return result as T;
+}
+
+/**
+ * 카탈로그에서 엔드포인트를 조회한다.
+ * 카탈로그가 없거나 엔드포인트가 없으면 null 반환.
+ */
+export function resolveEndpoint(
+  catalog: ApiCatalog | null,
+  endpointId: string,
+): CatalogEntry | null {
+  if (!catalog) return null;
+  return catalog.entries.find((e) => e.id === endpointId) ?? null;
+}
+
+/**
+ * 카탈로그에서 엔드포인트 URL을 조회하거나, 없으면 폴백 URL 반환.
+ */
+export function resolveUrl(
+  baseUrl: string,
+  catalog: ApiCatalog | null,
+  endpointId: string,
+  fallbackPath: string,
+): string {
+  const entry = resolveEndpoint(catalog, endpointId);
+  return entry ? `${baseUrl}${entry.urlPattern}` : `${baseUrl}${fallbackPath}`;
+}

--- a/apps/flex-cli/src/crawlers/template.ts
+++ b/apps/flex-cli/src/crawlers/template.ts
@@ -1,0 +1,175 @@
+import type { AuthContext } from "../auth/index.js";
+import type { Config } from "../config/index.js";
+import type { Logger } from "../logger/index.js";
+import type { StorageWriter } from "../storage/index.js";
+import type { ApiCatalog } from "../types/catalog.js";
+import type { WorkflowTemplate, TemplateField } from "../types/template.js";
+import { type CrawlResult, delay, emptyCrawlResult, nowISO, withRetry, flexFetch, resolveUrl } from "./shared.js";
+
+export async function crawlTemplates(
+  authCtx: AuthContext,
+  config: Config,
+  catalog: ApiCatalog | null,
+  storage: StorageWriter,
+  logger: Logger,
+): Promise<CrawlResult> {
+  const startTime = Date.now();
+  const result = emptyCrawlResult();
+
+  logger.info("양식(템플릿) 수집 시작");
+
+  const listUrl = resolveUrl(
+    config.flexBaseUrl, catalog, "template-list",
+    "/api/v3/approval-document-template/templates",
+  );
+
+  try {
+    const data = await withRetry(
+      () => flexFetch<{ templates: RawTemplate[] }>(authCtx, listUrl),
+      { maxRetries: config.maxRetries, delayMs: config.requestDelayMs },
+    );
+
+    const rawTemplates = data.templates ?? [];
+    result.totalCount = rawTemplates.length;
+    logger.info(`양식 ${rawTemplates.length}건 발견`);
+
+    for (let i = 0; i < rawTemplates.length; i++) {
+      const raw = rawTemplates[i];
+      try {
+        logger.progress("양식 수집", i + 1, rawTemplates.length);
+
+        const detailUrl = resolveUrl(
+          config.flexBaseUrl, catalog, "template-detail",
+          "/api/v3/approval-document-template/templates",
+        ).replace(/\{[^}]+\}/, raw.templateKey) +
+          (catalog ? "" : `/${raw.templateKey}`);
+
+        // 카탈로그의 urlPattern에 {param}이 있으면 replace로 처리됨
+        // 폴백일 때는 직접 경로 추가
+        const finalDetailUrl = detailUrl.includes(raw.templateKey)
+          ? detailUrl
+          : `${config.flexBaseUrl}/api/v3/approval-document-template/templates/${raw.templateKey}`;
+
+        const detail = await withRetry(
+          () => flexFetch<{ template: RawTemplateDetail }>(authCtx, finalDetailUrl),
+          { maxRetries: config.maxRetries, delayMs: config.requestDelayMs },
+        );
+
+        const template = mapTemplate(raw, detail.template);
+        await storage.saveTemplate(template);
+        result.successCount++;
+      } catch (error) {
+        try {
+          const template = mapTemplate(raw, null);
+          await storage.saveTemplate(template);
+          result.successCount++;
+        } catch {
+          result.failureCount++;
+          result.errors.push({
+            target: `template:${raw.templateKey}:${raw.name}`,
+            phase: "detail",
+            message: error instanceof Error ? error.message : String(error),
+            timestamp: nowISO(),
+          });
+          logger.error(`양식 수집 실패: ${raw.name}`, {
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+
+      if (i < rawTemplates.length - 1) await delay(config.requestDelayMs);
+    }
+  } catch (error) {
+    logger.error("양식 목록 수집 실패", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    result.errors.push({
+      target: "template-list",
+      phase: "list",
+      message: error instanceof Error ? error.message : String(error),
+      timestamp: nowISO(),
+    });
+  }
+
+  result.durationMs = Date.now() - startTime;
+  logger.info(`\n양식 수집 완료: 성공 ${result.successCount}, 실패 ${result.failureCount}`);
+  return result;
+}
+
+// --- flex API 응답 타입 ---
+
+interface RawTemplate {
+  templateKey: string;
+  name: string;
+  description?: string;
+  emoji?: string;
+  onlyVisibleForAdmin?: boolean;
+  tags?: Array<{ idHash: string; name: string; displayOrder: number }>;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+interface RawTemplateDetail {
+  templateKey: string;
+  name: string;
+  inputFields?: Array<{
+    idHash: string;
+    name: string;
+    displayOrder: number;
+    type: string;
+    data?: string;
+    required?: boolean;
+    prefill?: { defaultValue: string; type: string };
+  }>;
+  approvalProcess?: {
+    lines?: Array<{
+      step: number;
+      actors: Array<{
+        resolvedTarget: {
+          type: string;
+          value: string;
+          displayName: string;
+        };
+      }>;
+    }>;
+  };
+}
+
+function mapTemplate(raw: RawTemplate, detail: RawTemplateDetail | null): WorkflowTemplate {
+  const fields: TemplateField[] = (detail?.inputFields ?? []).map((f) => ({
+    name: f.name,
+    type: f.type,
+    required: f.required,
+    description: f.data ? tryParseFieldData(f.data) : undefined,
+  }));
+
+  const defaultApprovalLine = detail?.approvalProcess?.lines?.map((line) => ({
+    order: line.step,
+    type: "승인",
+    approver: {
+      name: line.actors.map((a) => a.resolvedTarget.displayName).join(", "),
+    },
+    status: "pending" as const,
+  }));
+
+  return {
+    id: raw.templateKey,
+    name: raw.name,
+    category: raw.tags?.map((t) => t.name).join(", ") || undefined,
+    fields,
+    defaultApprovalLine: defaultApprovalLine?.length ? defaultApprovalLine : undefined,
+    createdAt: raw.createdAt,
+    updatedAt: raw.updatedAt,
+    _raw: { list: raw, detail },
+  };
+}
+
+function tryParseFieldData(data: string): string | undefined {
+  try {
+    const parsed = JSON.parse(data);
+    if (parsed.currencyCode) return `currency: ${parsed.currencyCode}`;
+    return undefined;
+  } catch {
+    return data || undefined;
+  }
+}

--- a/apps/flex-cli/src/discovery/catalog.ts
+++ b/apps/flex-cli/src/discovery/catalog.ts
@@ -1,0 +1,107 @@
+import { readFile } from "node:fs/promises";
+import type { ApiCatalog, CatalogEntry } from "../types/catalog.js";
+import type { CapturedRequest } from "./traffic-capture.js";
+import type { DiscoveredPage } from "./navigator.js";
+
+/** 알려진 엔드포인트 패턴 → 안정적 ID 매핑 */
+const ENDPOINT_PATTERNS: Array<{ id: string; method: string; pattern: RegExp }> = [
+  { id: "template-list", method: "GET", pattern: /\/api\/v\d+\/approval-document-template\/templates$/ },
+  { id: "template-detail", method: "GET", pattern: /\/api\/v\d+\/approval-document-template\/templates\/[^/]+$/ },
+  { id: "instance-search", method: "POST", pattern: /\/action\/v\d+\/approval-document\/user-boxes\/search/ },
+  { id: "instance-detail", method: "GET", pattern: /\/api\/v\d+\/approval-document\/approval-documents\/[^/]+$/ },
+  { id: "time-off-uses", method: "GET", pattern: /\/api\/v\d+\/time-off\/users\/[^/]+\/time-off-uses/ },
+  { id: "user-me", method: "GET", pattern: /\/api\/v\d+\/core\/me/ },
+];
+
+/** UUID-like 세그먼트를 {param}으로 일반화 */
+function generalizeUrlPattern(url: string): string {
+  const parsed = new URL(url);
+  const segments = parsed.pathname.split("/");
+  const generalized = segments.map((seg) => {
+    // UUID, hash ID, 긴 영숫자 문자열을 {param}으로
+    if (/^[a-f0-9-]{20,}$/i.test(seg) || /^[a-zA-Z0-9]{20,}$/.test(seg)) {
+      return "{param}";
+    }
+    return seg;
+  });
+  return generalized.join("/");
+}
+
+/** URL에서 쿼리 파라미터 추출 */
+function extractQueryParams(url: string): Record<string, string> | undefined {
+  const parsed = new URL(url);
+  const params: Record<string, string> = {};
+  parsed.searchParams.forEach((value, key) => {
+    params[key] = value;
+  });
+  return Object.keys(params).length > 0 ? params : undefined;
+}
+
+/** 캡처된 요청에 ID를 매칭 */
+function matchEndpointId(method: string, url: string): string | null {
+  const pathname = new URL(url).pathname;
+  for (const pattern of ENDPOINT_PATTERNS) {
+    if (pattern.method === method && pattern.pattern.test(pathname)) {
+      return pattern.id;
+    }
+  }
+  return null;
+}
+
+/** 캡처 결과 + 페이지 정보로 카탈로그 생성 */
+export function buildCatalog(
+  captures: CapturedRequest[],
+  discoveredPages: DiscoveredPage[],
+  flexBaseUrl: string,
+): ApiCatalog {
+  const entries: CatalogEntry[] = [];
+  const unclassified: CatalogEntry[] = [];
+
+  for (const capture of captures) {
+    const id = matchEndpointId(capture.method, capture.url);
+    const urlPattern = generalizeUrlPattern(capture.url);
+    const pageInfo = discoveredPages.find((p) =>
+      capture.pageUrl.includes(p.url),
+    );
+
+    const entry: CatalogEntry = {
+      id,
+      discoveredFrom: new URL(capture.pageUrl).pathname,
+      menuLabel: pageInfo?.menuLabel,
+      method: capture.method as CatalogEntry["method"],
+      urlPattern,
+      exampleUrl: new URL(capture.url).pathname + new URL(capture.url).search,
+      queryParams: extractQueryParams(capture.url),
+      requestBodySample: capture.requestBody,
+      statusCode: capture.statusCode,
+      responseBodySample: capture.responseBody,
+      totalItems: (capture as CapturedRequest & { totalItems?: number }).totalItems,
+      capturedAt: capture.capturedAt,
+    };
+
+    if (id) {
+      entries.push(entry);
+    } else {
+      unclassified.push(entry);
+    }
+  }
+
+  return {
+    version: "1.0",
+    capturedAt: new Date().toISOString(),
+    flexBaseUrl,
+    discoveredPages: discoveredPages.map((p) => p.url),
+    entries,
+    unclassified,
+  };
+}
+
+/** 파일에서 카탈로그 로드 */
+export async function loadCatalog(catalogPath: string): Promise<ApiCatalog | null> {
+  try {
+    const content = await readFile(catalogPath, "utf-8");
+    return JSON.parse(content) as ApiCatalog;
+  } catch {
+    return null;
+  }
+}

--- a/apps/flex-cli/src/discovery/navigator.ts
+++ b/apps/flex-cli/src/discovery/navigator.ts
@@ -1,0 +1,166 @@
+import type { Page } from "playwright";
+import type { Config } from "../config/index.js";
+import type { Logger } from "../logger/index.js";
+
+export interface DiscoveredPage {
+  url: string;
+  menuLabel: string;
+}
+
+/** 알려진 페이지 폴백 목록 */
+const FALLBACK_PATHS = [
+  "/approval/document-box/sent",
+  "/approval/admin/templates",
+  "/time-tracking/my",
+  "/time-off/my",
+];
+
+/**
+ * flex.team 사이드바 메뉴를 자동으로 순회하며 페이지를 탐색한다.
+ * 각 페이지에서 리스트 항목이 있으면 첫 번째 항목을 클릭해서 상세 API도 트리거한다.
+ */
+export async function navigateForDiscovery(
+  page: Page,
+  config: Config,
+  logger: Logger,
+): Promise<DiscoveredPage[]> {
+  const discoveredPages: DiscoveredPage[] = [];
+
+  // 메인 페이지 로드
+  await page.goto(config.flexBaseUrl, { waitUntil: "networkidle" });
+  await page.waitForTimeout(2000);
+
+  // 사이드바 메뉴 항목 추출 시도
+  const menuItems = await extractMenuItems(page, logger);
+
+  if (menuItems.length > 0) {
+    logger.info(`사이드바에서 ${menuItems.length}개 메뉴 항목 발견`);
+    for (const item of menuItems) {
+      await visitPage(page, item, config, logger, discoveredPages);
+    }
+  } else {
+    // 폴백: 알려진 URL 직접 방문
+    logger.warn("사이드바 메뉴 탐색 실패, 폴백 URL 사용");
+    for (const path of FALLBACK_PATHS) {
+      await visitPage(
+        page,
+        { url: `${config.flexBaseUrl}${path}`, label: path },
+        config,
+        logger,
+        discoveredPages,
+      );
+    }
+  }
+
+  return discoveredPages;
+}
+
+interface MenuItem {
+  url: string;
+  label: string;
+}
+
+async function extractMenuItems(page: Page, logger: Logger): Promise<MenuItem[]> {
+  try {
+    // flex.team의 사이드바 메뉴 링크를 추출
+    // 여러 셀렉터를 시도하여 호환성 확보
+    const selectors = [
+      'nav a[href]',
+      '[class*="sidebar"] a[href]',
+      '[class*="menu"] a[href]',
+      '[class*="nav"] a[href]',
+      'aside a[href]',
+    ];
+
+    for (const selector of selectors) {
+      const items = await page.evaluate((sel) => {
+        const links = document.querySelectorAll(sel);
+        const results: Array<{ url: string; label: string }> = [];
+        const seen = new Set<string>();
+
+        links.forEach((link) => {
+          const href = (link as HTMLAnchorElement).href;
+          const label = (link as HTMLElement).textContent?.trim() ?? "";
+          if (href && label && !seen.has(href) && !href.includes("javascript:")) {
+            seen.add(href);
+            results.push({ url: href, label });
+          }
+        });
+
+        return results;
+      }, selector);
+
+      if (items.length > 0) {
+        logger.info(`셀렉터 '${selector}'로 ${items.length}개 메뉴 발견`);
+        // flex.team 내부 링크만 필터
+        return items.filter((item) => item.url.includes("flex.team"));
+      }
+    }
+  } catch (error) {
+    logger.warn("메뉴 항목 추출 실패", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  return [];
+}
+
+async function visitPage(
+  page: Page,
+  target: MenuItem,
+  config: Config,
+  logger: Logger,
+  discoveredPages: DiscoveredPage[],
+): Promise<void> {
+  try {
+    logger.info(`페이지 탐색: ${target.label} (${target.url})`);
+
+    await page.goto(target.url, { waitUntil: "networkidle", timeout: 15000 });
+    await page.waitForTimeout(2000);
+
+    discoveredPages.push({
+      url: new URL(page.url()).pathname,
+      menuLabel: target.label,
+    });
+
+    // 리스트 페이지에서 첫 번째 항목 클릭 시도 (상세 API 트리거)
+    await tryClickFirstListItem(page, logger);
+
+    // 요청 간 딜레이
+    await page.waitForTimeout(config.requestDelayMs);
+  } catch (error) {
+    logger.warn(`페이지 탐색 실패: ${target.label}`, {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+async function tryClickFirstListItem(page: Page, logger: Logger): Promise<void> {
+  try {
+    // 리스트 항목의 일반적인 셀렉터
+    const listSelectors = [
+      'table tbody tr:first-child',
+      '[class*="list"] [class*="item"]:first-child',
+      '[class*="row"]:first-child a',
+      '[role="row"]:first-child',
+    ];
+
+    for (const selector of listSelectors) {
+      const element = page.locator(selector).first();
+      if (await element.isVisible({ timeout: 2000 }).catch(() => false)) {
+        await element.click();
+        await page.waitForLoadState("networkidle").catch(() => {});
+        await page.waitForTimeout(2000);
+
+        // 뒤로 가기
+        await page.goBack({ waitUntil: "networkidle" }).catch(() => {});
+        await page.waitForTimeout(1000);
+
+        logger.info("리스트 항목 클릭 → 상세 페이지 API 캡처");
+        return;
+      }
+    }
+  } catch {
+    // 클릭 실패는 무시 — 리스트가 없는 페이지일 수 있음
+  }
+}

--- a/apps/flex-cli/src/discovery/traffic-capture.ts
+++ b/apps/flex-cli/src/discovery/traffic-capture.ts
@@ -1,0 +1,132 @@
+import type { Page, Response } from "playwright";
+
+/** 캡처된 API 요청/응답 */
+export interface CapturedRequest {
+  url: string;
+  method: string;
+  /** 요청 발생 시점의 페이지 URL */
+  pageUrl: string;
+  requestBody?: unknown;
+  statusCode: number;
+  responseBody?: unknown;
+  capturedAt: string;
+}
+
+const SKIP_PATTERNS = [
+  /\.(js|css|png|jpg|jpeg|gif|svg|ico|woff|woff2|ttf|eot|map)(\?|$)/i,
+  /analytics/i,
+  /tracking/i,
+  /sentry/i,
+  /hotjar/i,
+  /gtag/i,
+  /google-analytics/i,
+  /googletagmanager/i,
+];
+
+function isApiUrl(url: string): boolean {
+  return (url.includes("/api/") || url.includes("/action/")) &&
+    !SKIP_PATTERNS.some((p) => p.test(url));
+}
+
+/**
+ * 응답 바디를 간결하게 만든다.
+ * - 배열: 첫 번째 요소만 남기고 totalItems 반환
+ * - 깊이 제한
+ */
+function truncateResponse(body: unknown, depth = 0): { truncated: unknown; totalItems?: number } {
+  if (depth > 5) return { truncated: "[TRUNCATED]" };
+
+  if (Array.isArray(body)) {
+    const totalItems = body.length;
+    const first = body.length > 0 ? truncateResponse(body[0], depth + 1).truncated : undefined;
+    return { truncated: first !== undefined ? [first] : [], totalItems };
+  }
+
+  if (body && typeof body === "object") {
+    const result: Record<string, unknown> = {};
+    let itemCount: number | undefined;
+
+    for (const [key, value] of Object.entries(body as Record<string, unknown>)) {
+      const { truncated, totalItems } = truncateResponse(value, depth + 1);
+      result[key] = truncated;
+      if (totalItems !== undefined) {
+        itemCount = totalItems;
+      }
+    }
+    return { truncated: result, totalItems: itemCount };
+  }
+
+  return { truncated: body };
+}
+
+export interface TrafficCapture {
+  start(): void;
+  stop(): CapturedRequest[];
+}
+
+export function createTrafficCapture(page: Page): TrafficCapture {
+  const captured: CapturedRequest[] = [];
+  const seenPatterns = new Set<string>();
+  let handler: ((response: Response) => Promise<void>) | null = null;
+
+  return {
+    start() {
+      handler = async (response: Response) => {
+        const url = response.url();
+        if (!isApiUrl(url)) return;
+
+        const method = response.request().method();
+        // 중복 방지: 같은 method + URL path 패턴은 한 번만 캡처
+        const urlPath = new URL(url).pathname;
+        const patternKey = `${method}:${urlPath}`;
+        if (seenPatterns.has(patternKey)) return;
+        seenPatterns.add(patternKey);
+
+        try {
+          const statusCode = response.status();
+          let responseBody: unknown;
+          try {
+            responseBody = await response.json();
+          } catch {
+            // JSON이 아닌 응답은 무시
+            return;
+          }
+
+          let requestBody: unknown;
+          if (method === "POST" || method === "PUT" || method === "PATCH") {
+            try {
+              requestBody = JSON.parse(response.request().postData() ?? "");
+            } catch {
+              // 파싱 실패 무시
+            }
+          }
+
+          const { truncated, totalItems } = truncateResponse(responseBody);
+
+          captured.push({
+            url,
+            method,
+            pageUrl: page.url(),
+            requestBody,
+            statusCode,
+            responseBody: truncated,
+            ...(totalItems !== undefined ? { totalItems } : {}),
+            capturedAt: new Date().toISOString(),
+          } as CapturedRequest & { totalItems?: number });
+        } catch {
+          // 캡처 실패는 무시
+        }
+      };
+
+      page.on("response", handler);
+    },
+
+    stop() {
+      if (handler) {
+        page.removeListener("response", handler);
+        handler = null;
+      }
+      return [...captured];
+    },
+  };
+}

--- a/apps/flex-cli/src/logger/index.ts
+++ b/apps/flex-cli/src/logger/index.ts
@@ -1,0 +1,49 @@
+export interface Logger {
+  info(message: string, meta?: Record<string, unknown>): void;
+  warn(message: string, meta?: Record<string, unknown>): void;
+  error(message: string, meta?: Record<string, unknown>): void;
+  progress(phase: string, current: number, total?: number): void;
+}
+
+const SENSITIVE_KEYS = ["password", "token", "cookie", "authorization", "secret"];
+
+function sanitize(meta: Record<string, unknown>): Record<string, unknown> {
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(meta)) {
+    if (SENSITIVE_KEYS.some((k) => key.toLowerCase().includes(k))) {
+      sanitized[key] = "[REDACTED]";
+    } else {
+      sanitized[key] = value;
+    }
+  }
+  return sanitized;
+}
+
+function timestamp(): string {
+  return new Date().toISOString();
+}
+
+function formatMeta(meta?: Record<string, unknown>): string {
+  if (!meta || Object.keys(meta).length === 0) return "";
+  return " " + JSON.stringify(sanitize(meta));
+}
+
+export function createLogger(prefix?: string): Logger {
+  const tag = prefix ? `[FLEX-AX:${prefix}]` : "";
+
+  return {
+    info(message, meta) {
+      console.log(`[${timestamp()}] INFO  ${tag} ${message}${formatMeta(meta)}`);
+    },
+    warn(message, meta) {
+      console.warn(`[${timestamp()}] WARN  ${tag} ${message}${formatMeta(meta)}`);
+    },
+    error(message, meta) {
+      console.error(`[${timestamp()}] ERROR ${tag} ${message}${formatMeta(meta)}`);
+    },
+    progress(phase, current, total) {
+      const totalStr = total != null ? `/${total}` : "";
+      process.stdout.write(`\r[${timestamp()}] ${phase}: ${current}${totalStr}`);
+    },
+  };
+}

--- a/apps/flex-cli/src/storage/index.ts
+++ b/apps/flex-cli/src/storage/index.ts
@@ -1,0 +1,68 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import type { CrawlError } from "../types/common.js";
+import type { AttendanceApproval } from "../types/attendance.js";
+import type { WorkflowInstance } from "../types/instance.js";
+import type { WorkflowTemplate } from "../types/template.js";
+import type { ApiCatalog } from "../types/catalog.js";
+import type { CrawlResult } from "../crawlers/shared.js";
+
+export interface CrawlReport {
+  startedAt: string;
+  completedAt: string;
+  durationMs: number;
+  templates: CrawlResult;
+  instances: CrawlResult;
+  attendance: CrawlResult;
+  totalErrors: CrawlError[];
+}
+
+export interface StorageWriter {
+  saveTemplate(template: WorkflowTemplate): Promise<void>;
+  saveInstance(instance: WorkflowInstance): Promise<void>;
+  saveAttendanceApproval(approval: AttendanceApproval): Promise<void>;
+  saveAttachment(instanceId: string, fileName: string, data: Buffer): Promise<string>;
+  saveReport(report: CrawlReport): Promise<void>;
+  saveCatalog(catalog: ApiCatalog): Promise<void>;
+}
+
+async function ensureDir(dir: string): Promise<void> {
+  await mkdir(dir, { recursive: true });
+}
+
+async function writeJson(filePath: string, data: unknown): Promise<void> {
+  await ensureDir(path.dirname(filePath));
+  await writeFile(filePath, JSON.stringify(data, null, 2), "utf-8");
+}
+
+export function createStorageWriter(outputDir: string, catalogPath: string): StorageWriter {
+  return {
+    async saveTemplate(template) {
+      await writeJson(path.join(outputDir, "templates", `${template.id}.json`), template);
+    },
+
+    async saveInstance(instance) {
+      await writeJson(path.join(outputDir, "instances", `${instance.id}.json`), instance);
+    },
+
+    async saveAttendanceApproval(approval) {
+      await writeJson(path.join(outputDir, "attendance", `${approval.id}.json`), approval);
+    },
+
+    async saveAttachment(instanceId, fileName, data) {
+      const dir = path.join(outputDir, "attachments", instanceId);
+      await ensureDir(dir);
+      const filePath = path.join(dir, fileName);
+      await writeFile(filePath, data);
+      return filePath;
+    },
+
+    async saveReport(report) {
+      await writeJson(path.join(outputDir, "crawl-report.json"), report);
+    },
+
+    async saveCatalog(catalog) {
+      await writeJson(catalogPath, catalog);
+    },
+  };
+}

--- a/apps/flex-cli/src/types/attendance.ts
+++ b/apps/flex-cli/src/types/attendance.ts
@@ -1,0 +1,14 @@
+import type { ApprovalStatus, UserInfo } from "./common.js";
+
+/** 근태/휴가 승인 이력 */
+export interface AttendanceApproval {
+  id: string;
+  type: string;
+  applicant: UserInfo;
+  appliedAt: string;
+  details: Record<string, unknown>;
+  status: ApprovalStatus;
+  approver?: UserInfo;
+  processedAt?: string;
+  _raw?: unknown;
+}

--- a/apps/flex-cli/src/types/catalog.ts
+++ b/apps/flex-cli/src/types/catalog.ts
@@ -1,0 +1,43 @@
+/** API 카탈로그 엔트리 */
+export interface CatalogEntry {
+  /** 안정적 식별자. 알려진 패턴이면 "template-list" 등, 새 발견이면 null */
+  id: string | null;
+  /** 발견된 페이지 경로 */
+  discoveredFrom: string;
+  /** 사이드바 메뉴 라벨 */
+  menuLabel?: string;
+  /** HTTP 메서드 */
+  method: "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
+  /** URL 패턴 (path param은 {param}으로 일반화) */
+  urlPattern: string;
+  /** 실제 요청 URL 예시 */
+  exampleUrl: string;
+  /** 쿼리 파라미터 */
+  queryParams?: Record<string, string>;
+  /** POST 요청 바디 샘플 */
+  requestBodySample?: unknown;
+  /** HTTP 응답 코드 */
+  statusCode: number;
+  /** 응답 바디 샘플 (배열은 첫 번째 요소만) */
+  responseBodySample?: unknown;
+  /** 응답 배열의 총 아이템 수 */
+  totalItems?: number;
+  /** 캡처 시각 */
+  capturedAt: string;
+}
+
+/** API 카탈로그 */
+export interface ApiCatalog {
+  /** 카탈로그 스키마 버전 */
+  version: string;
+  /** 디스커버리 실행 시각 */
+  capturedAt: string;
+  /** Flex 기본 URL */
+  flexBaseUrl: string;
+  /** 디스커버리에서 탐색된 모든 페이지 경로 */
+  discoveredPages: string[];
+  /** 알려진 엔드포인트 (id가 있는 것) */
+  entries: CatalogEntry[];
+  /** 새로 발견된 미분류 엔드포인트 (id가 null) */
+  unclassified: CatalogEntry[];
+}

--- a/apps/flex-cli/src/types/common.ts
+++ b/apps/flex-cli/src/types/common.ts
@@ -1,0 +1,50 @@
+/** 결재 상태 */
+export type ApprovalStatus =
+  | "pending"
+  | "in_progress"
+  | "approved"
+  | "rejected"
+  | "canceled"
+  | (string & {});
+
+/** 사용자 정보 (기안자, 승인자 등) */
+export interface UserInfo {
+  id?: string;
+  name: string;
+  department?: string;
+  position?: string;
+}
+
+/** 결재선 단계 */
+export interface ApprovalStep {
+  order: number;
+  type: string;
+  approver: UserInfo;
+  status: ApprovalStatus;
+  processedAt?: string;
+  comment?: string;
+}
+
+/** 첨부파일 정보 */
+export interface AttachmentInfo {
+  fileName: string;
+  fileSize?: number;
+  mimeType?: string;
+  localPath?: string;
+  downloadError?: string;
+}
+
+/** 필드 값 */
+export interface FieldValue {
+  fieldName: string;
+  fieldType: string;
+  value: unknown;
+}
+
+/** 수집 실패 항목 */
+export interface CrawlError {
+  target: string;
+  phase: string;
+  message: string;
+  timestamp: string;
+}

--- a/apps/flex-cli/src/types/instance.ts
+++ b/apps/flex-cli/src/types/instance.ts
@@ -1,0 +1,27 @@
+import type {
+  ApprovalStatus,
+  ApprovalStep,
+  AttachmentInfo,
+  FieldValue,
+  UserInfo,
+} from "./common.js";
+
+/** 워크플로우 인스턴스(결재 문서) */
+export interface WorkflowInstance {
+  id: string;
+  documentNumber?: string;
+  templateId: string;
+  templateName: string;
+  drafter: UserInfo;
+  draftedAt: string;
+  status: ApprovalStatus;
+  approvalLine: ApprovalStep[];
+  fields: FieldValue[];
+  attachments: AttachmentInfo[];
+  modificationHistory?: Array<{
+    modifiedBy: UserInfo;
+    modifiedAt: string;
+    description?: string;
+  }>;
+  _raw?: unknown;
+}

--- a/apps/flex-cli/src/types/template.ts
+++ b/apps/flex-cli/src/types/template.ts
@@ -1,0 +1,23 @@
+import type { ApprovalStep } from "./common.js";
+
+/** 양식 필드 정의 */
+export interface TemplateField {
+  name: string;
+  type: string;
+  required?: boolean;
+  options?: string[];
+  description?: string;
+}
+
+/** 워크플로우 양식(템플릿) */
+export interface WorkflowTemplate {
+  id: string;
+  name: string;
+  category?: string;
+  fields: TemplateField[];
+  defaultApprovalLine?: ApprovalStep[];
+  createdAt?: string;
+  updatedAt?: string;
+  permissions?: Record<string, unknown>;
+  _raw?: unknown;
+}

--- a/apps/flex-cli/tsconfig.json
+++ b/apps/flex-cli/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "lib": ["ES2022", "DOM"]
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,31 @@ importers:
         specifier: ^2
         version: 2.9.1
 
+  apps/flex-cli:
+    dependencies:
+      dotenv:
+        specifier: ^16.4.7
+        version: 16.6.1
+      playwright:
+        specifier: ^1.50.1
+        version: 1.58.2
+      zod:
+        specifier: ^3.24.2
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^22.13.5
+        version: 22.19.15
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.1.3
+      tsx:
+        specifier: ^4.19.2
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+
   apps/flex-crawler:
     dependencies:
       dotenv:


### PR DESCRIPTION
## Summary

- **flex-ax CLI 추가** — `discover`, `crawl`, `check-apis`, `install-skills` 서브커맨드
- **API 디스커버리** — Playwright로 flex.team을 브라우저 탐색하여 API 카탈로그(`api-catalog.json`) 자동 생성
- **자가 복구 크롤러** — 카탈로그 기반 엔드포인트 조회, 없으면 하드코딩 폴백
- **근태 API 수정** — 디스커버리로 기존 API 3개가 404임을 확인, 실제 API(`time-off-uses`)로 교체
- **에이전트 스킬** — `/flex-discover`, `/flex-crawl` 스킬 포함 (`install-skills`로 설치)
- **SSO 인증** — Google SSO 등 수동 로그인 지원

## Test plan

- [x] `flex-ax discover` — 카탈로그 생성 (129개 API 캡처, 9개 메뉴 자동 순회)
- [x] `flex-ax check-apis` — 기존 근태 API 404 확인, 템플릿/인스턴스 API 정상 확인
- [x] `flex-ax crawl` — 템플릿 29건, 인스턴스 11,254건 수집 성공
- [x] `flex-ax install-skills` — `.claude/skills/`에 스킬 설치 확인
- [x] `tsc --noEmit` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)