### PR TITLE
feat: add --file and --var support to flex-ax query

### DIFF
--- a/apps/flex-cli/package.json
+++ b/apps/flex-cli/package.json
@@ -16,6 +16,7 @@
     "crawl": "tsx src/cli.ts crawl",
     "install-skills": "tsx src/cli.ts install-skills",
     "build": "tsc && node scripts/postbuild.cjs",
+    "test": "tsx --test src/**/*.test.ts",
     "lint": "tsc --noEmit",
     "clean": "rimraf output dist"
   },

--- a/apps/flex-cli/package.json
+++ b/apps/flex-cli/package.json
@@ -15,7 +15,7 @@
     "start": "tsx src/cli.ts",
     "crawl": "tsx src/cli.ts crawl",
     "install-skills": "tsx src/cli.ts install-skills",
-    "build": "tsc && node scripts/postbuild.cjs",
+    "build": "tsc -p tsconfig.build.json && node scripts/postbuild.cjs",
     "test": "tsx --test src/**/*.test.ts",
     "lint": "tsc --noEmit",
     "clean": "rimraf output dist"

--- a/apps/flex-cli/src/cli.ts
+++ b/apps/flex-cli/src/cli.ts
@@ -54,7 +54,7 @@ Commands:
   import          크롤링 결과(JSON) → SQLite DB 변환
   query "SQL"     DB 쿼리 실행 → JSON 출력 (read-only)
                   --file <path>  SQL 파일 경로
-                  --var key=val  {{key}} 플레이스홀더 치환 (반복 가능)
+                  --var key=value  {{key}} 플레이스홀더 치환 (반복 가능)
   file <fileKey>  파일 내용 출력 (--info로 메타데이터만)
   install-skills  에이전트 스킬을 .claude/skills/에 설치
 

--- a/apps/flex-cli/src/cli.ts
+++ b/apps/flex-cli/src/cli.ts
@@ -53,6 +53,8 @@ Commands:
   crawl           카탈로그 기반 크롤링 → output/ 저장
   import          크롤링 결과(JSON) → SQLite DB 변환
   query "SQL"     DB 쿼리 실행 → JSON 출력 (read-only)
+                  --file <path>  SQL 파일 경로
+                  --var key=val  {{key}} 플레이스홀더 치환 (반복 가능)
   file <fileKey>  파일 내용 출력 (--info로 메타데이터만)
   install-skills  에이전트 스킬을 .claude/skills/에 설치
 

