### PR TITLE
[codex] Fix flex-cli version command cwd handling

### DIFF
--- a/apps/flex-cli/package.json
+++ b/apps/flex-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flex-ax",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": true,
   "type": "module",
   "description": "flex HR SaaS AX CLI - discover, crawl, and manage flex data",

--- a/apps/flex-cli/src/cli.ts
+++ b/apps/flex-cli/src/cli.ts
@@ -1,4 +1,3 @@
-import "dotenv/config";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
@@ -26,6 +25,8 @@ if (command === "--version" || command === "-v") {
   console.log(`flex-ax ${pkg.version}`);
   process.exit(0);
 }
+
+await import("dotenv/config");
 
 switch (command) {
   case "discover": {


### PR DESCRIPTION
## Summary
- bump flex-cli from 0.5.2 to 0.5.3
- make flex-ax 0.5.2 return before loading dotenv so it does not depend on the current working directory

## Verification
- pnpm --filter flex-ax lint
- pnpm --filter flex-ax build
- npm pack --cache /tmp/npm-cache-flex-ax