### PR TITLE
chore(flex-cli): deprecate npm auto-update ahead of binary migration

### DIFF
--- a/apps/flex-cli/package.json
+++ b/apps/flex-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flex-ax",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "description": "flex HR SaaS AX CLI - discover, crawl, and manage flex data",

--- a/apps/flex-cli/src/auto-update.ts
+++ b/apps/flex-cli/src/auto-update.ts
@@ -1,16 +1,11 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 import semver from "semver";
 
-import {
-  downloadAndInstall,
-  getCurrentVersion,
-  getLatestVersion,
-} from "./commands/update.js";
+import { getCurrentVersion, getLatestVersion } from "./commands/update.js";
 
 export const SUCCESS_TTL_MS = 6 * 60 * 60 * 1000;
 export const FAILURE_TTL_MS = 30 * 60 * 1000;
@@ -122,64 +117,17 @@ export async function maybeAutoUpdate(originalArgs: string[]): Promise<void> {
   // 로컬 빌드/프리릴리스로 current가 더 높을 수 있으므로 다운그레이드는 skip.
   if (compareVersions(latest, current) <= 0) return;
 
-  if (isCi() || !isInteractive()) {
-    console.error(
-      `[FLEX-AX] 새 버전 ${latest} 사용 가능 (현재 ${current}). \`flex-ax update\` 로 업데이트하세요.`,
-    );
-    return;
-  }
-
+  // flex-ax는 다음 릴리스부터 bun compile 기반 standalone 바이너리로 배포
+  // 방식을 전환한다. npm pack tarball을 덮어쓰는 기존 자동 업데이트는 새
+  // 포맷을 로드할 수 없어 브릭을 유발할 수 있으므로, 여기서는 알림만 출력하고
+  // 실제 교체는 사용자가 한 번만 수동으로 수행하도록 안내한다.
   console.error(
-    `[FLEX-AX] 새 버전 감지: ${current} → ${latest}, 자동 업데이트 후 재실행합니다.`,
+    `[FLEX-AX] 새 버전 ${latest} 사용 가능 (현재 ${current}).`,
   );
   console.error(
-    `[FLEX-AX] 자동 업데이트를 끄려면 FLEX_AX_AUTO_UPDATE=false 환경변수를 설정하세요.`,
+    `[FLEX-AX] flex-ax는 standalone 바이너리 배포로 전환됩니다. npm 자동 업데이트는 중단되었습니다.`,
   );
-
-  try {
-    await downloadAndInstall(latest);
-  } catch (err) {
-    console.error(
-      `[FLEX-AX] 자동 업데이트 실패, 기존 버전으로 진행합니다: ${err instanceof Error ? err.message : err}`,
-    );
-    // 같은 latest를 계속 잡고 매 호출마다 다운로드/설치를 재시도하면
-    // 네트워크나 권한 문제가 지속될 때 에러 로그가 6시간 동안 반복된다.
-    // 실패 캐시(FAILURE_TTL)로 전환해 최소 30분은 조용하도록 둔다.
-    await writeCache({ checkedAt: Date.now() }).catch(() => {});
-    return;
-  }
-
-  const result = spawnSync(process.execPath, [process.argv[1]!, ...originalArgs], {
-    stdio: "inherit",
-    env: { ...process.env, [REENTRY_GUARD_ENV]: "1" },
-  });
-
-  if (result.error) {
-    console.error(
-      `[FLEX-AX] 자동 업데이트 후 재실행 실패: ${result.error.message}`,
-    );
-    process.exit(1);
-  }
-  if (result.signal) {
-    // 자식이 시그널로 종료된 경우 동일 시그널로 자기 자신을 종료해
-    // 호출자가 정확한 종료 사유를 알 수 있도록 한다. Windows 등 일부
-    // 플랫폼에서는 미지원 시그널이 ERR_UNKNOWN_SIGNAL을 던질 수 있으므로
-    // 그때는 조용히 exit 1로 떨어진다.
-    let signalSent = false;
-    try {
-      process.kill(process.pid, result.signal);
-      signalSent = true;
-    } catch {
-      // ignore — 아래 process.exit으로 fallback
-    }
-    if (signalSent) {
-      // 시그널이 즉시 도착하지 않을 수 있으므로 잠깐 대기. 이벤트 루프가
-      // 비어 있으면 unref로 끝나도 process가 자연 종료되지 않으니, 이 경우
-      // 100ms 후 fallback으로 exit 1.
-      setTimeout(() => process.exit(1), 100).unref();
-      return;
-    }
-    process.exit(1);
-  }
-  process.exit(result.status ?? 1);
+  console.error(
+    `[FLEX-AX] 최신 바이너리: https://github.com/planetarium/flex-ax/releases/latest`,
+  );
 }

