### PR TITLE
[codex] Improve flex-cli export query paths and crawl logging

### DIFF
--- a/apps/flex-cli/package.json
+++ b/apps/flex-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flex-ax",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "description": "flex HR SaaS AX CLI - discover, crawl, and manage flex data",

--- a/apps/flex-cli/src/commands/file.ts
+++ b/apps/flex-cli/src/commands/file.ts
@@ -1,6 +1,7 @@
 import Database from "better-sqlite3";
 import { createReadStream } from "node:fs";
 import { loadConfig } from "../config/index.js";
+import { resolveFlexDataDir } from "../paths/index.js";
 import path from "node:path";
 
 export async function runFile(): Promise<void> {
@@ -22,7 +23,14 @@ export async function runFile(): Promise<void> {
     console.error(`[FLEX-AX:ERROR] 설정 로딩 실패: ${error instanceof Error ? error.message : String(error)}`);
     process.exit(1);
   }
-  const dbPath = path.resolve(config.outputDir, "flex-ax.db");
+  let resolved: ReturnType<typeof resolveFlexDataDir>;
+  try {
+    resolved = resolveFlexDataDir(config.outputDir);
+  } catch (error) {
+    console.error(`[FLEX-AX:ERROR] ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  }
+  const dbPath = path.resolve(resolved.resolvedPath, "flex-ax.db");
 
   let db: InstanceType<typeof Database>;
   try {

--- a/apps/flex-cli/src/commands/import.ts
+++ b/apps/flex-cli/src/commands/import.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { loadConfig, type Config } from "../config/index.js";
 import { createLogger, type Logger } from "../logger/index.js";
 import { importToSqlite } from "../db/import.js";
+import { resolveFlexDataDir } from "../paths/index.js";
 
 export async function runImport(): Promise<void> {
   const logger = createLogger("IMPORT");
@@ -21,35 +22,39 @@ export async function runImport(): Promise<void> {
   const customerDirs = await discoverCustomerDirs(config.outputDir, logger);
 
   if (customerDirs.length === 0) {
-    // outputDir 자체에 크롤 아티팩트가 있는 경우: (a) 레거시 단일 구조 또는
-    // (b) outputDir이 이미 특정 법인 디렉토리(output/<customerIdHash>)를 직접 가리키는 경우
     if (hasCrawlArtifacts(config.outputDir)) {
+      let resolved: ReturnType<typeof resolveFlexDataDir>;
+      try {
+        resolved = resolveFlexDataDir(config.outputDir);
+      } catch (error) {
+        logger.error(error instanceof Error ? error.message : String(error));
+        process.exit(1);
+      }
+
       if (config.customers.length > 0) {
-        const dirBasename = path.basename(path.resolve(config.outputDir));
-        // outputDir의 basename이 요청한 법인과 일치하면 그대로 임포트 (케이스 b)
+        const dirBasename = path.basename(resolved.resolvedPath);
         if (config.customers.includes(dirBasename)) {
           logger.info("outputDir이 특정 법인 디렉토리를 가리킴 — 단일 법인 임포트", {
             customerIdHash: dirBasename,
           });
-          await importOne(config.outputDir, config.outputDir, logger);
+          await importOne(resolved.resolvedPath, resolved.resolvedPath, logger);
           return;
         }
-        // 그 외엔 필터와 데이터가 어긋남 — 중단
         logger.error(
-          "FLEX_CUSTOMERS가 지정됐지만 outputDir이 해당 법인 디렉토리가 아니고 " +
-            "법인별로 분리되어 있지도 않습니다. 크롤을 먼저 실행하거나, 필터를 제거해 주세요.",
-          { customers: config.customers, outputDir: config.outputDir, basename: dirBasename },
+          "FLEX_CUSTOMERS가 지정됐지만 outputDir이 해당 법인 디렉토리가 아닙니다.",
+          { customers: config.customers, outputDir: resolved.resolvedPath, basename: dirBasename },
         );
         process.exit(1);
       }
-      await importOne(config.outputDir, config.outputDir, logger);
+
+      await importOne(resolved.resolvedPath, resolved.resolvedPath, logger);
       return;
     }
+
     logger.error("임포트할 데이터가 없습니다", { outputDir: config.outputDir });
     process.exit(1);
   }
 
-  // customers 필터가 있으면 해당 법인만
   const targets =
     config.customers.length > 0
       ? customerDirs.filter((d) => config.customers.includes(path.basename(d)))
@@ -78,13 +83,6 @@ async function importOne(sourceDir: string, dbDir: string, logger: Logger): Prom
   console.log(`[FLEX-AX:IMPORT] users=${result.users}, fields=${result.fieldValues}, approvals=${result.approvalLines}, comments=${result.comments}, attachments=${result.attachments}`);
 }
 
-/**
- * outputDir 바로 아래에서 크롤 아티팩트(templates/ 등)를 가진 하위 디렉토리를 찾는다.
- * 각 하위 디렉토리는 하나의 법인(customerIdHash)에 해당한다.
- *
- * 경로가 존재하지 않거나 읽기에 실패하면 빈 배열을 반환한다 — 호출부가
- * "법인 분리 없음"으로 간주해 레거시 단일 구조 폴백으로 이어갈 수 있게 한다.
- */
 async function discoverCustomerDirs(
   outputDir: string,
   logger: Logger,

--- a/apps/flex-cli/src/commands/query.ts
+++ b/apps/flex-cli/src/commands/query.ts
@@ -1,5 +1,6 @@
 import Database from "better-sqlite3";
 import { loadConfig } from "../config/index.js";
+import { resolveFlexDataDir } from "../paths/index.js";
 import path from "node:path";
 import { readFileSync } from "node:fs";
 
@@ -118,7 +119,14 @@ SQL을 실행하고 결과를 JSON으로 출력합니다 (read-only).
     console.error(`[FLEX-AX:ERROR] 설정 로딩 실패: ${error instanceof Error ? error.message : String(error)}`);
     process.exit(1);
   }
-  const dbPath = path.resolve(config.outputDir, "flex-ax.db");
+  let resolved: ReturnType<typeof resolveFlexDataDir>;
+  try {
+    resolved = resolveFlexDataDir(config.outputDir);
+  } catch (error) {
+    console.error(`[FLEX-AX:ERROR] ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  }
+  const dbPath = path.resolve(resolved.resolvedPath, "flex-ax.db");
 
   let db: InstanceType<typeof Database>;
   try {

--- a/apps/flex-cli/src/crawlers/instance.ts
+++ b/apps/flex-cli/src/crawlers/instance.ts
@@ -63,9 +63,19 @@ export async function crawlInstances(
       );
 
       const docs = page.documents ?? [];
+      const firstDocKey = docs[0]?.document.documentKey ?? null;
+      const lastDocKeyInPage = docs[docs.length - 1]?.document.documentKey ?? null;
       if (result.totalCount === 0) {
         logger.info(`총 ${page.total}건의 문서 발견`);
       }
+      logger.info("인스턴스 페이지 수신", {
+        total: page.total,
+        hasNext: page.hasNext,
+        docsInPage: docs.length,
+        requestLastDocumentKey: lastDocumentKey ?? null,
+        firstDocumentKey: firstDocKey,
+        lastDocumentKeyInPage: lastDocKeyInPage,
+      });
 
       let newInPage = 0;
       for (const doc of docs) {
@@ -120,6 +130,15 @@ export async function crawlInstances(
 
         await delay(config.requestDelayMs);
       }
+
+      logger.info("인스턴스 페이지 처리 완료", {
+        totalCollected: result.totalCount,
+        successCount: result.successCount,
+        failureCount: result.failureCount,
+        newInPage,
+        hasNext: page.hasNext,
+        nextLastDocumentKeyCandidate: lastDocKeyInPage,
+      });
 
       // 이 페이지에 새 문서가 없으면 커서가 전진 안 하는 것 → 종료
       if (newInPage === 0) {

--- a/apps/flex-cli/src/logger/index.ts
+++ b/apps/flex-cli/src/logger/index.ts
@@ -1,3 +1,6 @@
+import { appendFileSync, mkdirSync } from "node:fs";
+import path from "node:path";
+
 export interface Logger {
   info(message: string, meta?: Record<string, unknown>): void;
   warn(message: string, meta?: Record<string, unknown>): void;
@@ -28,22 +31,40 @@ function formatMeta(meta?: Record<string, unknown>): string {
   return " " + JSON.stringify(sanitize(meta));
 }
 
+function resolveLogFilePath(): string {
+  return path.resolve(process.env.FLEX_AX_LOG_FILE || "./output/flex-ax.log");
+}
+
+function writeLogLine(line: string): void {
+  const logFilePath = resolveLogFilePath();
+  mkdirSync(path.dirname(logFilePath), { recursive: true });
+  appendFileSync(logFilePath, `${line}\n`, "utf-8");
+}
+
 export function createLogger(prefix?: string): Logger {
   const tag = prefix ? `[FLEX-AX:${prefix}]` : "";
 
   return {
     info(message, meta) {
-      console.log(`[${timestamp()}] INFO  ${tag} ${message}${formatMeta(meta)}`);
+      const line = `[${timestamp()}] INFO  ${tag} ${message}${formatMeta(meta)}`;
+      console.log(line);
+      writeLogLine(line);
     },
     warn(message, meta) {
-      console.warn(`[${timestamp()}] WARN  ${tag} ${message}${formatMeta(meta)}`);
+      const line = `[${timestamp()}] WARN  ${tag} ${message}${formatMeta(meta)}`;
+      console.warn(line);
+      writeLogLine(line);
     },
     error(message, meta) {
-      console.error(`[${timestamp()}] ERROR ${tag} ${message}${formatMeta(meta)}`);
+      const line = `[${timestamp()}] ERROR ${tag} ${message}${formatMeta(meta)}`;
+      console.error(line);
+      writeLogLine(line);
     },
     progress(phase, current, total) {
       const totalStr = total != null ? `/${total}` : "";
-      process.stdout.write(`\r[${timestamp()}] ${phase}: ${current}${totalStr}`);
+      const line = `[${timestamp()}] ${phase}: ${current}${totalStr}`;
+      process.stdout.write(`\r${line}`);
+      writeLogLine(line);
     },
   };
 }

--- a/apps/flex-cli/src/paths/index.ts
+++ b/apps/flex-cli/src/paths/index.ts
@@ -1,0 +1,74 @@
+import { existsSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+
+export interface ResolvedFlexDataDir {
+  requestedPath: string;
+  resolvedPath: string;
+}
+
+export function resolveFlexDataDir(inputPath: string): ResolvedFlexDataDir {
+  const requestedPath = path.resolve(inputPath);
+
+  if (isExportDir(requestedPath)) {
+    return {
+      requestedPath,
+      resolvedPath: requestedPath,
+    };
+  }
+
+  const candidates = listExportDirs(path.join(requestedPath, "output"));
+  if (candidates.length > 0) {
+    throw new Error(buildAmbiguousPathMessage(requestedPath, candidates));
+  }
+
+  throw new Error(
+    `유효한 export 디렉터리가 아닙니다: ${requestedPath}\n` +
+    `예시: OUTPUT_DIR=flex-export/output/<export-id>`,
+  );
+}
+
+function buildAmbiguousPathMessage(requestedPath: string, candidates: string[]): string {
+  const formatted = candidates.map((candidate) => `  - ${candidate}`).join("\n");
+  return (
+    `export 디렉터리를 명시적으로 지정해 주세요: ${requestedPath}\n` +
+    `다음 중 하나를 OUTPUT_DIR로 지정하면 됩니다:\n${formatted}`
+  );
+}
+
+function listExportDirs(basePath: string): string[] {
+  let entries: string[];
+  try {
+    entries = readdirSync(basePath);
+  } catch {
+    return [];
+  }
+
+  const candidates: string[] = [];
+  for (const entry of entries) {
+    const fullPath = path.join(basePath, entry);
+    try {
+      if (!statSync(fullPath).isDirectory()) {
+        continue;
+      }
+    } catch {
+      continue;
+    }
+
+    if (isExportDir(fullPath)) {
+      candidates.push(fullPath);
+    }
+  }
+
+  return candidates.sort((a, b) => a.localeCompare(b));
+}
+
+function isExportDir(dirPath: string): boolean {
+  const hasDb = existsSync(path.join(dirPath, "flex-ax.db"));
+  const hasReport = existsSync(path.join(dirPath, "crawl-report.json"));
+  const hasJsonDirs =
+    existsSync(path.join(dirPath, "templates")) ||
+    existsSync(path.join(dirPath, "instances")) ||
+    existsSync(path.join(dirPath, "attendance"));
+
+  return hasDb || hasReport || hasJsonDirs;
+}


### PR DESCRIPTION
## What changed
- require `OUTPUT_DIR` to point to a specific export directory and surface valid export candidates when a parent path is given
- allow `import`, `query`, and `file` to resolve and validate export directories consistently
- preserve the multi-corporation import flow from `main` while validating direct export-directory imports explicitly
- add per-page instance crawl diagnostics for `total`, `hasNext`, request cursor, first/last document keys, and `newInPage`
- write logger output to a file in addition to stdout, defaulting to `./output/flex-ax.log`
- bump `apps/flex-cli` version from `0.5.0` to `0.5.1`

## Why
We needed better observability to determine whether approval-document crawling is failing to advance pagination, while also making export querying safer and more explicit after rebasing onto the latest `main`.

## Impact
- operators can re-run `crawl` and inspect `output/flex-ax.log` for page-by-page pagination behavior
- `flex-ax query`, `import`, and `file` now fail fast with explicit export directory guidance instead of silently choosing an export
- import still supports the corporation-split layout already present on `main`
- version metadata reflects the CLI behavior change on top of `flex-cli@0.5.0`

## Root cause
The crawl flow did not emit enough pagination state to distinguish user-scope limitations from cursor/pagination failures, and export querying was previously ambiguous when pointed at a parent folder.

## Validation
- `pnpm --filter flex-ax lint`
- local query validation against export DBs during development