### PR TITLE
feat(flex-cli): add startup auto-update with re-exec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 dist/
 .turbo/
+*.tsbuildinfo
 .env
 .env.*
 !.env.example

--- a/apps/flex-cli/package.json
+++ b/apps/flex-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flex-ax",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "description": "flex HR SaaS AX CLI - discover, crawl, and manage flex data",

--- a/apps/flex-cli/package.json
+++ b/apps/flex-cli/package.json
@@ -24,6 +24,7 @@
     "better-sqlite3": "^12.8.0",
     "dotenv": "^16.4.7",
     "playwright": "^1.50.1",
+    "semver": "^7.7.4",
     "zod": "^3.24.2"
   },
   "engines": {
@@ -32,6 +33,7 @@
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^22.13.5",
+    "@types/semver": "^7.7.1",
     "rimraf": "^6.0.1",
     "tsx": "^4.19.2",
     "typescript": "^5.7.3"

--- a/apps/flex-cli/src/auto-update.test.ts
+++ b/apps/flex-cli/src/auto-update.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   FAILURE_TTL_MS,
   SUCCESS_TTL_MS,
+  compareVersions,
   isCacheFresh,
   isCi,
   isOptedOut,
@@ -61,5 +62,30 @@ describe("isCacheFresh", () => {
 
   it("FAILURE_TTL is shorter than SUCCESS_TTL", () => {
     assert.ok(FAILURE_TTL_MS < SUCCESS_TTL_MS);
+  });
+});
+
+describe("compareVersions", () => {
+  it("returns 0 for equal versions", () => {
+    assert.equal(compareVersions("0.5.4", "0.5.4"), 0);
+  });
+
+  it("returns negative when a < b (patch)", () => {
+    assert.ok(compareVersions("0.5.3", "0.5.4") < 0);
+  });
+
+  it("returns positive when a > b (minor and major)", () => {
+    assert.ok(compareVersions("0.6.0", "0.5.4") > 0);
+    assert.ok(compareVersions("1.0.0", "0.99.99") > 0);
+  });
+
+  it("treats prerelease suffix as the base version", () => {
+    assert.equal(compareVersions("0.5.4-rc1", "0.5.4"), 0);
+  });
+
+  it("supports the downgrade-skip predicate (latest <= current)", () => {
+    assert.ok(compareVersions("0.5.0", "0.5.4") <= 0); // remote stale → skip
+    assert.ok(compareVersions("0.5.4", "0.5.4") <= 0); // already latest → skip
+    assert.ok(compareVersions("0.6.0", "0.5.4") > 0); // upgrade available
   });
 });

--- a/apps/flex-cli/src/auto-update.test.ts
+++ b/apps/flex-cli/src/auto-update.test.ts
@@ -79,13 +79,21 @@ describe("compareVersions", () => {
     assert.ok(compareVersions("1.0.0", "0.99.99") > 0);
   });
 
-  it("treats prerelease suffix as the base version", () => {
-    assert.equal(compareVersions("0.5.4-rc1", "0.5.4"), 0);
+  it("orders prerelease below the corresponding release", () => {
+    assert.ok(compareVersions("0.5.4-rc1", "0.5.4") < 0);
+    assert.ok(compareVersions("0.5.4", "0.5.4-rc1") > 0);
+  });
+
+  it("compares two prereleases by suffix", () => {
+    assert.ok(compareVersions("0.5.4-rc1", "0.5.4-rc2") < 0);
+    assert.equal(compareVersions("0.5.4-rc1", "0.5.4-rc1"), 0);
   });
 
   it("supports the downgrade-skip predicate (latest <= current)", () => {
     assert.ok(compareVersions("0.5.0", "0.5.4") <= 0); // remote stale → skip
     assert.ok(compareVersions("0.5.4", "0.5.4") <= 0); // already latest → skip
     assert.ok(compareVersions("0.6.0", "0.5.4") > 0); // upgrade available
+    // current가 prerelease이고 latest가 release면 업그레이드해야 한다.
+    assert.ok(compareVersions("0.5.4", "0.5.4-rc1") > 0);
   });
 });

--- a/apps/flex-cli/src/auto-update.test.ts
+++ b/apps/flex-cli/src/auto-update.test.ts
@@ -84,9 +84,20 @@ describe("compareVersions", () => {
     assert.ok(compareVersions("0.5.4", "0.5.4-rc1") > 0);
   });
 
-  it("compares two prereleases by suffix", () => {
+  it("compares two prereleases by SemVer §11 (numeric, dotted)", () => {
     assert.ok(compareVersions("0.5.4-rc1", "0.5.4-rc2") < 0);
     assert.equal(compareVersions("0.5.4-rc1", "0.5.4-rc1"), 0);
+    // dot-separated numeric identifier: numeric ordering kicks in.
+    // 단순 문자열 비교라면 rc.2 > rc.10이었을 케이스.
+    assert.ok(compareVersions("1.0.0-rc.2", "1.0.0-rc.10") < 0);
+    assert.ok(compareVersions("1.0.0-alpha.1", "1.0.0-alpha.2") < 0);
+    assert.ok(compareVersions("1.0.0-alpha", "1.0.0-alpha.1") < 0);
+    assert.ok(compareVersions("1.0.0-alpha.1", "1.0.0-beta") < 0);
+  });
+
+  it("returns 0 for invalid versions (skip auto-update)", () => {
+    assert.equal(compareVersions("not-a-version", "0.5.4"), 0);
+    assert.equal(compareVersions("0.5.4", ""), 0);
   });
 
   it("supports the downgrade-skip predicate (latest <= current)", () => {

--- a/apps/flex-cli/src/auto-update.test.ts
+++ b/apps/flex-cli/src/auto-update.test.ts
@@ -1,0 +1,65 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  FAILURE_TTL_MS,
+  SUCCESS_TTL_MS,
+  isCacheFresh,
+  isCi,
+  isOptedOut,
+} from "./auto-update.js";
+
+describe("isOptedOut", () => {
+  it("treats false/0/no as opt-out", () => {
+    for (const v of ["false", "0", "no"]) {
+      assert.equal(isOptedOut({ FLEX_AX_AUTO_UPDATE: v }), true);
+    }
+  });
+
+  it("treats unset or other values as opt-in", () => {
+    assert.equal(isOptedOut({}), false);
+    assert.equal(isOptedOut({ FLEX_AX_AUTO_UPDATE: "true" }), false);
+    assert.equal(isOptedOut({ FLEX_AX_AUTO_UPDATE: "1" }), false);
+    assert.equal(isOptedOut({ FLEX_AX_AUTO_UPDATE: "" }), false);
+  });
+});
+
+describe("isCi", () => {
+  it("returns true for CI=true|1", () => {
+    assert.equal(isCi({ CI: "true" }), true);
+    assert.equal(isCi({ CI: "1" }), true);
+  });
+
+  it("returns false for unset or other values", () => {
+    assert.equal(isCi({}), false);
+    assert.equal(isCi({ CI: "false" }), false);
+    assert.equal(isCi({ CI: "" }), false);
+  });
+});
+
+describe("isCacheFresh", () => {
+  const now = 1_700_000_000_000;
+
+  it("returns false for null cache", () => {
+    assert.equal(isCacheFresh(null, now), false);
+  });
+
+  it("uses SUCCESS_TTL when latestVersion is set", () => {
+    assert.equal(
+      isCacheFresh({ checkedAt: now - SUCCESS_TTL_MS + 1, latestVersion: "1.0.0" }, now),
+      true,
+    );
+    assert.equal(
+      isCacheFresh({ checkedAt: now - SUCCESS_TTL_MS, latestVersion: "1.0.0" }, now),
+      false,
+    );
+  });
+
+  it("uses FAILURE_TTL when latestVersion is missing", () => {
+    assert.equal(isCacheFresh({ checkedAt: now - FAILURE_TTL_MS + 1 }, now), true);
+    assert.equal(isCacheFresh({ checkedAt: now - FAILURE_TTL_MS }, now), false);
+  });
+
+  it("FAILURE_TTL is shorter than SUCCESS_TTL", () => {
+    assert.ok(FAILURE_TTL_MS < SUCCESS_TTL_MS);
+  });
+});

--- a/apps/flex-cli/src/auto-update.ts
+++ b/apps/flex-cli/src/auto-update.ts
@@ -1,0 +1,118 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+import {
+  downloadAndInstall,
+  getCurrentVersion,
+  getLatestVersion,
+} from "./commands/update.js";
+
+const CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000;
+const NETWORK_TIMEOUT_MS = 2000;
+const REENTRY_GUARD_ENV = "FLEX_AX_AUTO_UPDATE_REENTRY";
+
+interface CheckCache {
+  lastCheckedAt: number;
+  latestVersion?: string;
+}
+
+function getCachePath(): string {
+  return path.join(os.homedir(), ".flex-ax", "update-check.json");
+}
+
+async function readCache(): Promise<CheckCache | null> {
+  try {
+    const content = await readFile(getCachePath(), "utf-8");
+    return JSON.parse(content) as CheckCache;
+  } catch {
+    return null;
+  }
+}
+
+async function writeCache(cache: CheckCache): Promise<void> {
+  const cachePath = getCachePath();
+  await mkdir(path.dirname(cachePath), { recursive: true });
+  await writeFile(cachePath, JSON.stringify(cache, null, 2));
+}
+
+function isOptedOut(): boolean {
+  const v = process.env.FLEX_AX_AUTO_UPDATE;
+  return v === "false" || v === "0" || v === "no";
+}
+
+function isCi(): boolean {
+  const v = process.env.CI;
+  return v === "true" || v === "1";
+}
+
+function isInteractive(): boolean {
+  return Boolean(process.stdout.isTTY) && Boolean(process.stdin.isTTY);
+}
+
+function isInstalledRun(): boolean {
+  const entry = process.argv[1];
+  return typeof entry === "string" && entry.endsWith("dist/cli.js");
+}
+
+async function fetchLatestWithTimeout(): Promise<string | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), NETWORK_TIMEOUT_MS);
+  try {
+    return await getLatestVersion(controller.signal);
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function maybeAutoUpdate(originalArgs: string[]): Promise<void> {
+  if (isOptedOut()) return;
+  if (process.env[REENTRY_GUARD_ENV] === "1") return;
+  if (!isInstalledRun()) return;
+
+  const cache = await readCache();
+  const now = Date.now();
+  if (cache && now - cache.lastCheckedAt < CHECK_INTERVAL_MS) return;
+
+  const current = await getCurrentVersion().catch(() => null);
+  if (!current) return;
+
+  const latest = await fetchLatestWithTimeout();
+  if (!latest) return;
+
+  await writeCache({ lastCheckedAt: now, latestVersion: latest }).catch(() => {});
+
+  if (current === latest) return;
+
+  if (isCi() || !isInteractive()) {
+    console.error(
+      `[FLEX-AX] 새 버전 ${latest} 사용 가능 (현재 ${current}). \`flex-ax update\` 로 업데이트하세요.`,
+    );
+    return;
+  }
+
+  console.error(
+    `[FLEX-AX] 새 버전 감지: ${current} → ${latest}, 자동 업데이트 후 재실행합니다.`,
+  );
+  console.error(
+    `[FLEX-AX] 자동 업데이트를 끄려면 FLEX_AX_AUTO_UPDATE=false 환경변수를 설정하세요.`,
+  );
+
+  try {
+    await downloadAndInstall(latest);
+  } catch (err) {
+    console.error(
+      `[FLEX-AX] 자동 업데이트 실패, 기존 버전으로 진행합니다: ${err instanceof Error ? err.message : err}`,
+    );
+    return;
+  }
+
+  const result = spawnSync(process.execPath, [process.argv[1]!, ...originalArgs], {
+    stdio: "inherit",
+    env: { ...process.env, [REENTRY_GUARD_ENV]: "1" },
+  });
+  process.exit(result.status ?? 0);
+}

--- a/apps/flex-cli/src/auto-update.ts
+++ b/apps/flex-cli/src/auto-update.ts
@@ -2,6 +2,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 
 import {
   downloadAndInstall,
@@ -59,8 +60,12 @@ function isInteractive(): boolean {
 }
 
 function isInstalledRun(): boolean {
-  const entry = process.argv[1];
-  return typeof entry === "string" && entry.endsWith(path.join("dist", "cli.js"));
+  // npm/pnpm bin shim과 symlink는 process.argv[1]를 .../.bin/flex-ax 같이
+  // 만들어 dist/cli.js와 매칭되지 않는 경우가 있다. 이 모듈 자체의 위치를
+  // 보면 빌드된 dist에서 import된 경로(또는 tsx의 src/.ts)가 그대로 드러나므로
+  // 설치 실행과 dev 실행을 안정적으로 구분할 수 있다.
+  const here = fileURLToPath(import.meta.url);
+  return here.endsWith(path.join("dist", "auto-update.js"));
 }
 
 export function compareVersions(a: string, b: string): number {

--- a/apps/flex-cli/src/auto-update.ts
+++ b/apps/flex-cli/src/auto-update.ts
@@ -69,13 +69,26 @@ function isInstalledRun(): boolean {
 }
 
 export function compareVersions(a: string, b: string): number {
-  const parse = (v: string) =>
-    v.split("-")[0].split(".").map((n) => Number.parseInt(n, 10) || 0);
-  const [a1 = 0, a2 = 0, a3 = 0] = parse(a);
-  const [b1 = 0, b2 = 0, b3 = 0] = parse(b);
-  if (a1 !== b1) return a1 - b1;
-  if (a2 !== b2) return a2 - b2;
-  return a3 - b3;
+  const split = (v: string): { base: number[]; pre: string | null } => {
+    const dash = v.indexOf("-");
+    const baseStr = dash === -1 ? v : v.slice(0, dash);
+    const pre = dash === -1 ? null : v.slice(dash + 1);
+    return {
+      base: baseStr.split(".").map((n) => Number.parseInt(n, 10) || 0),
+      pre,
+    };
+  };
+  const A = split(a);
+  const B = split(b);
+  for (let i = 0; i < 3; i++) {
+    const diff = (A.base[i] ?? 0) - (B.base[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  // semver: base가 같다면 prerelease 있는 쪽이 더 낮다.
+  if (A.pre === null && B.pre === null) return 0;
+  if (A.pre === null) return 1;
+  if (B.pre === null) return -1;
+  return A.pre < B.pre ? -1 : A.pre > B.pre ? 1 : 0;
 }
 
 async function fetchLatestWithTimeout(): Promise<string | null> {
@@ -162,10 +175,19 @@ export async function maybeAutoUpdate(originalArgs: string[]): Promise<void> {
     // 호출자가 정확한 종료 사유를 알 수 있도록 한다. Windows 등 일부
     // 플랫폼에서는 미지원 시그널이 ERR_UNKNOWN_SIGNAL을 던질 수 있으므로
     // 그때는 조용히 exit 1로 떨어진다.
+    let signalSent = false;
     try {
       process.kill(process.pid, result.signal);
+      signalSent = true;
     } catch {
       // ignore — 아래 process.exit으로 fallback
+    }
+    if (signalSent) {
+      // 시그널이 즉시 도착하지 않을 수 있으므로 잠깐 대기. 이벤트 루프가
+      // 비어 있으면 unref로 끝나도 process가 자연 종료되지 않으니, 이 경우
+      // 100ms 후 fallback으로 exit 1.
+      setTimeout(() => process.exit(1), 100).unref();
+      return;
     }
     process.exit(1);
   }

--- a/apps/flex-cli/src/auto-update.ts
+++ b/apps/flex-cli/src/auto-update.ts
@@ -9,12 +9,13 @@ import {
   getLatestVersion,
 } from "./commands/update.js";
 
-const CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000;
+export const SUCCESS_TTL_MS = 6 * 60 * 60 * 1000;
+export const FAILURE_TTL_MS = 30 * 60 * 1000;
 const NETWORK_TIMEOUT_MS = 2000;
 const REENTRY_GUARD_ENV = "FLEX_AX_AUTO_UPDATE_REENTRY";
 
-interface CheckCache {
-  lastCheckedAt: number;
+export interface CheckCache {
+  checkedAt: number;
   latestVersion?: string;
 }
 
@@ -37,13 +38,19 @@ async function writeCache(cache: CheckCache): Promise<void> {
   await writeFile(cachePath, JSON.stringify(cache, null, 2));
 }
 
-function isOptedOut(): boolean {
-  const v = process.env.FLEX_AX_AUTO_UPDATE;
+export function isCacheFresh(cache: CheckCache | null, now: number): boolean {
+  if (!cache) return false;
+  const ttl = cache.latestVersion ? SUCCESS_TTL_MS : FAILURE_TTL_MS;
+  return now - cache.checkedAt < ttl;
+}
+
+export function isOptedOut(env: NodeJS.ProcessEnv = process.env): boolean {
+  const v = env.FLEX_AX_AUTO_UPDATE;
   return v === "false" || v === "0" || v === "no";
 }
 
-function isCi(): boolean {
-  const v = process.env.CI;
+export function isCi(env: NodeJS.ProcessEnv = process.env): boolean {
+  const v = env.CI;
   return v === "true" || v === "1";
 }
 
@@ -73,17 +80,26 @@ export async function maybeAutoUpdate(originalArgs: string[]): Promise<void> {
   if (process.env[REENTRY_GUARD_ENV] === "1") return;
   if (!isInstalledRun()) return;
 
-  const cache = await readCache();
-  const now = Date.now();
-  if (cache && now - cache.lastCheckedAt < CHECK_INTERVAL_MS) return;
-
   const current = await getCurrentVersion().catch(() => null);
   if (!current) return;
 
-  const latest = await fetchLatestWithTimeout();
-  if (!latest) return;
+  const now = Date.now();
+  const cached = await readCache();
 
-  await writeCache({ lastCheckedAt: now, latestVersion: latest }).catch(() => {});
+  let latest: string | null = null;
+  if (isCacheFresh(cached, now)) {
+    latest = cached?.latestVersion ?? null;
+  } else {
+    latest = await fetchLatestWithTimeout();
+    // 성공 시 SUCCESS_TTL, 실패 시 FAILURE_TTL짜리 캐시를 남겨
+    // 네트워크 장애가 지속될 때 매 실행마다 2초 대기를 막는다.
+    await writeCache(
+      latest
+        ? { checkedAt: now, latestVersion: latest }
+        : { checkedAt: now },
+    ).catch(() => {});
+  }
+  if (!latest) return;
 
   if (current === latest) return;
 
@@ -114,5 +130,18 @@ export async function maybeAutoUpdate(originalArgs: string[]): Promise<void> {
     stdio: "inherit",
     env: { ...process.env, [REENTRY_GUARD_ENV]: "1" },
   });
-  process.exit(result.status ?? 0);
+
+  if (result.error) {
+    console.error(
+      `[FLEX-AX] 자동 업데이트 후 재실행 실패: ${result.error.message}`,
+    );
+    process.exit(1);
+  }
+  if (result.signal) {
+    // 자식이 시그널로 종료된 경우 동일 시그널로 자기 자신을 종료해
+    // 호출자가 정확한 종료 사유를 알 수 있도록 한다.
+    process.kill(process.pid, result.signal);
+    process.exit(1);
+  }
+  process.exit(result.status ?? 1);
 }

--- a/apps/flex-cli/src/auto-update.ts
+++ b/apps/flex-cli/src/auto-update.ts
@@ -155,8 +155,14 @@ export async function maybeAutoUpdate(originalArgs: string[]): Promise<void> {
   }
   if (result.signal) {
     // 자식이 시그널로 종료된 경우 동일 시그널로 자기 자신을 종료해
-    // 호출자가 정확한 종료 사유를 알 수 있도록 한다.
-    process.kill(process.pid, result.signal);
+    // 호출자가 정확한 종료 사유를 알 수 있도록 한다. Windows 등 일부
+    // 플랫폼에서는 미지원 시그널이 ERR_UNKNOWN_SIGNAL을 던질 수 있으므로
+    // 그때는 조용히 exit 1로 떨어진다.
+    try {
+      process.kill(process.pid, result.signal);
+    } catch {
+      // ignore — 아래 process.exit으로 fallback
+    }
     process.exit(1);
   }
   process.exit(result.status ?? 1);

--- a/apps/flex-cli/src/auto-update.ts
+++ b/apps/flex-cli/src/auto-update.ts
@@ -60,7 +60,17 @@ function isInteractive(): boolean {
 
 function isInstalledRun(): boolean {
   const entry = process.argv[1];
-  return typeof entry === "string" && entry.endsWith("dist/cli.js");
+  return typeof entry === "string" && entry.endsWith(path.join("dist", "cli.js"));
+}
+
+export function compareVersions(a: string, b: string): number {
+  const parse = (v: string) =>
+    v.split("-")[0].split(".").map((n) => Number.parseInt(n, 10) || 0);
+  const [a1 = 0, a2 = 0, a3 = 0] = parse(a);
+  const [b1 = 0, b2 = 0, b3 = 0] = parse(b);
+  if (a1 !== b1) return a1 - b1;
+  if (a2 !== b2) return a2 - b2;
+  return a3 - b3;
 }
 
 async function fetchLatestWithTimeout(): Promise<string | null> {
@@ -101,7 +111,8 @@ export async function maybeAutoUpdate(originalArgs: string[]): Promise<void> {
   }
   if (!latest) return;
 
-  if (current === latest) return;
+  // 로컬 빌드/프리릴리스로 current가 더 높을 수 있으므로 다운그레이드는 skip.
+  if (compareVersions(latest, current) <= 0) return;
 
   if (isCi() || !isInteractive()) {
     console.error(

--- a/apps/flex-cli/src/auto-update.ts
+++ b/apps/flex-cli/src/auto-update.ts
@@ -4,6 +4,8 @@ import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
+import semver from "semver";
+
 import {
   downloadAndInstall,
   getCurrentVersion,
@@ -69,26 +71,14 @@ function isInstalledRun(): boolean {
 }
 
 export function compareVersions(a: string, b: string): number {
-  const split = (v: string): { base: number[]; pre: string | null } => {
-    const dash = v.indexOf("-");
-    const baseStr = dash === -1 ? v : v.slice(0, dash);
-    const pre = dash === -1 ? null : v.slice(dash + 1);
-    return {
-      base: baseStr.split(".").map((n) => Number.parseInt(n, 10) || 0),
-      pre,
-    };
-  };
-  const A = split(a);
-  const B = split(b);
-  for (let i = 0; i < 3; i++) {
-    const diff = (A.base[i] ?? 0) - (B.base[i] ?? 0);
-    if (diff !== 0) return diff;
-  }
-  // semver: base가 같다면 prerelease 있는 쪽이 더 낮다.
-  if (A.pre === null && B.pre === null) return 0;
-  if (A.pre === null) return 1;
-  if (B.pre === null) return -1;
-  return A.pre < B.pre ? -1 : A.pre > B.pre ? 1 : 0;
+  // SemVer §11 (numeric prerelease ordering, dot-separated identifiers 등)을
+  // 직접 구현하면 rc10/rc2, alpha.1 같은 케이스를 놓치기 쉬워 검증된
+  // semver 패키지에 위임한다. 둘 중 하나라도 invalid면 자동 업데이트를
+  // 건너뛰는 게 안전하므로 0(동등)으로 떨어진다.
+  const av = semver.valid(a);
+  const bv = semver.valid(b);
+  if (!av || !bv) return 0;
+  return semver.compare(av, bv);
 }
 
 async function fetchLatestWithTimeout(): Promise<string | null> {

--- a/apps/flex-cli/src/auto-update.ts
+++ b/apps/flex-cli/src/auto-update.ts
@@ -139,6 +139,10 @@ export async function maybeAutoUpdate(originalArgs: string[]): Promise<void> {
     console.error(
       `[FLEX-AX] 자동 업데이트 실패, 기존 버전으로 진행합니다: ${err instanceof Error ? err.message : err}`,
     );
+    // 같은 latest를 계속 잡고 매 호출마다 다운로드/설치를 재시도하면
+    // 네트워크나 권한 문제가 지속될 때 에러 로그가 6시간 동안 반복된다.
+    // 실패 캐시(FAILURE_TTL)로 전환해 최소 30분은 조용하도록 둔다.
+    await writeCache({ checkedAt: Date.now() }).catch(() => {});
     return;
   }
 

--- a/apps/flex-cli/src/cli.ts
+++ b/apps/flex-cli/src/cli.ts
@@ -2,6 +2,9 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
+// 자동 업데이트 시 재실행할 원본 인자 보존
+const originalArgs = process.argv.slice(2);
+
 // --auth <mode> 플래그 파싱 (커맨드 앞뒤 어디든 가능)
 const rawArgs = process.argv.slice(2);
 const authIdx = rawArgs.indexOf("--auth");
@@ -27,6 +30,12 @@ if (command === "--version" || command === "-v") {
 }
 
 await import("dotenv/config");
+
+// update/help 외 명령에 대해 새 버전 감지 → 자동 설치 → 재실행
+if (command && command !== "update" && command !== "help") {
+  const { maybeAutoUpdate } = await import("./auto-update.js");
+  await maybeAutoUpdate(originalArgs);
+}
 
 switch (command) {
   case "discover": {
@@ -89,6 +98,9 @@ Commands:
 
 Options:
   --auth <mode>   인증 모드: credentials | sso | playwriter
-  --version, -v   버전 출력`);
+  --version, -v   버전 출력
+
+Env:
+  FLEX_AX_AUTO_UPDATE=false   기동 시 자동 업데이트 비활성화`);
     process.exit(command === "help" ? 0 : 1);
 }

--- a/apps/flex-cli/src/commands/update.ts
+++ b/apps/flex-cli/src/commands/update.ts
@@ -8,16 +8,16 @@ import { pipeline } from "node:stream/promises";
 const REPO = "planetarium/flex-ax";
 const RELEASE_URL = `https://github.com/${REPO}/releases`;
 
-async function getCurrentVersion(): Promise<string> {
+export async function getCurrentVersion(): Promise<string> {
   const __dirname = path.dirname(fileURLToPath(import.meta.url));
   const pkgPath = path.resolve(__dirname, "../../package.json");
   const pkg = JSON.parse(await readFile(pkgPath, "utf-8"));
   return pkg.version;
 }
 
-async function getLatestVersion(): Promise<string> {
+export async function getLatestVersion(signal?: AbortSignal): Promise<string> {
   // GitHub redirects /releases/latest to /releases/tag/<tag>
-  const res = await fetch(`${RELEASE_URL}/latest`, { redirect: "manual" });
+  const res = await fetch(`${RELEASE_URL}/latest`, { redirect: "manual", signal });
   const location = res.headers.get("location");
   if (!location) {
     throw new Error("최신 릴리스를 찾을 수 없습니다.");
@@ -28,7 +28,7 @@ async function getLatestVersion(): Promise<string> {
   return version;
 }
 
-async function downloadAndInstall(version: string): Promise<void> {
+export async function downloadAndInstall(version: string): Promise<void> {
   const tgzName = `flex-ax-${version}.tgz`;
   const downloadUrl = `${RELEASE_URL}/download/flex-cli@${version}/${tgzName}`;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       playwright:
         specifier: ^1.50.1
         version: 1.58.2
+      semver:
+        specifier: ^7.7.4
+        version: 7.7.4
       zod:
         specifier: ^3.24.2
         version: 3.25.76
@@ -33,6 +36,9 @@ importers:
       '@types/node':
         specifier: ^22.13.5
         version: 22.19.15
+      '@types/semver':
+        specifier: ^7.7.1
+        version: 7.7.1
       rimraf:
         specifier: ^6.0.1
         version: 6.1.3
@@ -286,6 +292,9 @@ packages:
 
   '@types/node@22.19.15':
     resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
+
+  '@types/semver@7.7.1':
+    resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -786,6 +795,8 @@ snapshots:
   '@types/node@22.19.15':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/semver@7.7.1': {}
 
   agent-base@7.1.4: {}
 


### PR DESCRIPTION
Closes #19.

## Summary
- 모든 `flex-ax <cmd>` 진입 시 GitHub latest release를 2초 타임아웃으로 조회하고, 새 버전이면 자동으로 `downloadAndInstall` → 같은 인자로 자식 프로세스 재실행 (`spawnSync`, `process.exit(child.status)`)
- 체크 결과는 `~/.flex-ax/update-check.json`에 6시간 캐싱; 네트워크 실패는 silent
- CI (`CI=true`) / non-tty 환경은 자동 설치 대신 경고 배너만 출력
- opt-out: `FLEX_AX_AUTO_UPDATE=false`. 무한 재실행 방지용 내부 가드(`FLEX_AX_AUTO_UPDATE_REENTRY=1`)는 자식 프로세스에 자동 주입
- 개발 모드(`tsx src/cli.ts`)는 entrypoint가 `dist/cli.js`가 아니므로 skip
- `update`/`help`/`--version`은 훅 자체를 우회

`apps/flex-cli/src/commands/update.ts`의 `getCurrentVersion`/`getLatestVersion`/`downloadAndInstall`을 export해서 재사용; `getLatestVersion`에 `AbortSignal` 인자 추가.

## Test plan
- [x] `tsc --noEmit` 통과
- [x] `tsc -p tsconfig.build.json` + postbuild 통과
- [x] `node dist/cli.js --version` — 자동 업데이트 훅 우회 확인
- [x] `node dist/cli.js help` — 자동 업데이트 훅 우회 + env 문서 노출 확인
- [x] 캐시 비운 상태에서 `node dist/cli.js check-apis` — 라이브 GitHub 조회 → `~/.flex-ax/update-check.json`에 `latestVersion: "0.5.4"` 기록, current==latest라 업데이트 시도 없이 명령 진행 확인
- [x] `FLEX_AX_AUTO_UPDATE=false node dist/cli.js check-apis` — 네트워크 호출 없이 즉시 명령 진행 확인
- [ ] 다음 릴리스 후 실제 stale 바이너리에서 자동 업데이트 → 재실행 동작 확인 (실제 새 릴리스가 있어야 검증 가능)

🤖 Generated with [Claude Code](https://claude.com/claude-code)