--- a/apps/flex-cli/src/commands/update.ts
+++ b/apps/flex-cli/src/commands/update.ts
@@ -1,9 +1,6 @@
-import { createWriteStream } from "node:fs";
-import { rename, rm, mkdir, readFile } from "node:fs/promises";
-import { execSync } from "node:child_process";
+import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { pipeline } from "node:stream/promises";
 
 const REPO = "planetarium/flex-ax";
 const RELEASE_URL = `https://github.com/${REPO}/releases`;
@@ -28,73 +25,17 @@ export async function getLatestVersion(signal?: AbortSignal): Promise<string> {
   return version;
 }
 
-export async function downloadAndInstall(version: string): Promise<void> {
-  const tgzName = `flex-ax-${version}.tgz`;
-  const downloadUrl = `${RELEASE_URL}/download/flex-cli@${version}/${tgzName}`;
-
-  console.log(`[FLEX-AX:UPDATE] 다운로드 중: ${downloadUrl}`);
-  const res = await fetch(downloadUrl);
-  if (!res.ok || !res.body) {
-    throw new Error(`다운로드 실패: ${res.status} ${res.statusText}`);
-  }
-
-  // npm pack tarball 구조: package/ 아래에 파일이 들어있음
-  const __dirname = path.dirname(fileURLToPath(import.meta.url));
-  const packageRoot = path.resolve(__dirname, "../..");
-  const tmpDir = path.join(packageRoot, ".update-tmp");
-
-  await rm(tmpDir, { recursive: true, force: true });
-  await mkdir(tmpDir, { recursive: true });
-
-  const tgzPath = path.join(tmpDir, tgzName);
-
-  // 다운로드
-  const fileStream = createWriteStream(tgzPath);
-  // @ts-expect-error ReadableStream to NodeJS stream
-  await pipeline(res.body, fileStream);
-
-  // 압축 해제
-  console.log("[FLEX-AX:UPDATE] 압축 해제 중...");
-  execSync(`tar -xzf ${JSON.stringify(tgzPath)} -C ${JSON.stringify(tmpDir)}`);
-
-  // package/ 내용물을 패키지 루트로 복사
-  const extractedDir = path.join(tmpDir, "package");
-
-  // dist/ 교체
-  const distTarget = path.join(packageRoot, "dist");
-  await rm(distTarget, { recursive: true, force: true });
-  await rename(path.join(extractedDir, "dist"), distTarget);
-
-  // package.json 교체
-  await rename(
-    path.join(extractedDir, "package.json"),
-    path.join(packageRoot, "package.json"),
-  );
-
-  // 정리
-  await rm(tmpDir, { recursive: true, force: true });
-}
-
 export async function runUpdate(): Promise<void> {
-  try {
-    const current = await getCurrentVersion();
-    console.log(`[FLEX-AX:UPDATE] 현재 버전: ${current}`);
-
-    const latest = await getLatestVersion();
-    console.log(`[FLEX-AX:UPDATE] 최신 버전: ${latest}`);
-
-    if (current === latest) {
-      console.log("[FLEX-AX:UPDATE] 이미 최신 버전입니다.");
-      return;
-    }
-
-    console.log(`[FLEX-AX:UPDATE] ${current} → ${latest} 업데이트 시작`);
-    await downloadAndInstall(latest);
-    console.log(`[FLEX-AX:UPDATE] ${latest} 업데이트 완료!`);
-  } catch (err) {
-    console.error(
-      `[FLEX-AX:ERROR] 업데이트 실패: ${err instanceof Error ? err.message : err}`,
-    );
-    process.exit(1);
-  }
+  const current = await getCurrentVersion().catch(() => "unknown");
+  console.log(`[FLEX-AX:UPDATE] 현재 버전: ${current}`);
+  console.log(
+    `[FLEX-AX:UPDATE] flex-ax는 standalone 바이너리 배포로 전환됩니다.`,
+  );
+  console.log(
+    `[FLEX-AX:UPDATE] npm 기반 자동 업데이트는 더 이상 지원되지 않습니다.`,
+  );
+  console.log(
+    `[FLEX-AX:UPDATE] 최신 바이너리를 직접 내려받아 주세요:`,
+  );
+  console.log(`  https://github.com/planetarium/flex-ax/releases/latest`);
 }


