### PR TITLE
feat: add GitHub Actions workflow for flex-cli releases

### DIFF
--- a/.github/workflows/release-flex-cli.yml
+++ b/.github/workflows/release-flex-cli.yml
@@ -12,13 +12,13 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
         with:
           version: 9.15.4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
           cache: pnpm

--- a/.github/workflows/release-flex-cli.yml
+++ b/.github/workflows/release-flex-cli.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: "22"
           cache: pnpm
 
-      - run: pnpm install --frozen-lockfile
+      - run: pnpm install --frozen-lockfile --filter ./apps/flex-cli...
 
       - name: Build flex-cli
         run: pnpm --filter ./apps/flex-cli build
@@ -47,7 +47,7 @@ jobs:
         run: pnpm pack --pack-destination ../../
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           name: "flex-cli ${{ steps.version.outputs.version }}"
           files: flex-ax-*.tgz

--- a/.github/workflows/release-flex-cli.yml
+++ b/.github/workflows/release-flex-cli.yml
@@ -15,6 +15,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.4
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release-flex-cli.yml
+++ b/.github/workflows/release-flex-cli.yml
@@ -24,15 +24,25 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Build flex-cli
-        run: pnpm --filter flex-ax build
-
-      - name: Pack tarball
-        working-directory: apps/flex-cli
-        run: pnpm pack --pack-destination ../../
+        run: pnpm --filter ./apps/flex-cli build
 
       - name: Extract version from tag
         id: version
         run: echo "version=${GITHUB_REF_NAME#flex-cli@}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify version matches package.json
+        working-directory: apps/flex-cli
+        run: |
+          pkg_version=$(node -p "require('./package.json').version")
+          tag_version="${{ steps.version.outputs.version }}"
+          if [ "$pkg_version" != "$tag_version" ]; then
+            echo "::error::Tag version ($tag_version) does not match package.json version ($pkg_version)"
+            exit 1
+          fi
+
+      - name: Pack tarball
+        working-directory: apps/flex-cli
+        run: pnpm pack --pack-destination ../../
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release-flex-cli.yml
+++ b/.github/workflows/release-flex-cli.yml
@@ -1,0 +1,42 @@
+name: Release flex-cli
+
+on:
+  push:
+    tags:
+      - "flex-cli@*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build flex-cli
+        run: pnpm --filter flex-ax build
+
+      - name: Pack tarball
+        working-directory: apps/flex-cli
+        run: pnpm pack --pack-destination ../../
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#flex-cli@}" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: "flex-cli ${{ steps.version.outputs.version }}"
+          files: flex-ax-*.tgz
+          generate_release_notes: true

--- a/apps/flex-cli/package.json
+++ b/apps/flex-cli/package.json
@@ -7,11 +7,15 @@
   "bin": {
     "flex-ax": "./dist/cli.js"
   },
+  "files": [
+    "dist",
+    "!dist/**/*.map"
+  ],
   "scripts": {
     "start": "tsx src/cli.ts",
     "crawl": "tsx src/cli.ts crawl",
     "install-skills": "tsx src/cli.ts install-skills",
-    "build": "tsc && node -e \"const fs=require('fs'); fs.mkdirSync('dist/db',{recursive:true}); fs.copyFileSync('src/db/schema.sql','dist/db/schema.sql');\"",
+    "build": "tsc && node -e \"const fs=require('fs'); fs.mkdirSync('dist/db',{recursive:true}); fs.copyFileSync('src/db/schema.sql','dist/db/schema.sql'); const cli='dist/cli.js'; const src=fs.readFileSync(cli,'utf8'); if(!src.startsWith('#!')) fs.writeFileSync(cli,'#!/usr/bin/env node\\n'+src);\"",
     "lint": "tsc --noEmit",
     "clean": "rimraf output dist"
   },

--- a/apps/flex-cli/package.json
+++ b/apps/flex-cli/package.json
@@ -15,7 +15,7 @@
     "start": "tsx src/cli.ts",
     "crawl": "tsx src/cli.ts crawl",
     "install-skills": "tsx src/cli.ts install-skills",
-    "build": "tsc && node -e \"const fs=require('fs'); fs.mkdirSync('dist/db',{recursive:true}); fs.copyFileSync('src/db/schema.sql','dist/db/schema.sql'); const cli='dist/cli.js'; const src=fs.readFileSync(cli,'utf8'); if(!src.startsWith('#!')) fs.writeFileSync(cli,'#!/usr/bin/env node\\n'+src);\"",
+    "build": "tsc && node scripts/postbuild.cjs",
     "lint": "tsc --noEmit",
     "clean": "rimraf output dist"
   },

--- a/apps/flex-cli/scripts/postbuild.cjs
+++ b/apps/flex-cli/scripts/postbuild.cjs
@@ -1,0 +1,12 @@
+const fs = require("fs");
+
+// Copy SQL schema to dist
+fs.mkdirSync("dist/db", { recursive: true });
+fs.copyFileSync("src/db/schema.sql", "dist/db/schema.sql");
+
+// Prepend shebang to CLI entry point
+const cli = "dist/cli.js";
+const src = fs.readFileSync(cli, "utf8");
+if (!src.startsWith("#!")) {
+  fs.writeFileSync(cli, "#!/usr/bin/env node\n" + src);
+}


### PR DESCRIPTION
## Summary
- `flex-cli@<version>` 태그 푸시 시 자동으로 GitHub Release를 생성하는 워크플로우 추가
- `apps/flex-cli/package.json`에 `files` 필드 추가로 tarball에 불필요한 파일 제외
- 빌드 시 `dist/cli.js`에 shebang(`#!/usr/bin/env node`) 자동 삽입

## 사용법

릴리스 생성:
```bash
git tag flex-cli@0.0.1
git push origin flex-cli@0.0.1
```

원격 에이전트 설치:
```bash
npm install -g https://github.com/planetarium/flex-ax/releases/download/flex-cli%400.0.1/flex-ax-0.0.1.tgz
```

## Test plan
- [x] `pnpm --filter flex-ax build` 로컬 빌드 성공 확인
- [x] `pnpm pack` tarball 내용물 확인 (dist/ + package.json만 포함)
- [x] shebang 삽입 확인
- [ ] 태그 푸시 후 GitHub Actions 워크플로우 실행 확인
- [ ] 생성된 Release에서 tarball 다운로드 후 `npm install -g` 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)