### PR TITLE
feat: add self-update command to flex-cli

### DIFF
--- a/apps/flex-cli/package.json
+++ b/apps/flex-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flex-ax",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "description": "flex HR SaaS AX CLI - discover, crawl, and manage flex data",

--- a/apps/flex-cli/src/cli.ts
+++ b/apps/flex-cli/src/cli.ts
@@ -53,6 +53,11 @@ switch (command) {
     await runInstallSkills();
     break;
   }
+  case "update": {
+    const { runUpdate } = await import("./commands/update.js");
+    await runUpdate();
+    break;
+  }
   default:
     if (command && command !== "help") {
       console.error(`[FLEX-AX:ERROR] Unknown command: ${command}`);
@@ -67,6 +72,7 @@ Commands:
                   --var key=value  {{key}} 플레이스홀더 치환 (반복 가능)
   file <fileKey>  파일 내용 출력 (--info로 메타데이터만)
   install-skills  에이전트 스킬을 .claude/skills/에 설치
+  update          최신 버전으로 업데이트
 
 Options:
   --auth <mode>   인증 모드: credentials | sso | playwriter

--- a/apps/flex-cli/src/commands/update.ts
+++ b/apps/flex-cli/src/commands/update.ts
@@ -1,0 +1,100 @@
+import { createWriteStream } from "node:fs";
+import { rename, rm, mkdir, readFile } from "node:fs/promises";
+import { execSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { pipeline } from "node:stream/promises";
+
+const REPO = "planetarium/flex-ax";
+const RELEASE_URL = `https://github.com/${REPO}/releases`;
+
+async function getCurrentVersion(): Promise<string> {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const pkgPath = path.resolve(__dirname, "../../package.json");
+  const pkg = JSON.parse(await readFile(pkgPath, "utf-8"));
+  return pkg.version;
+}
+
+async function getLatestVersion(): Promise<string> {
+  // GitHub redirects /releases/latest to /releases/tag/<tag>
+  const res = await fetch(`${RELEASE_URL}/latest`, { redirect: "manual" });
+  const location = res.headers.get("location");
+  if (!location) {
+    throw new Error("최신 릴리스를 찾을 수 없습니다.");
+  }
+  // location: https://github.com/planetarium/flex-ax/releases/tag/flex-cli@0.2.0
+  const tag = location.split("/").pop()!;
+  const version = tag.replace("flex-cli@", "");
+  return version;
+}
+
+async function downloadAndInstall(version: string): Promise<void> {
+  const tgzName = `flex-ax-${version}.tgz`;
+  const downloadUrl = `${RELEASE_URL}/download/flex-cli@${version}/${tgzName}`;
+
+  console.log(`[FLEX-AX:UPDATE] 다운로드 중: ${downloadUrl}`);
+  const res = await fetch(downloadUrl);
+  if (!res.ok || !res.body) {
+    throw new Error(`다운로드 실패: ${res.status} ${res.statusText}`);
+  }
+
+  // npm pack tarball 구조: package/ 아래에 파일이 들어있음
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const packageRoot = path.resolve(__dirname, "../..");
+  const tmpDir = path.join(packageRoot, ".update-tmp");
+
+  await rm(tmpDir, { recursive: true, force: true });
+  await mkdir(tmpDir, { recursive: true });
+
+  const tgzPath = path.join(tmpDir, tgzName);
+
+  // 다운로드
+  const fileStream = createWriteStream(tgzPath);
+  // @ts-expect-error ReadableStream to NodeJS stream
+  await pipeline(res.body, fileStream);
+
+  // 압축 해제
+  console.log("[FLEX-AX:UPDATE] 압축 해제 중...");
+  execSync(`tar -xzf ${JSON.stringify(tgzPath)} -C ${JSON.stringify(tmpDir)}`);
+
+  // package/ 내용물을 패키지 루트로 복사
+  const extractedDir = path.join(tmpDir, "package");
+
+  // dist/ 교체
+  const distTarget = path.join(packageRoot, "dist");
+  await rm(distTarget, { recursive: true, force: true });
+  await rename(path.join(extractedDir, "dist"), distTarget);
+
+  // package.json 교체
+  await rename(
+    path.join(extractedDir, "package.json"),
+    path.join(packageRoot, "package.json"),
+  );
+
+  // 정리
+  await rm(tmpDir, { recursive: true, force: true });
+}
+
+export async function runUpdate(): Promise<void> {
+  try {
+    const current = await getCurrentVersion();
+    console.log(`[FLEX-AX:UPDATE] 현재 버전: ${current}`);
+
+    const latest = await getLatestVersion();
+    console.log(`[FLEX-AX:UPDATE] 최신 버전: ${latest}`);
+
+    if (current === latest) {
+      console.log("[FLEX-AX:UPDATE] 이미 최신 버전입니다.");
+      return;
+    }
+
+    console.log(`[FLEX-AX:UPDATE] ${current} → ${latest} 업데이트 시작`);
+    await downloadAndInstall(latest);
+    console.log(`[FLEX-AX:UPDATE] ${latest} 업데이트 완료!`);
+  } catch (err) {
+    console.error(
+      `[FLEX-AX:ERROR] 업데이트 실패: ${err instanceof Error ? err.message : err}`,
+    );
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary
- `flex-ax update` 명령 추가
- GitHub Release에서 최신 빌드된 tarball을 다운받아 dist/ 및 package.json을 교체하는 자체 업데이트 기능
- API 토큰 불필요 (public repo의 release redirect URL 활용)

## 동작 방식
1. `https://github.com/planetarium/flex-ax/releases/latest` redirect로 최신 버전 확인
2. 현재 버전과 비교하여 동일하면 스킵
3. 최신 tarball 다운로드 → 압축 해제 → dist/ 및 package.json 교체

## Test plan
- [ ] `flex-ax update` 실행 시 최신 버전 확인 동작 검증
- [ ] 이미 최신 버전일 때 "이미 최신 버전입니다" 메시지 출력 확인
- [ ] 구버전에서 업데이트 시 dist/ 교체 및 버전 변경 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)