--- a/apps/flex-cli/src/commands/query.test.ts
+++ b/apps/flex-cli/src/commands/query.test.ts
@@ -1,0 +1,79 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { parseQueryArgs, applyVars } from "./query.js";
+
+describe("parseQueryArgs", () => {
+  // argv[0] = node, argv[1] = script, argv[2] = "query", argv[3..] = args
+  const base = ["node", "flex-ax", "query"];
+
+  it("parses inline SQL", () => {
+    const result = parseQueryArgs([...base, "SELECT * FROM users"]);
+    assert.equal(result.sql, "SELECT * FROM users");
+    assert.equal(result.filePath, null);
+    assert.equal(result.vars.size, 0);
+  });
+
+  it("parses multi-word inline SQL", () => {
+    const result = parseQueryArgs([...base, "SELECT", "*", "FROM", "users", "LIMIT", "10"]);
+    assert.equal(result.sql, "SELECT * FROM users LIMIT 10");
+  });
+
+  it("parses --file option", () => {
+    const result = parseQueryArgs([...base, "--file", "queries/search.sql"]);
+    assert.equal(result.sql, null);
+    assert.equal(result.filePath, "queries/search.sql");
+  });
+
+  it("parses --var options", () => {
+    const result = parseQueryArgs([...base, "--file", "q.sql", "--var", "name=홍길동", "--var", "limit=10"]);
+    assert.equal(result.filePath, "q.sql");
+    assert.equal(result.vars.get("name"), "홍길동");
+    assert.equal(result.vars.get("limit"), "10");
+    assert.equal(result.vars.size, 2);
+  });
+
+  it("handles --var with = in value", () => {
+    const result = parseQueryArgs([...base, "--file", "q.sql", "--var", "expr=a=b"]);
+    assert.equal(result.vars.get("expr"), "a=b");
+  });
+
+  it("returns null sql when no args", () => {
+    const result = parseQueryArgs([...base]);
+    assert.equal(result.sql, null);
+    assert.equal(result.filePath, null);
+  });
+
+  it("handles mixed positional and flags", () => {
+    const result = parseQueryArgs([...base, "--var", "x=1", "SELECT", "1"]);
+    assert.equal(result.sql, "SELECT 1");
+    assert.equal(result.vars.get("x"), "1");
+  });
+});
+
+describe("applyVars", () => {
+  it("replaces single placeholder", () => {
+    const result = applyVars("SELECT * FROM users WHERE name = '{{name}}'", new Map([["name", "홍길동"]]));
+    assert.equal(result, "SELECT * FROM users WHERE name = '홍길동'");
+  });
+
+  it("replaces multiple placeholders", () => {
+    const vars = new Map([["name", "홍길동"], ["limit", "5"]]);
+    const result = applyVars("SELECT * FROM users WHERE name LIKE '%{{name}}%' LIMIT {{limit}}", vars);
+    assert.equal(result, "SELECT * FROM users WHERE name LIKE '%홍길동%' LIMIT 5");
+  });
+
+  it("replaces duplicate placeholders", () => {
+    const result = applyVars("{{x}} and {{x}}", new Map([["x", "1"]]));
+    assert.equal(result, "1 and 1");
+  });
+
+  it("leaves unmatched placeholders as-is", () => {
+    const result = applyVars("{{a}} {{b}}", new Map([["a", "1"]]));
+    assert.equal(result, "1 {{b}}");
+  });
+
+  it("handles empty vars", () => {
+    const result = applyVars("SELECT 1", new Map());
+    assert.equal(result, "SELECT 1");
+  });
+});

--- a/apps/flex-cli/src/commands/query.test.ts
+++ b/apps/flex-cli/src/commands/query.test.ts
@@ -76,6 +76,13 @@ describe("parseQueryArgs", () => {
       (err: unknown) => err instanceof QueryArgError && /key=value/.test(err.message),
     );
   });
+
+  it("throws on --var with empty key", () => {
+    assert.throws(
+      () => parseQueryArgs([...base, "--var", "=value"]),
+      (err: unknown) => err instanceof QueryArgError && /non-empty/.test(err.message),
+    );
+  });
 });
 
 describe("applyVars", () => {

--- a/apps/flex-cli/src/commands/query.test.ts
+++ b/apps/flex-cli/src/commands/query.test.ts
@@ -111,4 +111,9 @@ describe("applyVars", () => {
     const result = applyVars("SELECT 1", new Map());
     assert.equal(result, "SELECT 1");
   });
+
+  it("preserves dollar signs in values literally", () => {
+    const result = applyVars("{{v}}", new Map([["v", "$& $$ $1"]]));
+    assert.equal(result, "$& $$ $1");
+  });
 });

--- a/apps/flex-cli/src/commands/query.test.ts
+++ b/apps/flex-cli/src/commands/query.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { parseQueryArgs, applyVars } from "./query.js";
+import { parseQueryArgs, applyVars, QueryArgError } from "./query.js";
 
 describe("parseQueryArgs", () => {
   // argv[0] = node, argv[1] = script, argv[2] = "query", argv[3..] = args
@@ -47,6 +47,34 @@ describe("parseQueryArgs", () => {
     const result = parseQueryArgs([...base, "--var", "x=1", "SELECT", "1"]);
     assert.equal(result.sql, "SELECT 1");
     assert.equal(result.vars.get("x"), "1");
+  });
+
+  it("throws on --file without value", () => {
+    assert.throws(
+      () => parseQueryArgs([...base, "--file"]),
+      (err: unknown) => err instanceof QueryArgError && /--file/.test(err.message),
+    );
+  });
+
+  it("throws on --file followed by another flag", () => {
+    assert.throws(
+      () => parseQueryArgs([...base, "--file", "--var", "x=1"]),
+      (err: unknown) => err instanceof QueryArgError && /--file/.test(err.message),
+    );
+  });
+
+  it("throws on --var without value", () => {
+    assert.throws(
+      () => parseQueryArgs([...base, "--var"]),
+      (err: unknown) => err instanceof QueryArgError && /--var/.test(err.message),
+    );
+  });
+
+  it("throws on --var with invalid format", () => {
+    assert.throws(
+      () => parseQueryArgs([...base, "--var", "badformat"]),
+      (err: unknown) => err instanceof QueryArgError && /key=value/.test(err.message),
+    );
   });
 });
 