### PR DESCRIPTION
## Summary

- **#21 (standalone binary) 머지 이전에 반드시 먼저 머지/릴리스되어야 하는 transitional 패치**
- 다음 릴리스에서 flex-ax는 bun compile 기반 단일 바이너리로 배포 방식이 전환됨. 기존 npm pack tarball을 그대로 덮어쓰는 자동 업데이트 경로는 새 포맷(\`bun:sqlite\`, text/json embed)을 Node 런타임에서 로드하지 못해 **기존 설치를 브릭시킬 위험**이 있음.
- 이 PR은 자동 업데이트를 안내-only로 돌려, 기존 유저가 0.6.1을 한 번 받은 뒤엔 스스로 tarball을 덮어쓰지 않도록 한다.

## 왜 필요한가

기존 설치(npm/pnpm)의 \`maybeAutoUpdate\`는 startup 시 \`downloadAndInstall(latest)\`로 tarball을 받아 \`dist/\`를 통째로 교체한다. 만약 #21이 먼저 머지되어 0.7.0으로 배포되면:

| 릴리스 구성 | 결과 |
|---|---|
| tarball 미발행 | 404 → "기존 버전으로 진행"으로 조용히 계속. 사용자는 새 바이너리 존재를 모름 |
| tarball에 bun 전용 dist가 들어감 | 자동 설치됨 → 다음 실행 시 \`Cannot find module 'bun:sqlite'\` **크래시** |

이 PR이 0.6.1로 먼저 배포되면, 기존 유저의 자동 업데이트가 한 번만 더 발동해서 이 "안내-only" 버전을 받고 나면, 이후 \`maybeAutoUpdate\`는 어떤 새 버전도 스스로 설치하지 않는다.

## 변경

- \`auto-update.ts\`의 \`maybeAutoUpdate\`: 버전 감지/캐싱 로직은 유지, download·spawn·re-exec 블록만 제거하고 "바이너리 마이그레이션 안내" 메시지로 교체.
- \`commands/update.ts\`의 \`runUpdate\`: 네트워크 호출 없이 현재 버전과 동일한 안내만 출력.
- 더 이상 쓰이지 않는 \`downloadAndInstall\`과 관련 import (\`createWriteStream\`, \`rename\`, \`rm\`, \`mkdir\`, \`execSync\`, \`pipeline\`) 제거.
- 버전 0.6.0 → **0.6.1**.

## 검증

| 항목 | 결과 |
|---|---|
| \`pnpm lint\` | ✅ tsc 통과 |
| \`pnpm test\` | ✅ 18/18 통과 |
| \`pnpm build\` | ✅ dist/cli.js 정상 생성 |
| \`node dist/cli.js --version\` | ✅ \`flex-ax 0.6.1\` |
| \`node dist/cli.js update\` | ✅ 안내 4줄 출력, 네트워크 호출 없음 |

### 출력 예시

\`\`\`
$ flex-ax update
[FLEX-AX:UPDATE] 현재 버전: 0.6.1
[FLEX-AX:UPDATE] flex-ax는 standalone 바이너리 배포로 전환됩니다.
[FLEX-AX:UPDATE] npm 기반 자동 업데이트는 더 이상 지원되지 않습니다.
[FLEX-AX:UPDATE] 최신 바이너리를 직접 내려받아 주세요:
  https://github.com/planetarium/flex-ax/releases/latest
\`\`\`

## 릴리스 순서

1. **이 PR(0.6.1) 머지 → 0.6.1 릴리스** (npm tarball 발행, 기존 CI 그대로)
2. 기존 유저들이 자연스럽게 0.6.1을 받아 자동 업데이트가 비활성화되는 기간 대기
3. **#21 (standalone binary) 머지 → 0.7.0 릴리스** (바이너리 asset 업로드, CI 워크플로 업데이트는 별도 PR)

## Test plan

- [ ] \`pnpm --filter flex-ax lint && pnpm --filter flex-ax test && pnpm --filter flex-ax build\`
- [ ] 기존 설치에서 \`flex-ax update\` 호출 시 안내 메시지만 출력 확인
- [ ] startup auto-update이 0.6.1로 올라간 뒤에는 그 이후 버전을 자동으로 덮어쓰지 않는지 수동 확인

## Related

- Blocks: #21 (standalone binary migration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)