### PR TITLE
feat(flex-cli): per-corporation crawling via token exchange

### DIFF
--- a/apps/flex-cli/src/auth/index.ts
+++ b/apps/flex-cli/src/auth/index.ts
@@ -54,7 +54,7 @@ function setupHeaderCapture(
       const reqHostname = new URL(url).hostname;
       if (reqHostname === baseHostname && (url.includes("/api/") || url.includes("/action/"))) {
         const headers = request.headers();
-        for (const key of ["authorization", "cookie", "x-csrf-token"]) {
+        for (const key of ["authorization", "cookie", "x-csrf-token", "x-flex-aid", "x-flex-axios"]) {
           if (headers[key]) {
             authHeaders[key] = headers[key];
           }
@@ -238,6 +238,127 @@ async function authenticatePlaywriter(
 
   console.log("[FLEX-AX:AUTH] Playwriter CDP relay로 로그인 성공");
   return { browser, context, page, authHeaders };
+}
+
+export interface Corporation {
+  customerIdHash: string;
+  userIdHash: string;
+  name: string;
+  isRepresentative: boolean;
+  displayOrder: number;
+}
+
+interface AffiliatesResponse {
+  currentUser?: {
+    customer: { customerIdHash: string; name: string; isRepresentative: boolean; displayOrder: number };
+    user: { userIdHash: string };
+  };
+  users: Array<{
+    customer: { customerIdHash: string; name: string; isRepresentative: boolean; displayOrder: number };
+    user: { userIdHash: string };
+  }>;
+}
+
+/**
+ * 현재 로그인한 사용자가 속한 법인(회사) 목록을 조회한다.
+ * `users` 배열에 (회사 × 유저) 페어가 들어있고, 회사마다 userIdHash가 다르다.
+ */
+export async function listCorporations(authCtx: AuthContext, baseUrl: string): Promise<Corporation[]> {
+  const url = `${baseUrl}/api/v2/core/users/me/workspace-users-corp-group-affiliates`;
+  const data = await authCtx.page.evaluate(
+    async ([fetchUrl, headers]) => {
+      const res = await fetch(fetchUrl, { headers: headers as Record<string, string> });
+      if (!res.ok) throw new Error(`HTTP ${res.status}: ${fetchUrl}`);
+      return (await res.json()) as AffiliatesResponse;
+    },
+    [url, authCtx.authHeaders] as const,
+  );
+
+  const fromUsers = data.users.map((u) => ({
+    customerIdHash: u.customer.customerIdHash,
+    userIdHash: u.user.userIdHash,
+    name: u.customer.name,
+    isRepresentative: u.customer.isRepresentative,
+    displayOrder: u.customer.displayOrder,
+  }));
+
+  if (fromUsers.length > 0) return fromUsers;
+
+  // fallback: currentUser만 있는 경우
+  if (data.currentUser) {
+    return [
+      {
+        customerIdHash: data.currentUser.customer.customerIdHash,
+        userIdHash: data.currentUser.user.userIdHash,
+        name: data.currentUser.customer.name,
+        isRepresentative: data.currentUser.customer.isRepresentative,
+        displayOrder: data.currentUser.customer.displayOrder,
+      },
+    ];
+  }
+
+  return [];
+}
+
+/**
+ * 지정된 법인 컨텍스트용 JWT를 발급받아 authHeaders에 주입한다.
+ * 이후 모든 flex API 호출은 해당 법인 스코프로 동작한다.
+ *
+ * 인증 방식: 워크스페이스 레벨 JWT(V2_WS_AID 쿠키)를 `flexteam-v2-workspace-access`
+ * 헤더로 전달하면, 서버가 해당 법인 스코프의 고객 JWT를 반환한다.
+ */
+export async function switchCustomer(
+  authCtx: AuthContext,
+  baseUrl: string,
+  customerUuid: string,
+  userUuid: string,
+): Promise<void> {
+  const url = `${baseUrl}/api-public/v2/auth/tokens/customer-user/exchange`;
+  const wsAid = extractCookieValue(authCtx.authHeaders["cookie"] ?? "", "V2_WS_AID");
+  if (!wsAid) {
+    throw new Error(
+      "V2_WS_AID 쿠키를 찾을 수 없습니다. 워크스페이스 인증이 만료되었거나 쿠키가 누락되었습니다.",
+    );
+  }
+
+  const exchangeHeaders: Record<string, string> = {
+    cookie: authCtx.authHeaders["cookie"] ?? "",
+    "content-type": "application/json",
+    "flexteam-v2-workspace-access": wsAid,
+    "x-flex-axios": "base",
+  };
+
+  const result = await authCtx.page.evaluate(
+    async ([fetchUrl, headers, bodyStr]) => {
+      const res = await fetch(fetchUrl, {
+        method: "POST",
+        headers: headers as Record<string, string>,
+        body: bodyStr as string,
+      });
+      if (!res.ok) {
+        const body = await res.text();
+        throw new Error(`HTTP ${res.status}: ${fetchUrl} — ${body.slice(0, 200)}`);
+      }
+      return (await res.json()) as { token: string };
+    },
+    [url, exchangeHeaders, JSON.stringify({ customerUuid, userUuid })] as const,
+  );
+
+  if (!result?.token) {
+    throw new Error(`회사 전환 토큰 발급 실패: customerUuid=${customerUuid}`);
+  }
+
+  authCtx.authHeaders["x-flex-aid"] = result.token;
+}
+
+function extractCookieValue(cookieStr: string, name: string): string | null {
+  for (const pair of cookieStr.split(";")) {
+    const trimmed = pair.trim();
+    if (trimmed.startsWith(`${name}=`)) {
+      return trimmed.slice(name.length + 1);
+    }
+  }
+  return null;
 }
 
 export async function cleanup(authCtx: AuthContext): Promise<void> {

--- a/apps/flex-cli/src/auth/index.ts
+++ b/apps/flex-cli/src/auth/index.ts
@@ -194,34 +194,47 @@ async function authenticatePlaywriter(
     await remotePage.goto(config.flexBaseUrl, { waitUntil: "domcontentloaded", timeout: 15000 });
   }
 
-  const cookieStr = await remotePage.evaluate(() => document.cookie);
+  // httpOnly 쿠키까지 포함하도록 Playwright context API로 전체 쿠키를 수집한다.
+  // (document.cookie는 httpOnly 쿠키를 반환하지 않으므로 V2_WS_AID 등이 누락될 수 있다.)
+  const origin = new URL(config.flexBaseUrl).origin;
+  let remoteCookies = await remoteContext.cookies(origin).catch(() => [] as Awaited<ReturnType<typeof remoteContext.cookies>>);
+
+  // context.cookies()가 빈 배열을 주면 document.cookie로 폴백
+  let cookieStr: string;
+  if (remoteCookies.length > 0) {
+    cookieStr = remoteCookies.map((c) => `${c.name}=${c.value}`).join("; ");
+  } else {
+    cookieStr = await remotePage.evaluate(() => document.cookie);
+    remoteCookies = cookieStr
+      .split(";")
+      .map((pair) => {
+        const [name, ...rest] = pair.trim().split("=");
+        return {
+          name: name.trim(),
+          value: rest.join("="),
+          domain: new URL(config.flexBaseUrl).hostname,
+          path: "/",
+        };
+      })
+      .filter((c) => c.name && c.value) as typeof remoteCookies;
+  }
 
   // CDP 연결 해제 (사용자 브라우저는 닫지 않음)
   remoteBrowser.close().catch(() => {});
 
-  if (!cookieStr) {
+  if (remoteCookies.length === 0) {
     throw new Error(
       "Playwriter에서 쿠키를 가져올 수 없습니다. " +
       "Chrome에서 flex.team에 로그인되어 있는지 확인하세요.",
     );
   }
 
-  const parsedCookies = cookieStr.split(";").map((pair) => {
-    const [name, ...rest] = pair.trim().split("=");
-    return {
-      name: name.trim(),
-      value: rest.join("="),
-      domain: new URL(config.flexBaseUrl).hostname,
-      path: "/",
-    };
-  }).filter((c) => c.name && c.value);
-
-  logger.info(`쿠키 ${parsedCookies.length}개 확보`);
+  logger.info(`쿠키 ${remoteCookies.length}개 확보`);
 
   // 3. headless 브라우저에 쿠키 주입
   const browser = await chromium.launch({ headless: true });
   const context = await browser.newContext();
-  await context.addCookies(parsedCookies);
+  await context.addCookies(remoteCookies);
 
   const page = await context.newPage();
   const authHeaders: Record<string, string> = { cookie: cookieStr };

--- a/apps/flex-cli/src/auth/index.ts
+++ b/apps/flex-cli/src/auth/index.ts
@@ -306,12 +306,15 @@ export async function listCorporations(authCtx: AuthContext, baseUrl: string): P
  *
  * 인증 방식: 워크스페이스 레벨 JWT(V2_WS_AID 쿠키)를 `flexteam-v2-workspace-access`
  * 헤더로 전달하면, 서버가 해당 법인 스코프의 고객 JWT를 반환한다.
+ *
+ * @param customerIdHash  법인 식별자. API 바디에는 `customerUuid` 필드로 전달된다.
+ * @param userIdHash      해당 법인에서의 사용자 식별자. API 바디에는 `userUuid` 필드로 전달된다.
  */
 export async function switchCustomer(
   authCtx: AuthContext,
   baseUrl: string,
-  customerUuid: string,
-  userUuid: string,
+  customerIdHash: string,
+  userIdHash: string,
 ): Promise<void> {
   const url = `${baseUrl}/api-public/v2/auth/tokens/customer-user/exchange`;
   const wsAid = extractCookieValue(authCtx.authHeaders["cookie"] ?? "", "V2_WS_AID");
@@ -328,6 +331,9 @@ export async function switchCustomer(
     "x-flex-axios": "base",
   };
 
+  // API 바디 필드명은 customerUuid/userUuid지만 실제 값은 hash 식별자다
+  const body = JSON.stringify({ customerUuid: customerIdHash, userUuid: userIdHash });
+
   const result = await authCtx.page.evaluate(
     async ([fetchUrl, headers, bodyStr]) => {
       const res = await fetch(fetchUrl, {
@@ -336,16 +342,16 @@ export async function switchCustomer(
         body: bodyStr as string,
       });
       if (!res.ok) {
-        const body = await res.text();
-        throw new Error(`HTTP ${res.status}: ${fetchUrl} — ${body.slice(0, 200)}`);
+        const errBody = await res.text();
+        throw new Error(`HTTP ${res.status}: ${fetchUrl} — ${errBody.slice(0, 200)}`);
       }
       return (await res.json()) as { token: string };
     },
-    [url, exchangeHeaders, JSON.stringify({ customerUuid, userUuid })] as const,
+    [url, exchangeHeaders, body] as const,
   );
 
   if (!result?.token) {
-    throw new Error(`회사 전환 토큰 발급 실패: customerUuid=${customerUuid}`);
+    throw new Error(`회사 전환 토큰 발급 실패: customerIdHash=${customerIdHash}`);
   }
 
   authCtx.authHeaders["x-flex-aid"] = result.token;

--- a/apps/flex-cli/src/auth/index.ts
+++ b/apps/flex-cli/src/auth/index.ts
@@ -317,15 +317,18 @@ export async function switchCustomer(
   userIdHash: string,
 ): Promise<void> {
   const url = `${baseUrl}/api-public/v2/auth/tokens/customer-user/exchange`;
-  const wsAid = extractCookieValue(authCtx.authHeaders["cookie"] ?? "", "V2_WS_AID");
+
+  // 브라우저 컨텍스트의 실제 쿠키가 진실이다.
+  // authHeaders.cookie는 네트워크 요청이 한 번도 없었거나 쿠키가 갱신된 경우 stale일 수 있다.
+  const wsAid = await getCookieFromContext(authCtx, baseUrl, "V2_WS_AID");
   if (!wsAid) {
     throw new Error(
       "V2_WS_AID 쿠키를 찾을 수 없습니다. 워크스페이스 인증이 만료되었거나 쿠키가 누락되었습니다.",
     );
   }
 
+  // 브라우저 fetch는 컨텍스트 쿠키를 자동 첨부하므로 Cookie 헤더를 명시할 필요가 없다.
   const exchangeHeaders: Record<string, string> = {
-    cookie: authCtx.authHeaders["cookie"] ?? "",
     "content-type": "application/json",
     "flexteam-v2-workspace-access": wsAid,
     "x-flex-axios": "base",
@@ -340,6 +343,7 @@ export async function switchCustomer(
         method: "POST",
         headers: headers as Record<string, string>,
         body: bodyStr as string,
+        credentials: "include",
       });
       if (!res.ok) {
         const errBody = await res.text();
@@ -355,6 +359,25 @@ export async function switchCustomer(
   }
 
   authCtx.authHeaders["x-flex-aid"] = result.token;
+}
+
+/**
+ * 브라우저 컨텍스트에서 지정된 쿠키 값을 읽는다 (httpOnly 쿠키 포함).
+ * Playwright의 context.cookies()는 실제 쿠키 저장소를 반환하므로 stale 이슈가 없다.
+ */
+async function getCookieFromContext(
+  authCtx: AuthContext,
+  baseUrl: string,
+  name: string,
+): Promise<string | null> {
+  try {
+    const cookies = await authCtx.context.cookies(baseUrl);
+    const hit = cookies.find((c) => c.name === name);
+    if (hit) return hit.value;
+  } catch {
+    // context.cookies()가 일부 CDP 구성에서 실패할 수 있음 — headers 폴백
+  }
+  return extractCookieValue(authCtx.authHeaders["cookie"] ?? "", name);
 }
 
 function extractCookieValue(cookieStr: string, name: string): string | null {

--- a/apps/flex-cli/src/auth/index.ts
+++ b/apps/flex-cli/src/auth/index.ts
@@ -198,12 +198,14 @@ async function authenticatePlaywriter(
   // (document.cookie는 httpOnly 쿠키를 반환하지 않으므로 V2_WS_AID 등이 누락될 수 있다.)
   const origin = new URL(config.flexBaseUrl).origin;
   let remoteCookies = await remoteContext.cookies(origin).catch(() => [] as Awaited<ReturnType<typeof remoteContext.cookies>>);
+  let usedFallback = false;
 
   // context.cookies()가 빈 배열을 주면 document.cookie로 폴백
   let cookieStr: string;
   if (remoteCookies.length > 0) {
     cookieStr = remoteCookies.map((c) => `${c.name}=${c.value}`).join("; ");
   } else {
+    usedFallback = true;
     cookieStr = await remotePage.evaluate(() => document.cookie);
     remoteCookies = cookieStr
       .split(";")
@@ -227,6 +229,16 @@ async function authenticatePlaywriter(
       "Playwriter에서 쿠키를 가져올 수 없습니다. " +
       "Chrome에서 flex.team에 로그인되어 있는지 확인하세요.",
     );
+  }
+
+  // 멀티-법인 전환에 필수인 V2_WS_AID가 확보됐는지 즉시 검증한다.
+  // 폴백 경로(document.cookie)에서는 httpOnly 쿠키를 얻을 수 없으므로 여기서 빠르게 실패시킨다.
+  const hasWsAid = remoteCookies.some((c) => c.name === "V2_WS_AID");
+  if (!hasWsAid) {
+    const hint = usedFallback
+      ? "httpOnly 쿠키를 가져올 수 없는 경로(document.cookie 폴백)라 V2_WS_AID를 얻지 못했을 수 있습니다. Playwriter Extension 연결 상태를 확인하세요."
+      : "Chrome에서 flex.team에 다시 로그인하면 갱신됩니다.";
+    throw new Error(`V2_WS_AID 쿠키를 찾을 수 없습니다 — 법인 전환(switchCustomer)이 불가능합니다. ${hint}`);
   }
 
   logger.info(`쿠키 ${remoteCookies.length}개 확보`);

--- a/apps/flex-cli/src/commands/crawl.ts
+++ b/apps/flex-cli/src/commands/crawl.ts
@@ -143,6 +143,7 @@ async function runCrawlForCustomer(
   let instanceResult: CrawlResult = emptyResult();
   let attendanceResult: CrawlResult = emptyResult();
   let catalogEndpointsResult: CrawlResult = emptyResult();
+  let fatalError: CrawlError | null = null;
 
   try {
     templateResult = await crawlTemplates(authCtx, config, catalog, storage, logger);
@@ -154,15 +155,16 @@ async function runCrawlForCustomer(
     catalogEndpointsResult = await crawlCatalogEndpoints(authCtx, config, catalog, storage, logger);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    logger.error("법인 크롤링 중 예외", { customerIdHash: corp.customerIdHash, error: message });
-    return [
-      {
-        target: `customer:${corp.customerIdHash}`,
-        phase: "crawl",
-        message,
-        timestamp: new Date().toISOString(),
-      },
-    ];
+    logger.error("법인 크롤링 중 예외 — 지금까지의 부분 결과를 보고서에 기록합니다", {
+      customerIdHash: corp.customerIdHash,
+      error: message,
+    });
+    fatalError = {
+      target: `customer:${corp.customerIdHash}`,
+      phase: "crawl",
+      message,
+      timestamp: new Date().toISOString(),
+    };
   }
 
   const completedAt = new Date().toISOString();
@@ -172,6 +174,7 @@ async function runCrawlForCustomer(
     ...attendanceResult.errors,
     ...catalogEndpointsResult.errors,
   ].map((e) => ({ ...e, target: `${corp.customerIdHash}/${e.target}` }));
+  if (fatalError) totalErrors.push(fatalError);
 
   const report: CrawlReport = {
     startedAt,
@@ -184,10 +187,19 @@ async function runCrawlForCustomer(
     totalErrors,
   };
 
-  await storage.saveReport(report);
+  // 예외 상황에서도 디버깅 가능하도록 보고서는 반드시 저장
+  try {
+    await storage.saveReport(report);
+  } catch (saveError) {
+    logger.error("크롤 보고서 저장 실패", {
+      customerIdHash: corp.customerIdHash,
+      error: saveError instanceof Error ? saveError.message : String(saveError),
+    });
+  }
 
+  const statusLabel = fatalError ? "중단(부분 결과)" : "완료";
   console.log(
-    `[FLEX-AX:CRAWL] ${corp.name} (${corp.customerIdHash}) 완료: ` +
+    `[FLEX-AX:CRAWL] ${corp.name} (${corp.customerIdHash}) ${statusLabel}: ` +
       `templates=${templateResult.successCount}, instances=${instanceResult.successCount}, ` +
       `attendance=${attendanceResult.successCount}, endpoints=${catalogEndpointsResult.successCount}`,
   );

--- a/apps/flex-cli/src/commands/crawl.ts
+++ b/apps/flex-cli/src/commands/crawl.ts
@@ -50,18 +50,15 @@ export async function runCrawl(): Promise<void> {
   }
 
   // 인증
-  let authCtx!: AuthContext;
-  try {
-    authCtx = await authenticate(config, logger);
-  } catch (error) {
+  const authCtx = await authenticate(config, logger).catch((error) => {
     logger.error("인증 실패", {
       error: error instanceof Error ? error.message : String(error),
     });
     process.exit(1);
-  }
+  });
 
   // 법인(회사) enumerate
-  let corporations!: Corporation[];
+  let corporations: Corporation[];
   try {
     corporations = await listCorporations(authCtx, config.flexBaseUrl);
   } catch (error) {

--- a/apps/flex-cli/src/commands/crawl.ts
+++ b/apps/flex-cli/src/commands/crawl.ts
@@ -97,6 +97,19 @@ export async function runCrawl(): Promise<void> {
   const allErrors: CrawlError[] = [];
   try {
     for (const corp of corporations) {
+      if (!isSafeIdHash(corp.customerIdHash)) {
+        logger.error("customerIdHash 형식이 안전하지 않아 스킵", {
+          customerIdHash: corp.customerIdHash,
+          name: corp.name,
+        });
+        allErrors.push({
+          target: `customer:${corp.customerIdHash}`,
+          phase: "validate-customer",
+          message: `unsafe customerIdHash: ${corp.customerIdHash}`,
+          timestamp: new Date().toISOString(),
+        });
+        continue;
+      }
       logger.info("법인 전환", { customerIdHash: corp.customerIdHash, name: corp.name });
       try {
         await switchCustomer(authCtx, config.flexBaseUrl, corp.customerIdHash, corp.userIdHash);
@@ -205,6 +218,15 @@ async function runCrawlForCustomer(
   );
 
   return totalErrors;
+}
+
+/**
+ * flex API에서 오는 ID 해시는 통상 영숫자 10자 내외다.
+ * 외부 입력이 디렉토리 경로로 쓰이므로 path traversal을 방지하기 위해
+ * 허용 문자셋을 엄격히 제한한다.
+ */
+function isSafeIdHash(id: string): boolean {
+  return typeof id === "string" && id.length > 0 && id.length <= 64 && /^[A-Za-z0-9_-]+$/.test(id);
 }
 
 function emptyResult(): CrawlResult {

--- a/apps/flex-cli/src/commands/crawl.ts
+++ b/apps/flex-cli/src/commands/crawl.ts
@@ -1,8 +1,16 @@
+import path from "node:path";
 import { readFile } from "node:fs/promises";
 import { loadConfig, type Config } from "../config/index.js";
-import { createLogger } from "../logger/index.js";
-import { authenticate, cleanup, type AuthContext } from "../auth/index.js";
-import { createStorageWriter, type CrawlReport } from "../storage/index.js";
+import { createLogger, type Logger } from "../logger/index.js";
+import {
+  authenticate,
+  cleanup,
+  listCorporations,
+  switchCustomer,
+  type AuthContext,
+  type Corporation,
+} from "../auth/index.js";
+import { createStorageWriter, type CrawlReport, type StorageWriter } from "../storage/index.js";
 import type { ApiCatalog } from "../types/catalog.js";
 import { crawlTemplates } from "../crawlers/template.js";
 import { crawlInstances } from "../crawlers/instance.js";
@@ -42,7 +50,7 @@ export async function runCrawl(): Promise<void> {
   }
 
   // 인증
-  let authCtx: AuthContext;
+  let authCtx!: AuthContext;
   try {
     authCtx = await authenticate(config, logger);
   } catch (error) {
@@ -52,13 +60,89 @@ export async function runCrawl(): Promise<void> {
     process.exit(1);
   }
 
-  const storage = createStorageWriter(config.outputDir, config.catalogPath);
+  // 법인(회사) enumerate
+  let corporations!: Corporation[];
+  try {
+    corporations = await listCorporations(authCtx, config.flexBaseUrl);
+  } catch (error) {
+    await cleanup(authCtx);
+    logger.error("법인 목록 조회 실패", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    process.exit(1);
+  }
+
+  if (config.customers.length > 0) {
+    const requested = new Set(config.customers);
+    corporations = corporations.filter((c) => requested.has(c.customerIdHash));
+    const missing = [...requested].filter(
+      (id) => !corporations.some((c) => c.customerIdHash === id),
+    );
+    if (missing.length > 0) {
+      logger.warn("요청한 법인이 접근 가능 목록에 없음", { missing });
+    }
+  }
+
+  if (corporations.length === 0) {
+    await cleanup(authCtx);
+    logger.error("크롤링할 법인이 없습니다");
+    process.exit(1);
+  }
+
+  logger.info("법인별 크롤링 시작", {
+    count: corporations.length,
+    names: corporations.map((c) => c.name),
+  });
+
+  const allErrors: CrawlError[] = [];
+  try {
+    for (const corp of corporations) {
+      logger.info("법인 전환", { customerIdHash: corp.customerIdHash, name: corp.name });
+      try {
+        await switchCustomer(authCtx, config.flexBaseUrl, corp.customerIdHash, corp.userIdHash);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        logger.error("법인 전환 실패 — 스킵", { customerIdHash: corp.customerIdHash, error: message });
+        allErrors.push({
+          target: `customer:${corp.customerIdHash}`,
+          phase: "switch-customer",
+          message,
+          timestamp: new Date().toISOString(),
+        });
+        continue;
+      }
+
+      const errors = await runCrawlForCustomer(authCtx, config, catalog, corp, logger);
+      allErrors.push(...errors);
+    }
+  } finally {
+    await cleanup(authCtx);
+  }
+
+  if (allErrors.length > 0) {
+    for (const err of allErrors) {
+      console.log(`[FLEX-AX:ERROR] ${err.target}: ${err.message}`);
+    }
+    process.exit(2);
+  }
+}
+
+async function runCrawlForCustomer(
+  authCtx: AuthContext,
+  config: Config,
+  catalog: ApiCatalog | null,
+  corp: Corporation,
+  logger: Logger,
+): Promise<CrawlError[]> {
+  const customerOutputDir = path.join(config.outputDir, corp.customerIdHash);
+  const storage: StorageWriter = createStorageWriter(customerOutputDir, config.catalogPath);
+
   const startedAt = new Date().toISOString();
   const startTime = Date.now();
-  let templateResult: CrawlResult = { totalCount: 0, successCount: 0, failureCount: 0, errors: [], durationMs: 0 };
-  let instanceResult: CrawlResult = { totalCount: 0, successCount: 0, failureCount: 0, errors: [], durationMs: 0 };
-  let attendanceResult: CrawlResult = { totalCount: 0, successCount: 0, failureCount: 0, errors: [], durationMs: 0 };
-  let catalogEndpointsResult: CrawlResult = { totalCount: 0, successCount: 0, failureCount: 0, errors: [], durationMs: 0 };
+  let templateResult: CrawlResult = emptyResult();
+  let instanceResult: CrawlResult = emptyResult();
+  let attendanceResult: CrawlResult = emptyResult();
+  let catalogEndpointsResult: CrawlResult = emptyResult();
 
   try {
     templateResult = await crawlTemplates(authCtx, config, catalog, storage, logger);
@@ -68,8 +152,17 @@ export async function runCrawl(): Promise<void> {
       authCtx, config, catalog, storage, logger, instanceCrawlResult.collectedKeys,
     );
     catalogEndpointsResult = await crawlCatalogEndpoints(authCtx, config, catalog, storage, logger);
-  } finally {
-    await cleanup(authCtx);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.error("법인 크롤링 중 예외", { customerIdHash: corp.customerIdHash, error: message });
+    return [
+      {
+        target: `customer:${corp.customerIdHash}`,
+        phase: "crawl",
+        message,
+        timestamp: new Date().toISOString(),
+      },
+    ];
   }
 
   const completedAt = new Date().toISOString();
@@ -78,7 +171,7 @@ export async function runCrawl(): Promise<void> {
     ...instanceResult.errors,
     ...attendanceResult.errors,
     ...catalogEndpointsResult.errors,
-  ];
+  ].map((e) => ({ ...e, target: `${corp.customerIdHash}/${e.target}` }));
 
   const report: CrawlReport = {
     startedAt,
@@ -93,13 +186,15 @@ export async function runCrawl(): Promise<void> {
 
   await storage.saveReport(report);
 
-  // 구조화된 출력
-  console.log(`[FLEX-AX:CRAWL] 크롤링 완료: templates=${templateResult.successCount}, instances=${instanceResult.successCount}, attendance=${attendanceResult.successCount}, endpoints=${catalogEndpointsResult.successCount}`);
+  console.log(
+    `[FLEX-AX:CRAWL] ${corp.name} (${corp.customerIdHash}) 완료: ` +
+      `templates=${templateResult.successCount}, instances=${instanceResult.successCount}, ` +
+      `attendance=${attendanceResult.successCount}, endpoints=${catalogEndpointsResult.successCount}`,
+  );
 
-  if (totalErrors.length > 0) {
-    for (const err of totalErrors) {
-      console.log(`[FLEX-AX:ERROR] ${err.target}: ${err.message}`);
-    }
-    process.exit(2);
-  }
+  return totalErrors;
+}
+
+function emptyResult(): CrawlResult {
+  return { totalCount: 0, successCount: 0, failureCount: 0, errors: [], durationMs: 0 };
 }

--- a/apps/flex-cli/src/commands/import.ts
+++ b/apps/flex-cli/src/commands/import.ts
@@ -23,6 +23,15 @@ export async function runImport(): Promise<void> {
   if (customerDirs.length === 0) {
     // 레거시(법인 분리 전) 구조 폴백
     if (hasCrawlArtifacts(config.outputDir)) {
+      // FLEX_CUSTOMERS 필터가 있는데 법인 구조 자체가 없으면 사용자 의도와 어긋남 — 중단
+      if (config.customers.length > 0) {
+        logger.error(
+          "FLEX_CUSTOMERS가 지정됐지만 outputDir이 법인별로 분리되어 있지 않습니다. " +
+            "크롤을 먼저 실행해 법인별 디렉토리를 생성하거나, 필터를 제거해 주세요.",
+          { customers: config.customers, outputDir: config.outputDir },
+        );
+        process.exit(1);
+      }
       await importOne(config.outputDir, config.outputDir, logger);
       return;
     }

--- a/apps/flex-cli/src/commands/import.ts
+++ b/apps/flex-cli/src/commands/import.ts
@@ -1,7 +1,9 @@
-import { loadConfig, type Config } from "../config/index.js";
-import { createLogger } from "../logger/index.js";
-import { importToSqlite } from "../db/import.js";
+import { existsSync } from "node:fs";
+import { readdir } from "node:fs/promises";
 import path from "node:path";
+import { loadConfig, type Config } from "../config/index.js";
+import { createLogger, type Logger } from "../logger/index.js";
+import { importToSqlite } from "../db/import.js";
 
 export async function runImport(): Promise<void> {
   const logger = createLogger("IMPORT");
@@ -16,12 +18,68 @@ export async function runImport(): Promise<void> {
     process.exit(1);
   }
 
-  const dbPath = path.resolve(config.outputDir, "flex-ax.db");
-  logger.info(`${config.outputDir}/ → ${dbPath}`);
+  const customerDirs = await discoverCustomerDirs(config.outputDir);
 
-  const result = await importToSqlite(config.outputDir, dbPath, logger);
+  if (customerDirs.length === 0) {
+    // 레거시(법인 분리 전) 구조 폴백
+    if (hasCrawlArtifacts(config.outputDir)) {
+      await importOne(config.outputDir, config.outputDir, logger);
+      return;
+    }
+    logger.error("임포트할 데이터가 없습니다", { outputDir: config.outputDir });
+    process.exit(1);
+  }
+
+  // customers 필터가 있으면 해당 법인만
+  const targets =
+    config.customers.length > 0
+      ? customerDirs.filter((d) => config.customers.includes(path.basename(d)))
+      : customerDirs;
+
+  if (targets.length === 0) {
+    logger.error("요청한 법인에 해당하는 데이터가 없습니다", { customers: config.customers });
+    process.exit(1);
+  }
+
+  logger.info("법인별 임포트 시작", { count: targets.length });
+
+  for (const dir of targets) {
+    await importOne(dir, dir, logger);
+  }
+}
+
+async function importOne(sourceDir: string, dbDir: string, logger: Logger): Promise<void> {
+  const dbPath = path.resolve(dbDir, "flex-ax.db");
+  logger.info(`${sourceDir}/ → ${dbPath}`);
+
+  const result = await importToSqlite(sourceDir, dbPath, logger);
 
   console.log(`[FLEX-AX:IMPORT] 임포트 완료: ${dbPath}`);
   console.log(`[FLEX-AX:IMPORT] templates=${result.templates}, instances=${result.instances}, attendance=${result.attendance}`);
   console.log(`[FLEX-AX:IMPORT] users=${result.users}, fields=${result.fieldValues}, approvals=${result.approvalLines}, comments=${result.comments}, attachments=${result.attachments}`);
+}
+
+/**
+ * outputDir 바로 아래에서 크롤 아티팩트(templates/ 등)를 가진 하위 디렉토리를 찾는다.
+ * 각 하위 디렉토리는 하나의 법인(customerIdHash)에 해당한다.
+ */
+async function discoverCustomerDirs(outputDir: string): Promise<string[]> {
+  if (!existsSync(outputDir)) return [];
+  const entries = await readdir(outputDir, { withFileTypes: true });
+  const dirs: string[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const full = path.join(outputDir, entry.name);
+    if (hasCrawlArtifacts(full)) dirs.push(full);
+  }
+  return dirs;
+}
+
+function hasCrawlArtifacts(dir: string): boolean {
+  return (
+    existsSync(path.join(dir, "templates")) ||
+    existsSync(path.join(dir, "instances")) ||
+    existsSync(path.join(dir, "attendance")) ||
+    existsSync(path.join(dir, "endpoints"))
+  );
 }

--- a/apps/flex-cli/src/commands/import.ts
+++ b/apps/flex-cli/src/commands/import.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { existsSync, type Dirent } from "node:fs";
 import { readdir } from "node:fs/promises";
 import path from "node:path";
 import { loadConfig, type Config } from "../config/index.js";
@@ -18,7 +18,7 @@ export async function runImport(): Promise<void> {
     process.exit(1);
   }
 
-  const customerDirs = await discoverCustomerDirs(config.outputDir);
+  const customerDirs = await discoverCustomerDirs(config.outputDir, logger);
 
   if (customerDirs.length === 0) {
     // 레거시(법인 분리 전) 구조 폴백
@@ -62,10 +62,25 @@ async function importOne(sourceDir: string, dbDir: string, logger: Logger): Prom
 /**
  * outputDir 바로 아래에서 크롤 아티팩트(templates/ 등)를 가진 하위 디렉토리를 찾는다.
  * 각 하위 디렉토리는 하나의 법인(customerIdHash)에 해당한다.
+ *
+ * 경로가 존재하지 않거나 읽기에 실패하면 빈 배열을 반환한다 — 호출부가
+ * "법인 분리 없음"으로 간주해 레거시 단일 구조 폴백으로 이어갈 수 있게 한다.
  */
-async function discoverCustomerDirs(outputDir: string): Promise<string[]> {
+async function discoverCustomerDirs(
+  outputDir: string,
+  logger: Logger,
+): Promise<string[]> {
   if (!existsSync(outputDir)) return [];
-  const entries = await readdir(outputDir, { withFileTypes: true });
+  let entries: Dirent[];
+  try {
+    entries = await readdir(outputDir, { withFileTypes: true });
+  } catch (error) {
+    logger.warn("output 디렉토리 스캔 실패 — 단일 구조로 폴백합니다", {
+      outputDir,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return [];
+  }
   const dirs: string[] = [];
   for (const entry of entries) {
     if (!entry.isDirectory()) continue;

--- a/apps/flex-cli/src/commands/import.ts
+++ b/apps/flex-cli/src/commands/import.ts
@@ -21,14 +21,24 @@ export async function runImport(): Promise<void> {
   const customerDirs = await discoverCustomerDirs(config.outputDir, logger);
 
   if (customerDirs.length === 0) {
-    // 레거시(법인 분리 전) 구조 폴백
+    // outputDir 자체에 크롤 아티팩트가 있는 경우: (a) 레거시 단일 구조 또는
+    // (b) outputDir이 이미 특정 법인 디렉토리(output/<customerIdHash>)를 직접 가리키는 경우
     if (hasCrawlArtifacts(config.outputDir)) {
-      // FLEX_CUSTOMERS 필터가 있는데 법인 구조 자체가 없으면 사용자 의도와 어긋남 — 중단
       if (config.customers.length > 0) {
+        const dirBasename = path.basename(path.resolve(config.outputDir));
+        // outputDir의 basename이 요청한 법인과 일치하면 그대로 임포트 (케이스 b)
+        if (config.customers.includes(dirBasename)) {
+          logger.info("outputDir이 특정 법인 디렉토리를 가리킴 — 단일 법인 임포트", {
+            customerIdHash: dirBasename,
+          });
+          await importOne(config.outputDir, config.outputDir, logger);
+          return;
+        }
+        // 그 외엔 필터와 데이터가 어긋남 — 중단
         logger.error(
-          "FLEX_CUSTOMERS가 지정됐지만 outputDir이 법인별로 분리되어 있지 않습니다. " +
-            "크롤을 먼저 실행해 법인별 디렉토리를 생성하거나, 필터를 제거해 주세요.",
-          { customers: config.customers, outputDir: config.outputDir },
+          "FLEX_CUSTOMERS가 지정됐지만 outputDir이 해당 법인 디렉토리가 아니고 " +
+            "법인별로 분리되어 있지도 않습니다. 크롤을 먼저 실행하거나, 필터를 제거해 주세요.",
+          { customers: config.customers, outputDir: config.outputDir, basename: dirBasename },
         );
         process.exit(1);
       }

--- a/apps/flex-cli/src/config/index.ts
+++ b/apps/flex-cli/src/config/index.ts
@@ -35,6 +35,19 @@ const configSchema = z
           .map((s) => s.trim())
           .filter((s) => s.length > 0),
       ),
+    /**
+     * 크롤링할 법인(customerIdHash) 목록. 콤마 구분.
+     * 비어있으면 사용자가 속한 모든 법인을 대상으로 한다.
+     */
+    customers: z
+      .string()
+      .default("")
+      .transform((v) =>
+        v
+          .split(",")
+          .map((s) => s.trim())
+          .filter((s) => s.length > 0),
+      ),
   });
 
 export type Config = z.infer<typeof configSchema>;
@@ -54,5 +67,6 @@ export function loadConfig(): Config {
     headless: process.env.HEADLESS || undefined,
     crawlSensitive: process.env.FLEX_CRAWL_SENSITIVE || undefined,
     skipEndpoints: process.env.FLEX_SKIP_ENDPOINTS || undefined,
+    customers: process.env.FLEX_CUSTOMERS || undefined,
   });
 }


### PR DESCRIPTION
## Summary
- 워크스페이스 내 여러 법인(customer)을 자동 enumerate하고 각 법인별 JWT로 크롤링
- `output/{customerIdHash}/` 로 분리 저장, 법인별 `flex-ax.db` 생성
- `FLEX_CUSTOMERS` 환경변수로 대상 법인 필터링 가능 (미지정 시 전체)

## Background
flex.team 워크스페이스 하나에 여러 법인이 묶일 수 있다 (예: 플라네타리움랩스코리아 / (주)디랩스 / (주)버스에잇코리아). 기존 크롤러는 로그인된 단일 법인 컨텍스트로만 동작했는데, 브라우저 네트워크를 분석해 공식 API를 발견했다:

| API | 용도 |
|---|---|
| `GET /api/v2/core/users/me/workspace-users-corp-group-affiliates` | 법인 목록 (customerIdHash, userIdHash per corp) |
| `POST /api-public/v2/auth/tokens/customer-user/exchange` | `V2_WS_AID` 쿠키를 `flexteam-v2-workspace-access` 헤더로 전달 → 법인 스코프 JWT 획득 |

## Changes
- **auth**: `listCorporations`, `switchCustomer` 추가. 헤더 캡처 화이트리스트에 `x-flex-aid`, `x-flex-axios` 포함
- **crawl**: 법인별 루프 + `output/{customerIdHash}/` 분리
- **import**: `output/` 하위 법인 디렉토리 자동 탐색 → 법인별 DB. 레거시(단일) 구조 폴백 유지
- **config**: `FLEX_CUSTOMERS` 환경변수 (콤마 구분)

## Test plan
- [x] `tsc --noEmit` 클린
- [x] 3개 법인 엔드투엔드 실행 검증 (플라네타리움 / 디랩스 / 버스에잇코리아)
  - 크롤 성공/실패: 0건 실패
  - 법인별 `flex-ax.db` 생성 확인
  - 플라네타리움: templates=31, instances=20, attendance=18, users=12
- [x] FK 무결성 체크 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)