### PR TITLE
[codex] Fix flex-cli approval pagination handling

### DIFF
--- a/apps/flex-cli/package.json
+++ b/apps/flex-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flex-ax",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "description": "flex HR SaaS AX CLI - discover, crawl, and manage flex data",

--- a/apps/flex-cli/src/crawlers/attendance.ts
+++ b/apps/flex-cli/src/crawlers/attendance.ts
@@ -142,6 +142,7 @@ export async function crawlAttendanceApprovals(
           logger.warn("hasNext=true 이지만 continuationToken/nextCursor 없음 — 페이지네이션 종료");
           hasMore = false;
         } else {
+          await delay(config.requestDelayMs);
           pageNumber += 1;
         }
       } else {

--- a/apps/flex-cli/src/crawlers/attendance.ts
+++ b/apps/flex-cli/src/crawlers/attendance.ts
@@ -136,12 +136,21 @@ export async function crawlAttendanceApprovals(
       }
 
       if (data.hasNext) {
-        continuationToken = data.continuationToken;
-        nextCursor = data.nextCursor;
-        if (!continuationToken && !nextCursor) {
+        const nextContinuationToken = data.continuationToken ?? continuationToken;
+        const nextPageCursor = data.nextCursor ?? nextCursor;
+
+        if (!nextContinuationToken && !nextPageCursor) {
           logger.warn("hasNext=true 이지만 continuationToken/nextCursor 없음 — 페이지네이션 종료");
           hasMore = false;
+        } else if (
+          nextContinuationToken === continuationToken &&
+          nextPageCursor === nextCursor
+        ) {
+          logger.warn("attendance cursor 정체 — 페이지네이션 종료");
+          hasMore = false;
         } else {
+          continuationToken = nextContinuationToken;
+          nextCursor = nextPageCursor;
           await delay(config.requestDelayMs);
           pageNumber += 1;
         }

--- a/apps/flex-cli/src/crawlers/attendance.ts
+++ b/apps/flex-cli/src/crawlers/attendance.ts
@@ -59,65 +59,94 @@ export async function crawlAttendanceApprovals(
   const url = `${config.flexBaseUrl}/api/v2/time-off/users/${userId}/time-off-uses/by-use-date-range/${oneYearAgo}..${now}`;
 
   try {
-    const data = await withRetry(
-      () => flexFetch<TimeOffUsesResponse>(authCtx, url),
-      { maxRetries: config.maxRetries, delayMs: config.requestDelayMs },
-    );
+    let continuationToken: string | undefined;
+    let nextCursor: string | undefined;
+    let pageNumber = 1;
+    let hasMore = true;
 
-    const uses = data.timeOffUses ?? [];
-    logger.info(`휴가 사용 내역: ${uses.length}건 발견`);
+    while (hasMore) {
+      const pageUrl = buildTimeOffUsesUrl(url, continuationToken, nextCursor);
+      const data = await withRetry(
+        () => flexFetch<TimeOffUsesResponse>(authCtx, pageUrl),
+        { maxRetries: config.maxRetries, delayMs: config.requestDelayMs },
+      );
 
-    for (const use of uses) {
-      const id = use.userTimeOffRegisterEventId;
-      if (!id) continue;
+      const uses = data.timeOffUses ?? [];
+      logger.info("휴가 사용 내역 페이지 수신", {
+        page: pageNumber,
+        usesInPage: uses.length,
+        hasNext: data.hasNext ?? false,
+        requestContinuationToken: continuationToken ?? null,
+        requestNextCursor: nextCursor ?? null,
+        nextContinuationToken: data.continuationToken ?? null,
+        nextCursor: data.nextCursor ?? null,
+      });
 
-      if (collectedInstanceKeys.has(id)) {
-        logger.info(`중복 스킵: ${id} (인스턴스에서 이미 수집)`);
-        continue;
+      for (const use of uses) {
+        const id = use.userTimeOffRegisterEventId;
+        if (!id) continue;
+
+        if (collectedInstanceKeys.has(id)) {
+          logger.info(`중복 스킵: ${id} (인스턴스에서 이미 수집)`);
+          continue;
+        }
+
+        result.totalCount++;
+
+        try {
+          const approval: AttendanceApproval = {
+            id,
+            type: use.timeOffPolicyType ?? "TIME_OFF",
+            applicant: {
+              id: use.userIdHash,
+              // 이름은 이 엔드포인트에서 제공되지 않으므로 비워둔다.
+              // import 단계의 upsertUser가 placeholder로 등록하고,
+              // 다른 엔드포인트에서 실제 이름이 들어오면 자동 갱신한다.
+              name: "",
+            },
+            appliedAt: use.timeOffRegisterDateFrom ?? "",
+            details: {
+              dateFrom: use.timeOffRegisterDateFrom,
+              dateTo: use.timeOffRegisterDateTo,
+              days: use.useTime?.timeOffDays,
+              minutes: use.useTime?.timeOffMinutes,
+              policyType: use.timeOffPolicyType,
+              canceled: use.canceled,
+            },
+            status: mapStatus(use.timeOffUseStatus, use.approvalStatus?.status),
+            processedAt: use.timeOffRegisteredAt
+              ? new Date(use.timeOffRegisteredAt).toISOString()
+              : undefined,
+            _raw: use,
+          };
+
+          await storage.saveAttendanceApproval(approval);
+          result.successCount++;
+        } catch (error) {
+          result.failureCount++;
+          result.errors.push({
+            target: `attendance:${id}`,
+            phase: "detail",
+            message: error instanceof Error ? error.message : String(error),
+            timestamp: nowISO(),
+          });
+        }
+
+        await delay(config.requestDelayMs);
       }
 
-      result.totalCount++;
-
-      try {
-        const approval: AttendanceApproval = {
-          id,
-          type: use.timeOffPolicyType ?? "TIME_OFF",
-          applicant: {
-            id: use.userIdHash,
-            // 이름은 이 엔드포인트에서 제공되지 않으므로 비워둔다.
-            // import 단계의 upsertUser가 placeholder로 등록하고,
-            // 다른 엔드포인트에서 실제 이름이 들어오면 자동 갱신한다.
-            name: "",
-          },
-          appliedAt: use.timeOffRegisterDateFrom ?? "",
-          details: {
-            dateFrom: use.timeOffRegisterDateFrom,
-            dateTo: use.timeOffRegisterDateTo,
-            days: use.useTime?.timeOffDays,
-            minutes: use.useTime?.timeOffMinutes,
-            policyType: use.timeOffPolicyType,
-            canceled: use.canceled,
-          },
-          status: mapStatus(use.timeOffUseStatus, use.approvalStatus?.status),
-          processedAt: use.timeOffRegisteredAt
-            ? new Date(use.timeOffRegisteredAt).toISOString()
-            : undefined,
-          _raw: use,
-        };
-
-        await storage.saveAttendanceApproval(approval);
-        result.successCount++;
-      } catch (error) {
-        result.failureCount++;
-        result.errors.push({
-          target: `attendance:${id}`,
-          phase: "detail",
-          message: error instanceof Error ? error.message : String(error),
-          timestamp: nowISO(),
-        });
+      if (data.hasNext) {
+        continuationToken = data.continuationToken;
+        nextCursor = data.nextCursor;
+        if (!continuationToken && !nextCursor) {
+          logger.warn("hasNext=true 이지만 continuationToken/nextCursor 없음 — 페이지네이션 종료");
+          hasMore = false;
+        } else {
+          pageNumber += 1;
+        }
+      } else {
+        hasMore = false;
       }
-
-      await delay(config.requestDelayMs);
     }
   } catch (error) {
     logger.warn("휴가 사용 내역 수집 실패", {
@@ -199,6 +228,15 @@ interface TimeOffUsesResponse {
     canceled?: boolean;
   }>;
   hasNext?: boolean;
+  continuationToken?: string;
+  nextCursor?: string;
+}
+
+function buildTimeOffUsesUrl(baseUrl: string, continuationToken?: string, nextCursor?: string): string {
+  const url = new URL(baseUrl);
+  if (continuationToken) url.searchParams.set("continuationToken", continuationToken);
+  if (nextCursor) url.searchParams.set("nextCursor", nextCursor);
+  return url.toString();
 }
 
 function mapStatus(useStatus?: string, approvalStatus?: string): string {

--- a/apps/flex-cli/src/crawlers/instance.ts
+++ b/apps/flex-cli/src/crawlers/instance.ts
@@ -33,123 +33,29 @@ export async function crawlInstances(
     config.flexBaseUrl, catalog, "instance-search",
     "/action/v3/approval-document/user-boxes/search",
   );
+  const detailBase = resolveUrl(
+    config.flexBaseUrl, catalog, "instance-detail",
+    "/api/v3/approval-document/approval-documents",
+  );
 
   try {
-    const statuses = ["IN_PROGRESS", "DONE", "DECLINED", "CANCELED"];
-    let lastDocumentKey: string | undefined;
-    let hasMore = true;
+    const searchGroups: SearchGroup[] = [
+      { label: "in-progress", statuses: ["IN_PROGRESS"] },
+      { label: "done", statuses: ["DONE", "DECLINED", "CANCELED"] },
+    ];
 
-    while (hasMore) {
-      const searchBody = {
-        filter: {
-          statuses,
-          templateKeys: [],
-          writerHashedIds: [],
-          approverTargets: [],
-          referrerTargets: [],
-          starred: false,
-        },
-        search: { keyword: "", type: "ALL" },
-        ...(lastDocumentKey ? { lastDocumentKey } : {}),
-      };
-
-      const page = await withRetry(
-        () => flexPost<SearchResponse>(
-          authCtx,
-          `${searchUrl}?size=20&sortType=LAST_UPDATED_AT&direction=DESC`,
-          searchBody,
-        ),
-        { maxRetries: config.maxRetries, delayMs: config.requestDelayMs },
+    for (const group of searchGroups) {
+      await crawlSearchGroup(
+        authCtx,
+        config,
+        storage,
+        logger,
+        result,
+        collectedKeys,
+        searchUrl,
+        detailBase,
+        group,
       );
-
-      const docs = page.documents ?? [];
-      const firstDocKey = docs[0]?.document.documentKey ?? null;
-      const lastDocKeyInPage = docs[docs.length - 1]?.document.documentKey ?? null;
-      if (result.totalCount === 0) {
-        logger.info(`총 ${page.total}건의 문서 발견`);
-      }
-      logger.info("인스턴스 페이지 수신", {
-        total: page.total,
-        hasNext: page.hasNext,
-        docsInPage: docs.length,
-        requestLastDocumentKey: lastDocumentKey ?? null,
-        firstDocumentKey: firstDocKey,
-        lastDocumentKeyInPage: lastDocKeyInPage,
-      });
-
-      let newInPage = 0;
-      for (const doc of docs) {
-        const docKey = doc.document.documentKey;
-
-        // 중복 스킵
-        if (collectedKeys.has(docKey)) {
-          continue;
-        }
-
-        result.totalCount++;
-        newInPage++;
-
-        try {
-          logger.progress("인스턴스 수집", result.successCount + result.failureCount + 1, page.total);
-
-          const detailBase = resolveUrl(
-            config.flexBaseUrl, catalog, "instance-detail",
-            "/api/v3/approval-document/approval-documents",
-          );
-          const hasPathParam = /\{[^}]+\}/.test(detailBase);
-          const detailUrl = hasPathParam
-            ? detailBase.replace(/\{[^}]+\}/, docKey)
-            : `${detailBase}/${docKey}`;
-
-          const detail = await withRetry(
-            () => flexFetch<DocumentDetailResponse>(authCtx, detailUrl),
-            { maxRetries: config.maxRetries, delayMs: config.requestDelayMs },
-          );
-
-          const attachments = await processAttachments(
-            authCtx, config, docKey, detail.document.attachments ?? [], storage, logger,
-          );
-
-          const instance = mapInstance(detail, attachments);
-          await storage.saveInstance(instance);
-          collectedKeys.add(docKey);
-          result.successCount++;
-        } catch (error) {
-          collectedKeys.add(docKey); // 실패해도 재시도 방지
-          result.failureCount++;
-          result.errors.push({
-            target: `instance:${docKey}`,
-            phase: "detail",
-            message: error instanceof Error ? error.message : String(error),
-            timestamp: nowISO(),
-          });
-          logger.error(`인스턴스 수집 실패: ${docKey}`, {
-            error: error instanceof Error ? error.message : String(error),
-          });
-        }
-
-        await delay(config.requestDelayMs);
-      }
-
-      logger.info("인스턴스 페이지 처리 완료", {
-        totalCollected: result.totalCount,
-        successCount: result.successCount,
-        failureCount: result.failureCount,
-        newInPage,
-        hasNext: page.hasNext,
-        nextLastDocumentKeyCandidate: lastDocKeyInPage,
-      });
-
-      // 이 페이지에 새 문서가 없으면 커서가 전진 안 하는 것 → 종료
-      if (newInPage === 0) {
-        logger.warn("새 문서 없음 — 페이지네이션 종료");
-        hasMore = false;
-      } else {
-        hasMore = page.hasNext && docs.length > 0;
-        if (hasMore) {
-          lastDocumentKey = docs[docs.length - 1].document.documentKey;
-        }
-      }
     }
   } catch (error) {
     logger.error("인스턴스 목록 수집 중 치명적 오류", {
@@ -168,11 +74,163 @@ export async function crawlInstances(
   return { ...result, collectedKeys };
 }
 
+interface SearchGroup {
+  label: string;
+  statuses: string[];
+}
+
+async function crawlSearchGroup(
+  authCtx: AuthContext,
+  config: Config,
+  storage: StorageWriter,
+  logger: Logger,
+  result: CrawlResult,
+  collectedKeys: Set<string>,
+  searchUrl: string,
+  detailBase: string,
+  group: SearchGroup,
+): Promise<void> {
+  logger.info("인스턴스 검색 그룹 시작", {
+    group: group.label,
+    statuses: group.statuses,
+  });
+
+  let continuationToken: string | undefined;
+  let hasMore = true;
+  let isFirstPage = true;
+
+  while (hasMore) {
+    const searchBody = {
+      filter: {
+        statuses: group.statuses,
+        templateKeys: [],
+        writerHashedIds: [],
+        approverTargets: [],
+        referrerTargets: [],
+        starred: false,
+      },
+      search: { keyword: "", type: "ALL" },
+    };
+
+    const searchParams = new URLSearchParams({
+      size: "20",
+      sortType: "LAST_UPDATED_AT",
+      direction: "DESC",
+    });
+    if (continuationToken) {
+      searchParams.set("continuationToken", continuationToken);
+    }
+
+    const page = await withRetry(
+      () => flexPost<SearchResponse>(
+        authCtx,
+        `${searchUrl}?${searchParams.toString()}`,
+        searchBody,
+      ),
+      { maxRetries: config.maxRetries, delayMs: config.requestDelayMs },
+    );
+
+    const docs = page.documents ?? [];
+    const firstDocKey = docs[0]?.document.documentKey ?? null;
+    const lastDocKeyInPage = docs[docs.length - 1]?.document.documentKey ?? null;
+    if (isFirstPage) {
+      logger.info(`인스턴스 그룹 ${group.label}: 총 ${page.total}건의 문서 발견`);
+      isFirstPage = false;
+    }
+    logger.info("인스턴스 페이지 수신", {
+      group: group.label,
+      statuses: group.statuses,
+      total: page.total,
+      hasNext: page.hasNext,
+      docsInPage: docs.length,
+      requestContinuationToken: continuationToken ?? null,
+      firstDocumentKey: firstDocKey,
+      lastDocumentKeyInPage: lastDocKeyInPage,
+      nextContinuationToken: page.continuationToken ?? null,
+    });
+
+    let newInPage = 0;
+    for (const doc of docs) {
+      const docKey = doc.document.documentKey;
+
+      if (collectedKeys.has(docKey)) {
+        continue;
+      }
+
+      result.totalCount++;
+      newInPage++;
+
+      try {
+        logger.progress("인스턴스 수집", result.successCount + result.failureCount + 1, page.total);
+
+        const hasPathParam = /\{[^}]+\}/.test(detailBase);
+        const detailUrl = hasPathParam
+          ? detailBase.replace(/\{[^}]+\}/, docKey)
+          : `${detailBase}/${docKey}`;
+
+        const detail = await withRetry(
+          () => flexFetch<DocumentDetailResponse>(authCtx, detailUrl),
+          { maxRetries: config.maxRetries, delayMs: config.requestDelayMs },
+        );
+
+        const attachments = await processAttachments(
+          authCtx, config, docKey, detail.document.attachments ?? [], storage, logger,
+        );
+
+        const instance = mapInstance(detail, attachments);
+        await storage.saveInstance(instance);
+        collectedKeys.add(docKey);
+        result.successCount++;
+      } catch (error) {
+        collectedKeys.add(docKey);
+        result.failureCount++;
+        result.errors.push({
+          target: `instance:${docKey}`,
+          phase: "detail",
+          message: error instanceof Error ? error.message : String(error),
+          timestamp: nowISO(),
+        });
+        logger.error(`인스턴스 수집 실패: ${docKey}`, {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+
+      await delay(config.requestDelayMs);
+    }
+
+    logger.info("인스턴스 페이지 처리 완료", {
+      group: group.label,
+      totalCollected: result.totalCount,
+      successCount: result.successCount,
+      failureCount: result.failureCount,
+      newInPage,
+      hasNext: page.hasNext,
+      nextLastDocumentKeyCandidate: lastDocKeyInPage,
+      nextContinuationTokenCandidate: page.continuationToken ?? null,
+    });
+
+    if (newInPage === 0) {
+      logger.warn("새 문서 없음 — 페이지네이션 종료", { group: group.label });
+      hasMore = false;
+    } else {
+      hasMore = page.hasNext && docs.length > 0;
+      if (hasMore) {
+        continuationToken = page.continuationToken;
+        if (!continuationToken) {
+          logger.warn("continuationToken 없음 — 페이지네이션 종료", { group: group.label });
+          hasMore = false;
+        }
+      }
+    }
+  }
+}
+
 // --- flex API 응답 타입 ---
 
 interface SearchResponse {
   hasNext: boolean;
   total: number;
+  continuationToken?: string;
   documents: Array<{
     document: {
       documentKey: string;

--- a/apps/flex-cli/src/crawlers/instance.ts
+++ b/apps/flex-cli/src/crawlers/instance.ts
@@ -205,23 +205,28 @@ async function crawlSearchGroup(
       failureCount: result.failureCount,
       newInPage,
       hasNext: page.hasNext,
-      nextLastDocumentKeyCandidate: lastDocKeyInPage,
       nextContinuationTokenCandidate: page.continuationToken ?? null,
     });
 
-    if (newInPage === 0) {
-      logger.warn("새 문서 없음 — 페이지네이션 종료", { group: group.label });
-      hasMore = false;
-    } else {
-      hasMore = page.hasNext && docs.length > 0;
-      if (hasMore) {
-        continuationToken = page.continuationToken;
-        if (!continuationToken) {
-          logger.warn("continuationToken 없음 — 페이지네이션 종료", { group: group.label });
-          hasMore = false;
-        }
-      }
+    hasMore = page.hasNext && docs.length > 0;
+    if (!hasMore) {
+      continue;
     }
+
+    const nextContinuationToken = page.continuationToken;
+    if (!nextContinuationToken) {
+      logger.warn("continuationToken 없음 — 페이지네이션 종료", { group: group.label });
+      hasMore = false;
+      continue;
+    }
+
+    if (nextContinuationToken === continuationToken) {
+      logger.warn("continuationToken 정체 — 페이지네이션 종료", { group: group.label });
+      hasMore = false;
+      continue;
+    }
+
+    continuationToken = nextContinuationToken;
   }
 }
 

--- a/apps/flex-cli/src/crawlers/instance.ts
+++ b/apps/flex-cli/src/crawlers/instance.ts
@@ -161,7 +161,7 @@ async function crawlSearchGroup(
       newInPage++;
 
       try {
-        logger.progress("인스턴스 수집", result.successCount + result.failureCount + 1, page.total);
+        logger.progress("인스턴스 수집", result.successCount + result.failureCount + 1);
 
         const hasPathParam = /\{[^}]+\}/.test(detailBase);
         const detailUrl = hasPathParam


### PR DESCRIPTION
## Summary
- bump flex-cli from 0.5.1 to 0.5.2 for this bugfix release
- align approval instance crawling with the actual flex UI request groups: in-progress and done
- switch approval document pagination from lastDocumentKey to the continuationToken used by flex
- add defensive pagination logging and cursor handling for time-off attendance crawling

## Verification
- pnpm --filter flex-ax lint
- captured live flex approval requests from 내 문서함 > 완료 and confirmed continuationToken pagination
- ran the patched crawler against 플라네타리움랩스코리아 (bYG0dkR8we) and verified instances=149 instead of stopping at 20