### PR TITLE
Add API discovery and fix attendance crawler

### DIFF
--- a/apps/flex-cli/src/cli.ts
+++ b/apps/flex-cli/src/cli.ts
@@ -28,6 +28,11 @@ if (command === "--version" || command === "-v") {
 }
 
 switch (command) {
+  case "discover": {
+    const { runDiscover } = await import("./commands/discover.js");
+    await runDiscover();
+    break;
+  }
   case "crawl": {
     const { runCrawl } = await import("./commands/crawl.js");
     await runCrawl();
@@ -48,6 +53,11 @@ switch (command) {
     await runFile();
     break;
   }
+  case "check-apis": {
+    const { runCheckApis } = await import("./commands/check-apis.js");
+    await runCheckApis();
+    break;
+  }
   case "install-skills": {
     const { runInstallSkills } = await import("./commands/install-skills.js");
     await runInstallSkills();
@@ -65,12 +75,14 @@ switch (command) {
     console.log(`Usage: flex-ax <command>
 
 Commands:
+  discover        API 디스커버리 → api-catalog.json 생성
   crawl           카탈로그 기반 크롤링 → output/ 저장
   import          크롤링 결과(JSON) → SQLite DB 변환
   query "SQL"     DB 쿼리 실행 → JSON 출력 (read-only)
                   --file <path>  SQL 파일 경로
                   --var key=value  {{key}} 플레이스홀더 치환 (반복 가능)
   file <fileKey>  파일 내용 출력 (--info로 메타데이터만)
+  check-apis      하드코딩된 API 엔드포인트 상태 확인
   install-skills  에이전트 스킬을 .claude/skills/에 설치
   update          최신 버전으로 업데이트
 

--- a/apps/flex-cli/src/commands/check-apis.ts
+++ b/apps/flex-cli/src/commands/check-apis.ts
@@ -1,0 +1,75 @@
+import { loadConfig } from "../config/index.js";
+import { createLogger } from "../logger/index.js";
+import { authenticate, cleanup } from "../auth/index.js";
+
+const APIS_TO_CHECK = [
+  { label: "template-list", method: "GET", path: "/api/v3/approval-document-template/templates" },
+  { label: "instance-search", method: "POST", path: "/action/v3/approval-document/user-boxes/search" },
+  { label: "core-me", method: "GET", path: "/api/v2/core/me" },
+  // 수정된 근태 API (userId는 core/me에서 가져와야 하므로 여기선 me로 테스트)
+  { label: "time-off-uses (old: 404)", method: "GET", path: "/api/v2/time-off/users/me/time-off-requests" },
+  { label: "time-off-uses (new)", method: "GET", path: "/api/v2/time-off/users/me/time-off-uses" },
+];
+
+export async function runCheckApis(): Promise<void> {
+  const logger = createLogger("CHECK");
+
+  let config;
+  try {
+    config = loadConfig();
+  } catch (error) {
+    logger.error("설정 로딩 실패", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    process.exit(1);
+  }
+
+  const authCtx = await authenticate(config, logger);
+
+  try {
+    console.log("\n  API 엔드포인트 상태 확인\n");
+    console.log("  " + "-".repeat(56));
+
+    for (const api of APIS_TO_CHECK) {
+      const url = `${config.flexBaseUrl}${api.path}`;
+
+      try {
+        const result = await authCtx.page.evaluate(
+          async ([fetchUrl, headers, method]) => {
+            const opts: RequestInit = {
+              method: method as string,
+              headers: headers as Record<string, string>,
+            };
+            if (method === "POST") {
+              (opts.headers as Record<string, string>)["content-type"] = "application/json";
+              opts.body = JSON.stringify({});
+            }
+            const res = await fetch(fetchUrl, opts);
+            const text = await res.text().catch(() => "");
+            let preview = "";
+            try {
+              const json = JSON.parse(text);
+              const keys = Object.keys(json);
+              preview = keys.slice(0, 3).join(", ");
+            } catch {
+              preview = text.slice(0, 50);
+            }
+            return { status: res.status, preview };
+          },
+          [url, authCtx.authHeaders, api.method] as const,
+        );
+
+        const icon = result.status >= 200 && result.status < 300 ? "OK" : result.status === 404 ? "NOT FOUND" : `ERR ${result.status}`;
+        console.log(`  ${api.method.padEnd(5)} ${api.path}`);
+        console.log(`    → ${icon}  ${result.preview ? `(${result.preview})` : ""}`);
+      } catch (error) {
+        console.log(`  ${api.method.padEnd(5)} ${api.path}`);
+        console.log(`    → FAIL  ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
+
+    console.log("\n  " + "-".repeat(56));
+  } finally {
+    await cleanup(authCtx);
+  }
+}

--- a/apps/flex-cli/src/commands/discover.ts
+++ b/apps/flex-cli/src/commands/discover.ts
@@ -1,0 +1,96 @@
+import { loadConfig } from "../config/index.js";
+import { createLogger } from "../logger/index.js";
+import { authenticate, cleanup } from "../auth/index.js";
+import { createTrafficCapture } from "../discovery/traffic-capture.js";
+import { navigateForDiscovery } from "../discovery/navigator.js";
+import { buildCatalog, loadCatalog } from "../discovery/catalog.js";
+import { createStorageWriter } from "../storage/index.js";
+
+export async function runDiscover(): Promise<void> {
+  const logger = createLogger("DISCOVER");
+
+  let config;
+  try {
+    config = loadConfig();
+  } catch (error) {
+    logger.error("설정 로딩 실패", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    process.exit(1);
+  }
+
+  // 이전 카탈로그 로드 (diff용)
+  const previousCatalog = await loadCatalog(config.catalogPath);
+
+  // 인증
+  const authCtx = await authenticate(config, logger);
+
+  try {
+    // 트래픽 캡처 시작
+    const capture = createTrafficCapture(authCtx.page);
+    capture.start();
+
+    // 페이지 탐색
+    const discoveredPages = await navigateForDiscovery(authCtx.page, config, logger);
+
+    // 캡처 종료 + 카탈로그 생성
+    const captured = capture.stop();
+    logger.info(`${captured.length}개 API 요청 캡처됨`);
+
+    const catalog = buildCatalog(captured, discoveredPages, config.flexBaseUrl);
+
+    // 저장
+    const storage = createStorageWriter(config.outputDir, config.catalogPath);
+    await storage.saveCatalog(catalog);
+
+    // 결과 출력
+    console.log(`[FLEX-AX:DISCOVER] 카탈로그 생성 완료: ${config.catalogPath}`);
+    console.log(`[FLEX-AX:DISCOVER] entries: ${catalog.entries.length}, unclassified: ${catalog.unclassified.length}, pages: ${discoveredPages.length}`);
+
+    // 이전 카탈로그와 비교
+    if (previousCatalog) {
+      printDiff(previousCatalog, catalog, logger);
+    }
+
+    // 미분류 항목 출력
+    if (catalog.unclassified.length > 0) {
+      console.log("\n[FLEX-AX:DISCOVER] 미분류 엔드포인트:");
+      for (const entry of catalog.unclassified) {
+        console.log(`  ${entry.method} ${entry.urlPattern} (from: ${entry.discoveredFrom})`);
+      }
+    }
+  } finally {
+    await cleanup(authCtx);
+  }
+}
+
+function printDiff(
+  prev: { entries: Array<{ id: string | null; urlPattern: string }>; unclassified: Array<{ urlPattern: string }> },
+  curr: { entries: Array<{ id: string | null; urlPattern: string }>; unclassified: Array<{ urlPattern: string }> },
+  logger: ReturnType<typeof createLogger>,
+): void {
+  const prevIds = new Set(prev.entries.map((e) => e.id).filter(Boolean));
+  const currIds = new Set(curr.entries.map((e) => e.id).filter(Boolean));
+
+  const added = [...currIds].filter((id) => !prevIds.has(id));
+  const removed = [...prevIds].filter((id) => !currIds.has(id));
+
+  const changed: string[] = [];
+  for (const entry of curr.entries) {
+    if (!entry.id) continue;
+    const prevEntry = prev.entries.find((e) => e.id === entry.id);
+    if (prevEntry && prevEntry.urlPattern !== entry.urlPattern) {
+      changed.push(`${entry.id}: ${prevEntry.urlPattern} → ${entry.urlPattern}`);
+    }
+  }
+
+  if (added.length === 0 && removed.length === 0 && changed.length === 0) {
+    logger.info("이전 카탈로그와 변경 없음");
+    return;
+  }
+
+  console.log("\n[FLEX-AX:DISCOVER] 카탈로그 변경사항:");
+  for (const id of added) console.log(`  + 추가: ${id}`);
+  for (const id of removed) console.log(`  - 삭제: ${id}`);
+  for (const c of changed) console.log(`  ~ 변경: ${c}`);
+}

--- a/apps/flex-cli/src/crawlers/attendance.ts
+++ b/apps/flex-cli/src/crawlers/attendance.ts
@@ -11,19 +11,24 @@ import {
   nowISO,
   withRetry,
   flexFetch,
-  resolveUrl,
 } from "./shared.js";
 
-const ATTENDANCE_ENDPOINTS = [
-  { id: "timeoff-requests", fallback: "/api/v2/time-off/users/me/time-off-requests" },
-  { id: "overtime-requests", fallback: "/api/v2/time-tracking/users/me/overtime-requests" },
-  { id: "workchange-requests", fallback: "/api/v2/time-tracking/users/me/work-change-requests" },
-] as const;
-
+/**
+ * 근태/휴가 승인 수집.
+ *
+ * 디스커버리 결과, 기존 하드코딩 API는 404:
+ *   - /api/v2/time-off/users/me/time-off-requests
+ *   - /api/v2/time-tracking/users/me/overtime-requests
+ *   - /api/v2/time-tracking/users/me/work-change-requests
+ *
+ * 실제 API (카탈로그에서 발견):
+ *   - GET /api/v2/time-off/users/{userId}/time-off-uses/by-use-date-range/{from}..{to}
+ *     → timeOffUses[] 배열 반환
+ */
 export async function crawlAttendanceApprovals(
   authCtx: AuthContext,
   config: Config,
-  catalog: ApiCatalog | null,
+  _catalog: ApiCatalog | null,
   storage: StorageWriter,
   logger: Logger,
   collectedInstanceKeys: Set<string>,
@@ -33,66 +38,87 @@ export async function crawlAttendanceApprovals(
 
   logger.info("근태/휴가 승인 수집 시작");
 
-  for (const endpoint of ATTENDANCE_ENDPOINTS) {
-    const url = resolveUrl(config.flexBaseUrl, catalog, endpoint.id, endpoint.fallback);
+  // 현재 사용자 ID를 먼저 확인
+  const userId = await getUserId(authCtx, config, logger);
+  if (!userId) {
+    logger.error("사용자 ID를 확인할 수 없습니다");
+    result.durationMs = Date.now() - startTime;
+    return result;
+  }
 
-    try {
-      const data = await withRetry(
-        () => flexFetch<Record<string, unknown>>(authCtx, url),
-        { maxRetries: config.maxRetries, delayMs: config.requestDelayMs },
-      );
+  // 최근 1년 범위로 휴가 사용 내역 조회
+  const now = Date.now();
+  const oneYearAgo = now - 365 * 24 * 60 * 60 * 1000;
+  const url = `${config.flexBaseUrl}/api/v2/time-off/users/${userId}/time-off-uses/by-use-date-range/${oneYearAgo}..${now}`;
 
-      const items = extractItems(data);
-      logger.info(`${endpoint.id}: ${items.length}건 발견`);
+  try {
+    const data = await withRetry(
+      () => flexFetch<TimeOffUsesResponse>(authCtx, url),
+      { maxRetries: config.maxRetries, delayMs: config.requestDelayMs },
+    );
 
-      for (const item of items) {
-        const id = String(item.id ?? item.requestId ?? item.idHash ?? "");
-        if (!id) continue;
+    const uses = data.timeOffUses ?? [];
+    logger.info(`휴가 사용 내역: ${uses.length}건 발견`);
 
-        if (collectedInstanceKeys.has(id)) {
-          logger.info(`중복 스킵: ${id} (인스턴스에서 이미 수집)`);
-          continue;
-        }
+    for (const use of uses) {
+      const id = use.userTimeOffRegisterEventId;
+      if (!id) continue;
 
-        result.totalCount++;
-
-        try {
-          const approval: AttendanceApproval = {
-            id,
-            type: String(item.type ?? item.category ?? endpoint.id),
-            applicant: {
-              name: String((item.applicant as Record<string, unknown>)?.name ?? (item.requester as Record<string, unknown>)?.name ?? "unknown"),
-              id: ((item.applicant as Record<string, unknown>)?.idHash as string) || undefined,
-            },
-            appliedAt: String(item.appliedAt ?? item.requestedAt ?? item.createdAt ?? ""),
-            details: extractDetails(item),
-            status: String(item.status ?? "unknown"),
-            approver: item.approver ? {
-              name: String((item.approver as Record<string, unknown>).name ?? ""),
-            } : undefined,
-            processedAt: item.processedAt ? String(item.processedAt) : undefined,
-            _raw: item,
-          };
-
-          await storage.saveAttendanceApproval(approval);
-          result.successCount++;
-        } catch (error) {
-          result.failureCount++;
-          result.errors.push({
-            target: `attendance:${id}`,
-            phase: "detail",
-            message: error instanceof Error ? error.message : String(error),
-            timestamp: nowISO(),
-          });
-        }
-
-        await delay(config.requestDelayMs);
+      if (collectedInstanceKeys.has(id)) {
+        logger.info(`중복 스킵: ${id} (인스턴스에서 이미 수집)`);
+        continue;
       }
-    } catch (error) {
-      logger.warn(`${endpoint.id} 접근 실패 (스킵)`, {
-        error: error instanceof Error ? error.message : String(error),
-      });
+
+      result.totalCount++;
+
+      try {
+        const approval: AttendanceApproval = {
+          id,
+          type: use.timeOffPolicyType ?? "TIME_OFF",
+          applicant: {
+            id: use.userIdHash,
+            name: use.userIdHash ?? "unknown", // 이름은 별도 API 필요
+          },
+          appliedAt: use.timeOffRegisterDateFrom ?? "",
+          details: {
+            dateFrom: use.timeOffRegisterDateFrom,
+            dateTo: use.timeOffRegisterDateTo,
+            days: use.useTime?.timeOffDays,
+            minutes: use.useTime?.timeOffMinutes,
+            policyType: use.timeOffPolicyType,
+            canceled: use.canceled,
+          },
+          status: mapStatus(use.timeOffUseStatus, use.approvalStatus?.status),
+          processedAt: use.timeOffRegisteredAt
+            ? new Date(use.timeOffRegisteredAt).toISOString()
+            : undefined,
+          _raw: use,
+        };
+
+        await storage.saveAttendanceApproval(approval);
+        result.successCount++;
+      } catch (error) {
+        result.failureCount++;
+        result.errors.push({
+          target: `attendance:${id}`,
+          phase: "detail",
+          message: error instanceof Error ? error.message : String(error),
+          timestamp: nowISO(),
+        });
+      }
+
+      await delay(config.requestDelayMs);
     }
+  } catch (error) {
+    logger.warn("휴가 사용 내역 수집 실패", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    result.errors.push({
+      target: "time-off-uses",
+      phase: "list",
+      message: error instanceof Error ? error.message : String(error),
+      timestamp: nowISO(),
+    });
   }
 
   result.durationMs = Date.now() - startTime;
@@ -100,28 +126,75 @@ export async function crawlAttendanceApprovals(
   return result;
 }
 
-function extractItems(data: Record<string, unknown>): Array<Record<string, unknown>> {
-  for (const key of Object.keys(data)) {
-    if (Array.isArray(data[key])) return data[key] as Array<Record<string, unknown>>;
-  }
-  if (data.data && typeof data.data === "object") {
-    const inner = data.data as Record<string, unknown>;
-    for (const key of Object.keys(inner)) {
-      if (Array.isArray(inner[key])) return inner[key] as Array<Record<string, unknown>>;
+// --- 사용자 ID 조회 ---
+
+async function getUserId(
+  authCtx: AuthContext,
+  config: Config,
+  logger: Logger,
+): Promise<string | null> {
+  try {
+    // /api/v2/core/me는 404이므로, workspace-users에서 currentUser를 가져옴
+    const data = await flexFetch<{
+      currentUser?: { userIdHash?: string };
+    }>(
+      authCtx,
+      `${config.flexBaseUrl}/api/v2/core/users/me/workspace-users-corp-group-affiliates`,
+    );
+    const userId = data.currentUser?.userIdHash ?? null;
+    if (userId) {
+      logger.info(`사용자 ID 확인: ${userId}`);
     }
+    return userId;
+  } catch (error) {
+    logger.warn("사용자 정보 조회 실패", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
   }
-  return [];
 }
 
-function extractDetails(item: Record<string, unknown>): Record<string, unknown> {
-  const details: Record<string, unknown> = {};
-  const keys = [
-    "targetDate", "startDate", "endDate", "startAt", "endAt",
-    "workType", "leaveType", "timeOffType", "reason", "memo",
-    "duration", "hours", "days", "shiftType",
-  ];
-  for (const key of keys) {
-    if (item[key] !== undefined) details[key] = item[key];
-  }
-  return details;
+// --- flex API 응답 타입 ---
+
+interface TimeOffUsesResponse {
+  timeOffUses?: Array<{
+    userTimeOffRegisterEventId: string;
+    timeOffUseStatus: string;
+    customerIdHash: string;
+    userIdHash: string;
+    timeOffRegisterDateFrom?: string;
+    timeOffRegisterDateTo?: string;
+    timeOffPolicyId?: string;
+    timeOffPolicyType?: string;
+    useTime?: {
+      timeOffDays: number;
+      timeOffMinutes: number;
+      timeOffTimeAmount?: {
+        days: number;
+        hours: number;
+        minutes: number;
+      };
+    };
+    approvalStatus?: {
+      status: string;
+      taskKey?: string;
+    };
+    cancelApprovalInProgress?: boolean;
+    timeOffRegisteredAt?: number;
+    canceled?: boolean;
+  }>;
+  hasNext?: boolean;
+}
+
+function mapStatus(useStatus?: string, approvalStatus?: string): string {
+  const status = approvalStatus ?? useStatus ?? "unknown";
+  const statusMap: Record<string, string> = {
+    APPROVED: "approved",
+    APPROVAL_COMPLETED: "approved",
+    REJECTED: "rejected",
+    CANCELED: "canceled",
+    IN_PROGRESS: "in_progress",
+    PENDING: "pending",
+  };
+  return statusMap[status] ?? status.toLowerCase();
 }

--- a/apps/flex-cli/src/discovery/catalog.ts
+++ b/apps/flex-cli/src/discovery/catalog.ts
@@ -1,0 +1,107 @@
+import { readFile } from "node:fs/promises";
+import type { ApiCatalog, CatalogEntry } from "../types/catalog.js";
+import type { CapturedRequest } from "./traffic-capture.js";
+import type { DiscoveredPage } from "./navigator.js";
+
+/** 알려진 엔드포인트 패턴 → 안정적 ID 매핑 */
+const ENDPOINT_PATTERNS: Array<{ id: string; method: string; pattern: RegExp }> = [
+  { id: "template-list", method: "GET", pattern: /\/api\/v\d+\/approval-document-template\/templates$/ },
+  { id: "template-detail", method: "GET", pattern: /\/api\/v\d+\/approval-document-template\/templates\/[^/]+$/ },
+  { id: "instance-search", method: "POST", pattern: /\/action\/v\d+\/approval-document\/user-boxes\/search/ },
+  { id: "instance-detail", method: "GET", pattern: /\/api\/v\d+\/approval-document\/approval-documents\/[^/]+$/ },
+  { id: "time-off-uses", method: "GET", pattern: /\/api\/v\d+\/time-off\/users\/[^/]+\/time-off-uses/ },
+  { id: "user-me", method: "GET", pattern: /\/api\/v\d+\/core\/me/ },
+];
+
+/** UUID-like 세그먼트를 {param}으로 일반화 */
+function generalizeUrlPattern(url: string): string {
+  const parsed = new URL(url);
+  const segments = parsed.pathname.split("/");
+  const generalized = segments.map((seg) => {
+    // UUID, hash ID, 긴 영숫자 문자열을 {param}으로
+    if (/^[a-f0-9-]{20,}$/i.test(seg) || /^[a-zA-Z0-9]{20,}$/.test(seg)) {
+      return "{param}";
+    }
+    return seg;
+  });
+  return generalized.join("/");
+}
+
+/** URL에서 쿼리 파라미터 추출 */
+function extractQueryParams(url: string): Record<string, string> | undefined {
+  const parsed = new URL(url);
+  const params: Record<string, string> = {};
+  parsed.searchParams.forEach((value, key) => {
+    params[key] = value;
+  });
+  return Object.keys(params).length > 0 ? params : undefined;
+}
+
+/** 캡처된 요청에 ID를 매칭 */
+function matchEndpointId(method: string, url: string): string | null {
+  const pathname = new URL(url).pathname;
+  for (const pattern of ENDPOINT_PATTERNS) {
+    if (pattern.method === method && pattern.pattern.test(pathname)) {
+      return pattern.id;
+    }
+  }
+  return null;
+}
+
+/** 캡처 결과 + 페이지 정보로 카탈로그 생성 */
+export function buildCatalog(
+  captures: CapturedRequest[],
+  discoveredPages: DiscoveredPage[],
+  flexBaseUrl: string,
+): ApiCatalog {
+  const entries: CatalogEntry[] = [];
+  const unclassified: CatalogEntry[] = [];
+
+  for (const capture of captures) {
+    const id = matchEndpointId(capture.method, capture.url);
+    const urlPattern = generalizeUrlPattern(capture.url);
+    const pageInfo = discoveredPages.find((p) =>
+      capture.pageUrl.includes(p.url),
+    );
+
+    const entry: CatalogEntry = {
+      id,
+      discoveredFrom: new URL(capture.pageUrl).pathname,
+      menuLabel: pageInfo?.menuLabel,
+      method: capture.method as CatalogEntry["method"],
+      urlPattern,
+      exampleUrl: new URL(capture.url).pathname + new URL(capture.url).search,
+      queryParams: extractQueryParams(capture.url),
+      requestBodySample: capture.requestBody,
+      statusCode: capture.statusCode,
+      responseBodySample: capture.responseBody,
+      totalItems: (capture as CapturedRequest & { totalItems?: number }).totalItems,
+      capturedAt: capture.capturedAt,
+    };
+
+    if (id) {
+      entries.push(entry);
+    } else {
+      unclassified.push(entry);
+    }
+  }
+
+  return {
+    version: "1.0",
+    capturedAt: new Date().toISOString(),
+    flexBaseUrl,
+    discoveredPages: discoveredPages.map((p) => p.url),
+    entries,
+    unclassified,
+  };
+}
+
+/** 파일에서 카탈로그 로드 */
+export async function loadCatalog(catalogPath: string): Promise<ApiCatalog | null> {
+  try {
+    const content = await readFile(catalogPath, "utf-8");
+    return JSON.parse(content) as ApiCatalog;
+  } catch {
+    return null;
+  }
+}

--- a/apps/flex-cli/src/discovery/navigator.ts
+++ b/apps/flex-cli/src/discovery/navigator.ts
@@ -1,0 +1,166 @@
+import type { Page } from "playwright";
+import type { Config } from "../config/index.js";
+import type { Logger } from "../logger/index.js";
+
+export interface DiscoveredPage {
+  url: string;
+  menuLabel: string;
+}
+
+/** 알려진 페이지 폴백 목록 */
+const FALLBACK_PATHS = [
+  "/approval/document-box/sent",
+  "/approval/admin/templates",
+  "/time-tracking/my",
+  "/time-off/my",
+];
+
+/**
+ * flex.team 사이드바 메뉴를 자동으로 순회하며 페이지를 탐색한다.
+ * 각 페이지에서 리스트 항목이 있으면 첫 번째 항목을 클릭해서 상세 API도 트리거한다.
+ */
+export async function navigateForDiscovery(
+  page: Page,
+  config: Config,
+  logger: Logger,
+): Promise<DiscoveredPage[]> {
+  const discoveredPages: DiscoveredPage[] = [];
+
+  // 메인 페이지 로드
+  await page.goto(config.flexBaseUrl, { waitUntil: "networkidle" });
+  await page.waitForTimeout(2000);
+
+  // 사이드바 메뉴 항목 추출 시도
+  const menuItems = await extractMenuItems(page, logger);
+
+  if (menuItems.length > 0) {
+    logger.info(`사이드바에서 ${menuItems.length}개 메뉴 항목 발견`);
+    for (const item of menuItems) {
+      await visitPage(page, item, config, logger, discoveredPages);
+    }
+  } else {
+    // 폴백: 알려진 URL 직접 방문
+    logger.warn("사이드바 메뉴 탐색 실패, 폴백 URL 사용");
+    for (const path of FALLBACK_PATHS) {
+      await visitPage(
+        page,
+        { url: `${config.flexBaseUrl}${path}`, label: path },
+        config,
+        logger,
+        discoveredPages,
+      );
+    }
+  }
+
+  return discoveredPages;
+}
+
+interface MenuItem {
+  url: string;
+  label: string;
+}
+
+async function extractMenuItems(page: Page, logger: Logger): Promise<MenuItem[]> {
+  try {
+    // flex.team의 사이드바 메뉴 링크를 추출
+    // 여러 셀렉터를 시도하여 호환성 확보
+    const selectors = [
+      'nav a[href]',
+      '[class*="sidebar"] a[href]',
+      '[class*="menu"] a[href]',
+      '[class*="nav"] a[href]',
+      'aside a[href]',
+    ];
+
+    for (const selector of selectors) {
+      const items = await page.evaluate((sel) => {
+        const links = document.querySelectorAll(sel);
+        const results: Array<{ url: string; label: string }> = [];
+        const seen = new Set<string>();
+
+        links.forEach((link) => {
+          const href = (link as HTMLAnchorElement).href;
+          const label = (link as HTMLElement).textContent?.trim() ?? "";
+          if (href && label && !seen.has(href) && !href.includes("javascript:")) {
+            seen.add(href);
+            results.push({ url: href, label });
+          }
+        });
+
+        return results;
+      }, selector);
+
+      if (items.length > 0) {
+        logger.info(`셀렉터 '${selector}'로 ${items.length}개 메뉴 발견`);
+        // flex.team 내부 링크만 필터
+        return items.filter((item) => item.url.includes("flex.team"));
+      }
+    }
+  } catch (error) {
+    logger.warn("메뉴 항목 추출 실패", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  return [];
+}
+
+async function visitPage(
+  page: Page,
+  target: MenuItem,
+  config: Config,
+  logger: Logger,
+  discoveredPages: DiscoveredPage[],
+): Promise<void> {
+  try {
+    logger.info(`페이지 탐색: ${target.label} (${target.url})`);
+
+    await page.goto(target.url, { waitUntil: "networkidle", timeout: 15000 });
+    await page.waitForTimeout(2000);
+
+    discoveredPages.push({
+      url: new URL(page.url()).pathname,
+      menuLabel: target.label,
+    });
+
+    // 리스트 페이지에서 첫 번째 항목 클릭 시도 (상세 API 트리거)
+    await tryClickFirstListItem(page, logger);
+
+    // 요청 간 딜레이
+    await page.waitForTimeout(config.requestDelayMs);
+  } catch (error) {
+    logger.warn(`페이지 탐색 실패: ${target.label}`, {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+async function tryClickFirstListItem(page: Page, logger: Logger): Promise<void> {
+  try {
+    // 리스트 항목의 일반적인 셀렉터
+    const listSelectors = [
+      'table tbody tr:first-child',
+      '[class*="list"] [class*="item"]:first-child',
+      '[class*="row"]:first-child a',
+      '[role="row"]:first-child',
+    ];
+
+    for (const selector of listSelectors) {
+      const element = page.locator(selector).first();
+      if (await element.isVisible({ timeout: 2000 }).catch(() => false)) {
+        await element.click();
+        await page.waitForLoadState("networkidle").catch(() => {});
+        await page.waitForTimeout(2000);
+
+        // 뒤로 가기
+        await page.goBack({ waitUntil: "networkidle" }).catch(() => {});
+        await page.waitForTimeout(1000);
+
+        logger.info("리스트 항목 클릭 → 상세 페이지 API 캡처");
+        return;
+      }
+    }
+  } catch {
+    // 클릭 실패는 무시 — 리스트가 없는 페이지일 수 있음
+  }
+}

--- a/apps/flex-cli/src/discovery/traffic-capture.ts
+++ b/apps/flex-cli/src/discovery/traffic-capture.ts
@@ -1,0 +1,132 @@
+import type { Page, Response } from "playwright";
+
+/** 캡처된 API 요청/응답 */
+export interface CapturedRequest {
+  url: string;
+  method: string;
+  /** 요청 발생 시점의 페이지 URL */
+  pageUrl: string;
+  requestBody?: unknown;
+  statusCode: number;
+  responseBody?: unknown;
+  capturedAt: string;
+}
+
+const SKIP_PATTERNS = [
+  /\.(js|css|png|jpg|jpeg|gif|svg|ico|woff|woff2|ttf|eot|map)(\?|$)/i,
+  /analytics/i,
+  /tracking/i,
+  /sentry/i,
+  /hotjar/i,
+  /gtag/i,
+  /google-analytics/i,
+  /googletagmanager/i,
+];
+
+function isApiUrl(url: string): boolean {
+  return (url.includes("/api/") || url.includes("/action/")) &&
+    !SKIP_PATTERNS.some((p) => p.test(url));
+}
+
+/**
+ * 응답 바디를 간결하게 만든다.
+ * - 배열: 첫 번째 요소만 남기고 totalItems 반환
+ * - 깊이 제한
+ */
+function truncateResponse(body: unknown, depth = 0): { truncated: unknown; totalItems?: number } {
+  if (depth > 5) return { truncated: "[TRUNCATED]" };
+
+  if (Array.isArray(body)) {
+    const totalItems = body.length;
+    const first = body.length > 0 ? truncateResponse(body[0], depth + 1).truncated : undefined;
+    return { truncated: first !== undefined ? [first] : [], totalItems };
+  }
+
+  if (body && typeof body === "object") {
+    const result: Record<string, unknown> = {};
+    let itemCount: number | undefined;
+
+    for (const [key, value] of Object.entries(body as Record<string, unknown>)) {
+      const { truncated, totalItems } = truncateResponse(value, depth + 1);
+      result[key] = truncated;
+      if (totalItems !== undefined) {
+        itemCount = totalItems;
+      }
+    }
+    return { truncated: result, totalItems: itemCount };
+  }
+
+  return { truncated: body };
+}
+
+export interface TrafficCapture {
+  start(): void;
+  stop(): CapturedRequest[];
+}
+
+export function createTrafficCapture(page: Page): TrafficCapture {
+  const captured: CapturedRequest[] = [];
+  const seenPatterns = new Set<string>();
+  let handler: ((response: Response) => Promise<void>) | null = null;
+
+  return {
+    start() {
+      handler = async (response: Response) => {
+        const url = response.url();
+        if (!isApiUrl(url)) return;
+
+        const method = response.request().method();
+        // 중복 방지: 같은 method + URL path 패턴은 한 번만 캡처
+        const urlPath = new URL(url).pathname;
+        const patternKey = `${method}:${urlPath}`;
+        if (seenPatterns.has(patternKey)) return;
+        seenPatterns.add(patternKey);
+
+        try {
+          const statusCode = response.status();
+          let responseBody: unknown;
+          try {
+            responseBody = await response.json();
+          } catch {
+            // JSON이 아닌 응답은 무시
+            return;
+          }
+
+          let requestBody: unknown;
+          if (method === "POST" || method === "PUT" || method === "PATCH") {
+            try {
+              requestBody = JSON.parse(response.request().postData() ?? "");
+            } catch {
+              // 파싱 실패 무시
+            }
+          }
+
+          const { truncated, totalItems } = truncateResponse(responseBody);
+
+          captured.push({
+            url,
+            method,
+            pageUrl: page.url(),
+            requestBody,
+            statusCode,
+            responseBody: truncated,
+            ...(totalItems !== undefined ? { totalItems } : {}),
+            capturedAt: new Date().toISOString(),
+          } as CapturedRequest & { totalItems?: number });
+        } catch {
+          // 캡처 실패는 무시
+        }
+      };
+
+      page.on("response", handler);
+    },
+
+    stop() {
+      if (handler) {
+        page.removeListener("response", handler);
+        handler = null;
+      }
+      return [...captured];
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- **discover 커맨드** — Playwright로 flex.team 사이드바 메뉴를 자동 순회하며 API 트래픽 캡처 → `api-catalog.json` 생성
- **check-apis 커맨드** — 하드코딩된 API 엔드포인트의 실제 상태(200/404/etc) 확인
- **근태 API 수정** — 디스커버리로 기존 API 3개가 404임을 발견, 실제 API(`time-off-uses`)로 교체
- **API 카탈로그** — `entries`(알려진 엔드포인트) + `unclassified`(새 발견)로 분류하여 에이전트가 새 API를 자동 감지 가능

## TODO

- [ ] 디스커버리 시 API 응답 샘플에서 `responseSchema` 자동 추론하여 카탈로그에 포함
  - `CatalogEntry.responseSchema` 타입은 PR1에서 정의 완료 (`JsonSchema`)
  - `buildCatalog()` 에서 `responseBodySample` → JSON 스키마 추론 로직 구현 필요

## 에이전트 자가 복구 흐름 (검증 완료)

```
1. discover 실행 → 129개 API 캡처, 9개 메뉴 자동 순회
2. check-apis로 기존 근태 API 404 확인
3. 카탈로그에서 실제 API(time-off-uses) 발견
4. 크롤러 코드 수정 → 타입 체크 통과
5. crawl로 검증 → 템플릿 29건, 인스턴스 11,254건 수집 성공
```

## Test plan

- [x] `flex-ax discover` — 카탈로그 생성, entries: 1, unclassified: 128, pages: 6
- [x] `flex-ax check-apis` — 근태 API 404 확인, 템플릿/인스턴스 API 정상
- [x] `flex-ax crawl` — 수정된 근태 API로 크롤링 동작 확인
- [x] `tsc --noEmit` 통과
- [ ] `responseSchema` 추론 구현 및 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)