--- a/apps/flex-cli/src/commands/query.ts
+++ b/apps/flex-cli/src/commands/query.ts
@@ -1,16 +1,74 @@
 import Database from "better-sqlite3";
 import { loadConfig } from "../config/index.js";
 import path from "node:path";
+import { readFileSync } from "node:fs";
+
+function parseQueryArgs(argv: string[]): {
+  sql: string | null;
+  filePath: string | null;
+  vars: Map<string, string>;
+} {
+  const args = argv.slice(3);
+  let filePath: string | null = null;
+  let vars = new Map<string, string>();
+  const positional: string[] = [];
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--file" && i + 1 < args.length) {
+      filePath = args[++i];
+    } else if (args[i] === "--var" && i + 1 < args.length) {
+      const varArg = args[++i];
+      const eqIdx = varArg.indexOf("=");
+      if (eqIdx === -1) {
+        console.error(`[FLEX-AX:ERROR] --var 형식이 잘못되었습니다: ${varArg} (expected key=value)`);
+        process.exit(1);
+      }
+      vars.set(varArg.slice(0, eqIdx), varArg.slice(eqIdx + 1));
+    } else {
+      positional.push(args[i]);
+    }
+  }
+
+  const inlineSQL = positional.join(" ").trim() || null;
+  return { sql: inlineSQL, filePath, vars };
+}
+
+function applyVars(sql: string, vars: Map<string, string>): string {
+  let result = sql;
+  for (const [key, value] of vars) {
+    result = result.replaceAll(`{{${key}}}`, value);
+  }
+  return result;
+}
 
 export async function runQuery(): Promise<void> {
-  const sql = process.argv.slice(3).join(" ").trim();
+  const { sql: inlineSQL, filePath, vars } = parseQueryArgs(process.argv);
 
-  if (!sql) {
+  let sql: string;
+  if (filePath) {
+    try {
+      sql = readFileSync(filePath, "utf-8").trim();
+    } catch (error) {
+      console.error(`[FLEX-AX:ERROR] SQL 파일을 읽을 수 없습니다: ${filePath}`);
+      process.exit(1);
+    }
+    if (inlineSQL) {
+      console.error(`[FLEX-AX:ERROR] --file과 인라인 SQL을 동시에 사용할 수 없습니다.`);
+      process.exit(1);
+    }
+  } else if (inlineSQL) {
+    sql = inlineSQL;
+  } else {
     console.error(`Usage: flex-ax query "SELECT ..."
+       flex-ax query --file queries/search.sql [--var key=value ...]
 
 SQL을 실행하고 결과를 JSON으로 출력합니다 (read-only).
 스키마는 apps/flex-cli/src/db/schema.sql 을 참조하세요.`);
     process.exit(1);
+  }
+
+  if (vars.size > 0) {
+    sql = applyVars(sql, vars);
   }
 
   let config: ReturnType<typeof loadConfig>;

--- a/apps/flex-cli/src/commands/query.ts
+++ b/apps/flex-cli/src/commands/query.ts
@@ -3,7 +3,7 @@ import { loadConfig } from "../config/index.js";
 import path from "node:path";
 import { readFileSync } from "node:fs";
 
-function parseQueryArgs(argv: string[]): {
+export function parseQueryArgs(argv: string[]): {
   sql: string | null;
   filePath: string | null;
   vars: Map<string, string>;
@@ -33,7 +33,7 @@ function parseQueryArgs(argv: string[]): {
   return { sql: inlineSQL, filePath, vars };
 }
 
-function applyVars(sql: string, vars: Map<string, string>): string {
+export function applyVars(sql: string, vars: Map<string, string>): string {
   let result = sql;
   for (const [key, value] of vars) {
     result = result.replaceAll(`{{${key}}}`, value);

--- a/apps/flex-cli/src/commands/query.ts
+++ b/apps/flex-cli/src/commands/query.ts
@@ -35,7 +35,11 @@ export function parseQueryArgs(argv: string[]): {
       if (eqIdx === -1) {
         throw new QueryArgError(`--var 형식이 잘못되었습니다: ${varArg} (expected key=value)`);
       }
-      vars.set(varArg.slice(0, eqIdx), varArg.slice(eqIdx + 1));
+      const key = varArg.slice(0, eqIdx);
+      if (key.trim().length === 0) {
+        throw new QueryArgError(`--var 형식이 잘못되었습니다: ${varArg} (expected non-empty key=value)`);
+      }
+      vars.set(key, varArg.slice(eqIdx + 1));
     } else {
       positional.push(args[i]);
     }
@@ -68,6 +72,10 @@ export async function runQuery(): Promise<void> {
 
   let sql: string;
   if (filePath) {
+    if (inlineSQL) {
+      console.error(`[FLEX-AX:ERROR] --file과 인라인 SQL을 동시에 사용할 수 없습니다.`);
+      process.exit(1);
+    }
     try {
       sql = readFileSync(filePath, "utf-8").trim();
     } catch (error) {
@@ -86,10 +94,6 @@ export async function runQuery(): Promise<void> {
     }
     if (!sql) {
       console.error(`[FLEX-AX:ERROR] SQL 파일이 비어 있습니다: ${filePath}`);
-      process.exit(1);
-    }
-    if (inlineSQL) {
-      console.error(`[FLEX-AX:ERROR] --file과 인라인 SQL을 동시에 사용할 수 없습니다.`);
       process.exit(1);
     }
   } else if (inlineSQL) {

--- a/apps/flex-cli/src/commands/query.ts
+++ b/apps/flex-cli/src/commands/query.ts
@@ -3,6 +3,13 @@ import { loadConfig } from "../config/index.js";
 import path from "node:path";
 import { readFileSync } from "node:fs";
 
+export class QueryArgError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "QueryArgError";
+  }
+}
+
 export function parseQueryArgs(argv: string[]): {
   sql: string | null;
   filePath: string | null;
@@ -10,18 +17,23 @@ export function parseQueryArgs(argv: string[]): {
 } {
   const args = argv.slice(3);
   let filePath: string | null = null;
-  let vars = new Map<string, string>();
+  const vars = new Map<string, string>();
   const positional: string[] = [];
 
   for (let i = 0; i < args.length; i++) {
-    if (args[i] === "--file" && i + 1 < args.length) {
+    if (args[i] === "--file") {
+      if (i + 1 >= args.length || args[i + 1].startsWith("-")) {
+        throw new QueryArgError("--file에 파일 경로를 지정해 주세요.");
+      }
       filePath = args[++i];
-    } else if (args[i] === "--var" && i + 1 < args.length) {
+    } else if (args[i] === "--var") {
+      if (i + 1 >= args.length || args[i + 1].startsWith("-")) {
+        throw new QueryArgError("--var에 key=value 값을 지정해 주세요.");
+      }
       const varArg = args[++i];
       const eqIdx = varArg.indexOf("=");
       if (eqIdx === -1) {
-        console.error(`[FLEX-AX:ERROR] --var 형식이 잘못되었습니다: ${varArg} (expected key=value)`);
-        process.exit(1);
+        throw new QueryArgError(`--var 형식이 잘못되었습니다: ${varArg} (expected key=value)`);
       }
       vars.set(varArg.slice(0, eqIdx), varArg.slice(eqIdx + 1));
     } else {
@@ -42,14 +54,38 @@ export function applyVars(sql: string, vars: Map<string, string>): string {
 }
 
 export async function runQuery(): Promise<void> {
-  const { sql: inlineSQL, filePath, vars } = parseQueryArgs(process.argv);
+  let parsed: ReturnType<typeof parseQueryArgs>;
+  try {
+    parsed = parseQueryArgs(process.argv);
+  } catch (error) {
+    if (error instanceof QueryArgError) {
+      console.error(`[FLEX-AX:ERROR] ${error.message}`);
+      process.exit(1);
+    }
+    throw error;
+  }
+  const { sql: inlineSQL, filePath, vars } = parsed;
 
   let sql: string;
   if (filePath) {
     try {
       sql = readFileSync(filePath, "utf-8").trim();
     } catch (error) {
-      console.error(`[FLEX-AX:ERROR] SQL 파일을 읽을 수 없습니다: ${filePath}`);
+      const errorCode =
+        typeof error === "object" &&
+        error !== null &&
+        "code" in error &&
+        typeof (error as { code?: unknown }).code === "string"
+          ? ` [${(error as { code: string }).code}]`
+          : "";
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.error(
+        `[FLEX-AX:ERROR] SQL 파일을 읽을 수 없습니다: ${filePath}${errorCode} - ${errorMessage}`,
+      );
+      process.exit(1);
+    }
+    if (!sql) {
+      console.error(`[FLEX-AX:ERROR] SQL 파일이 비어 있습니다: ${filePath}`);
       process.exit(1);
     }
     if (inlineSQL) {

--- a/apps/flex-cli/src/commands/query.ts
+++ b/apps/flex-cli/src/commands/query.ts
@@ -52,7 +52,7 @@ export function parseQueryArgs(argv: string[]): {
 export function applyVars(sql: string, vars: Map<string, string>): string {
   let result = sql;
   for (const [key, value] of vars) {
-    result = result.replaceAll(`{{${key}}}`, value);
+    result = result.replaceAll(`{{${key}}}`, () => value);
   }
   return result;
 }

--- a/apps/flex-cli/src/commands/query.ts
+++ b/apps/flex-cli/src/commands/query.ts
@@ -35,8 +35,8 @@ export function parseQueryArgs(argv: string[]): {
       if (eqIdx === -1) {
         throw new QueryArgError(`--var 형식이 잘못되었습니다: ${varArg} (expected key=value)`);
       }
-      const key = varArg.slice(0, eqIdx);
-      if (key.trim().length === 0) {
+      const key = varArg.slice(0, eqIdx).trim();
+      if (key.length === 0) {
         throw new QueryArgError(`--var 형식이 잘못되었습니다: ${varArg} (expected non-empty key=value)`);
       }
       vars.set(key, varArg.slice(eqIdx + 1));

--- a/apps/flex-cli/tsconfig.build.json
+++ b/apps/flex-cli/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/apps/flex-cli/tsconfig.json
+++ b/apps/flex-cli/tsconfig.json
@@ -5,5 +5,6 @@
     "rootDir": "./src",
     "lib": ["ES2022", "DOM"]
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/apps/flex-cli/tsconfig.json
+++ b/apps/flex-cli/tsconfig.json
@@ -5,6 +5,5 @@
     "rootDir": "./src",
     "lib": ["ES2022", "DOM"]
   },
-  "include": ["src/**/*"],
-  "exclude": ["src/**/*.test.ts"]
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
## Summary
- `--file <path>` 옵션으로 SQL 파일을 읽어 실행할 수 있도록 지원
- `--var key=value` 옵션으로 SQL 내 `{{key}}` 플레이스홀더를 치환 (반복 가능)
- 기존 인라인 SQL 인터페이스(`flex-ax query "SELECT ..."`)는 그대로 유지

## Usage

```bash
# 파일 기반 실행
flex-ax query --file queries/users-search.sql

# 파라미터 치환
flex-ax query --file queries/users-search.sql --var name=홍길동 --var limit=10
```

Closes #5

## Test plan
- [ ] `flex-ax query "SELECT 1"` — 기존 인라인 SQL 동작 확인
- [ ] `flex-ax query --file test.sql` — 파일 기반 실행 확인
- [ ] `flex-ax query --file test.sql --var key=value` — 플레이스홀더 치환 확인
- [ ] `flex-ax query --file nonexistent.sql` — 존재하지 않는 파일 에러 메시지 확인
- [ ] `flex-ax query --file test.sql "SELECT 1"` — 동시 사용 시 에러 확인
- [ ] `flex-ax query --var bad` — 잘못된 --var 형식 에러 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)