### PR TITLE
[codex] add direct flex-hr dump mode

### DIFF
--- a/apps/flex-cli/.env.example
+++ b/apps/flex-cli/.env.example
@@ -29,3 +29,45 @@ FLEX_PASSWORD=your-password
 
 # 브라우저 headless 모드 (기본값: true, SSO 모드에서는 무시됨)
 # HEADLESS=true
+
+# flex-hr direct dump 모드
+# true면 crawl 직후 SQLite 생성 및 flex-hr DB/스토리지 적재를 시도합니다.
+# FLEX_HR_DIRECT_DUMP=false
+
+# flex-hr workspace owner wallet (direct dump 필수)
+# FLEX_HR_OWNER_WALLET=0x0000000000000000000000000000000000000000
+
+# 추가 workspace member wallet 목록 (콤마 구분, 선택)
+# FLEX_HR_MEMBER_WALLETS=0x1111111111111111111111111111111111111111,0x2222222222222222222222222222222222222222
+
+# workspace 이름 override (선택, 미지정 시 고객사명 사용)
+# FLEX_HR_WORKSPACE_NAME=My Flex Workspace
+
+# 파일 import 병렬도 (기본값: 8)
+# FLEX_HR_IMPORT_PARALLEL=8
+
+# true면 DB commit 없이 메타데이터를 검증하고 롤백합니다.
+# STORAGE_BACKEND=r2 인 경우 R2 크리덴셜/버킷 접근성도 probe로 확인합니다.
+# FLEX_HR_IMPORT_DRY_RUN=false
+
+# direct dump scratch 디렉터리를 보존할지 여부 (기본값: false)
+# FLEX_HR_KEEP_SCRATCH=false
+
+# scratch root override (기본값: OS tmpdir)
+# FLEX_HR_SCRATCH_ROOT=/tmp/flex-ax-flex-hr
+
+# flex-hr DB 접속정보 (direct dump 필수)
+# DATABASE_URL=postgresql://app_postgraphile@localhost:5432/mydb
+# DB_SETUP_URL=postgresql://postgres@localhost:5432/mydb
+
+# 파일 저장소 backend: local | r2
+# STORAGE_BACKEND=local
+
+# local backend일 때 업로드 루트
+# LOCAL_UPLOAD_DIR=.uploads
+
+# R2 backend 설정
+# R2_ENDPOINT=https://<accountid>.r2.cloudflarestorage.com
+# R2_ACCESS_KEY_ID=...
+# R2_SECRET_ACCESS_KEY=...
+# R2_BUCKET=flex-hr-uploads

--- a/apps/flex-cli/package.json
+++ b/apps/flex-cli/package.json
@@ -21,8 +21,10 @@
     "clean": "rimraf output dist"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1037.0",
     "better-sqlite3": "^12.8.0",
     "dotenv": "^16.4.7",
+    "pg": "^8.20.0",
     "playwright": "^1.50.1",
     "zod": "^3.24.2"
   },
@@ -32,6 +34,7 @@
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^22.13.5",
+    "@types/pg": "^8.20.0",
     "rimraf": "^6.0.1",
     "tsx": "^4.19.2",
     "typescript": "^5.7.3"

--- a/apps/flex-cli/src/cli.ts
+++ b/apps/flex-cli/src/cli.ts
@@ -78,6 +78,7 @@ switch (command) {
 Commands:
   discover        API 디스커버리 → api-catalog.json 생성
   crawl           카탈로그 기반 크롤링 → output/ 저장
+                  env: FLEX_HR_DIRECT_DUMP=true 이면 flex-hr DB/스토리지까지 직접 적재
   import          크롤링 결과(JSON) → SQLite DB 변환
   query "SQL"     DB 쿼리 실행 → JSON 출력 (read-only)
                   --file <path>  SQL 파일 경로

--- a/apps/flex-cli/src/commands/crawl.ts
+++ b/apps/flex-cli/src/commands/crawl.ts
@@ -27,6 +27,7 @@ interface DirectDumpContext {
   enabled: boolean;
   baseDir: string | null;
   keepScratch: boolean;
+  autoCreatedBaseDir: boolean;
 }
 
 export async function runCrawl(): Promise<void> {
@@ -148,7 +149,13 @@ export async function runCrawl(): Promise<void> {
     await cleanup(authCtx);
   }
 
-  if (directDump.enabled && directDump.baseDir && !directDump.keepScratch && allErrors.length === 0) {
+  if (
+    directDump.enabled &&
+    directDump.baseDir &&
+    directDump.autoCreatedBaseDir &&
+    !directDump.keepScratch &&
+    allErrors.length === 0
+  ) {
     await rm(directDump.baseDir, { recursive: true, force: true }).catch(() => undefined);
   }
 
@@ -258,7 +265,7 @@ async function runCrawlForCustomer(
           config,
           logger,
         });
-        if (directDump.baseDir && !directDump.keepScratch) {
+        if (directDump.baseDir && directDump.autoCreatedBaseDir && !directDump.keepScratch) {
           await rm(customerOutputDir, { recursive: true, force: true }).catch(() => undefined);
         }
       } catch (error) {
@@ -283,18 +290,18 @@ async function runCrawlForCustomer(
 
 function createDirectDumpContext(config: Config): DirectDumpContext {
   if (!config.flexHrDirectDump) {
-    return { enabled: false, baseDir: null, keepScratch: true };
+    return { enabled: false, baseDir: null, keepScratch: true, autoCreatedBaseDir: false };
   }
-
-  const configuredBase =
-    config.flexHrScratchRoot.trim().length > 0
-      ? path.resolve(config.flexHrScratchRoot)
-      : path.join(os.tmpdir(), `flex-ax-flex-hr-dump-${Date.now()}`);
+  const timestampedDir = `flex-ax-flex-hr-dump-${Date.now()}`;
+  const configuredBase = config.flexHrScratchRoot.trim().length > 0
+    ? path.join(path.resolve(config.flexHrScratchRoot), timestampedDir)
+    : path.join(os.tmpdir(), timestampedDir);
 
   return {
     enabled: true,
     baseDir: configuredBase,
     keepScratch: config.flexHrKeepScratch,
+    autoCreatedBaseDir: true,
   };
 }
 

--- a/apps/flex-cli/src/commands/crawl.ts
+++ b/apps/flex-cli/src/commands/crawl.ts
@@ -1,4 +1,6 @@
 import path from "node:path";
+import os from "node:os";
+import { rm } from "node:fs/promises";
 import { readFile } from "node:fs/promises";
 import { loadConfig, type Config } from "../config/index.js";
 import { createLogger, type Logger } from "../logger/index.js";
@@ -18,6 +20,14 @@ import { crawlAttendanceApprovals } from "../crawlers/attendance.js";
 import { crawlCatalogEndpoints } from "../crawlers/catalog-endpoints.js";
 import type { CrawlError } from "../types/common.js";
 import type { CrawlResult } from "../crawlers/shared.js";
+import { importToSqlite } from "../db/import.js";
+import { importCustomerToFlexHr } from "../flexhr/import.js";
+
+interface DirectDumpContext {
+  enabled: boolean;
+  baseDir: string | null;
+  keepScratch: boolean;
+}
 
 export async function runCrawl(): Promise<void> {
   const logger = createLogger("CRAWL");
@@ -86,6 +96,15 @@ export async function runCrawl(): Promise<void> {
     process.exit(1);
   }
 
+  const directDump = createDirectDumpContext(config);
+  if (directDump.enabled) {
+    logger.info("flex-hr direct dump 모드 활성화", {
+      scratchRoot: directDump.baseDir,
+      dryRun: config.flexHrImportDryRun,
+      storageBackend: config.storageBackend,
+    });
+  }
+
   logger.info("법인별 크롤링 시작", {
     count: corporations.length,
     names: corporations.map((c) => c.name),
@@ -122,11 +141,15 @@ export async function runCrawl(): Promise<void> {
         continue;
       }
 
-      const errors = await runCrawlForCustomer(authCtx, config, catalog, corp, logger);
+      const errors = await runCrawlForCustomer(authCtx, config, catalog, corp, logger, directDump);
       allErrors.push(...errors);
     }
   } finally {
     await cleanup(authCtx);
+  }
+
+  if (directDump.enabled && directDump.baseDir && !directDump.keepScratch && allErrors.length === 0) {
+    await rm(directDump.baseDir, { recursive: true, force: true }).catch(() => undefined);
   }
 
   if (allErrors.length > 0) {
@@ -143,8 +166,9 @@ async function runCrawlForCustomer(
   catalog: ApiCatalog | null,
   corp: Corporation,
   logger: Logger,
+  directDump: DirectDumpContext,
 ): Promise<CrawlError[]> {
-  const customerOutputDir = path.join(config.outputDir, corp.customerIdHash);
+  const customerOutputDir = resolveCustomerOutputDir(config, corp.customerIdHash, directDump);
   const storage: StorageWriter = createStorageWriter(customerOutputDir, config.catalogPath);
 
   const startedAt = new Date().toISOString();
@@ -214,7 +238,75 @@ async function runCrawlForCustomer(
       `attendance=${attendanceResult.successCount}, endpoints=${catalogEndpointsResult.successCount}`,
   );
 
+  if (directDump.enabled) {
+    if (totalErrors.length > 0) {
+      logger.warn("크롤 오류가 있어 flex-hr direct dump를 스킵합니다", {
+        customerIdHash: corp.customerIdHash,
+        errors: totalErrors.length,
+      });
+    } else {
+      try {
+        const dbPath = path.join(customerOutputDir, "flex-ax.db");
+        logger.info("flex-hr direct dump 준비: SQLite 생성", {
+          customerIdHash: corp.customerIdHash,
+          dbPath,
+        });
+        await importToSqlite(customerOutputDir, dbPath, logger);
+        await importCustomerToFlexHr({
+          sourceDir: customerOutputDir,
+          customerIdHash: corp.customerIdHash,
+          config,
+          logger,
+        });
+        if (directDump.baseDir && !directDump.keepScratch) {
+          await rm(customerOutputDir, { recursive: true, force: true }).catch(() => undefined);
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        logger.error("flex-hr direct dump 실패", {
+          customerIdHash: corp.customerIdHash,
+          outputDir: customerOutputDir,
+          error: message,
+        });
+        totalErrors.push({
+          target: `customer:${corp.customerIdHash}`,
+          phase: "flex-hr-direct-dump",
+          message,
+          timestamp: new Date().toISOString(),
+        });
+      }
+    }
+  }
+
   return totalErrors;
+}
+
+function createDirectDumpContext(config: Config): DirectDumpContext {
+  if (!config.flexHrDirectDump) {
+    return { enabled: false, baseDir: null, keepScratch: true };
+  }
+
+  const configuredBase =
+    config.flexHrScratchRoot.trim().length > 0
+      ? path.resolve(config.flexHrScratchRoot)
+      : path.join(os.tmpdir(), `flex-ax-flex-hr-dump-${Date.now()}`);
+
+  return {
+    enabled: true,
+    baseDir: configuredBase,
+    keepScratch: config.flexHrKeepScratch,
+  };
+}
+
+function resolveCustomerOutputDir(
+  config: Config,
+  customerIdHash: string,
+  directDump: DirectDumpContext,
+): string {
+  if (!directDump.enabled || !directDump.baseDir) {
+    return path.join(config.outputDir, customerIdHash);
+  }
+  return path.join(directDump.baseDir, customerIdHash);
 }
 
 /**

--- a/apps/flex-cli/src/config/index.ts
+++ b/apps/flex-cli/src/config/index.ts
@@ -48,6 +48,38 @@ const configSchema = z
           .map((s) => s.trim())
           .filter((s) => s.length > 0),
       ),
+    flexHrDirectDump: z
+      .enum(["true", "false"])
+      .transform((v) => v === "true")
+      .default("false"),
+    flexHrOwnerWallet: z.string().default(""),
+    flexHrWorkspaceName: z.string().default(""),
+    flexHrMemberWallets: z
+      .string()
+      .default("")
+      .transform((v) =>
+        v
+          .split(",")
+          .map((s) => s.trim())
+          .filter((s) => s.length > 0),
+      ),
+    flexHrImportParallel: z.coerce.number().int().min(1).default(8),
+    flexHrImportDryRun: z
+      .enum(["true", "false"])
+      .transform((v) => v === "true")
+      .default("false"),
+    flexHrKeepScratch: z
+      .enum(["true", "false"])
+      .transform((v) => v === "true")
+      .default("false"),
+    flexHrScratchRoot: z.string().default(""),
+    databaseUrl: z.string().default(""),
+    storageBackend: z.enum(["local", "r2"]).default("local"),
+    localUploadDir: z.string().default(".uploads"),
+    r2Endpoint: z.string().default(""),
+    r2AccessKeyId: z.string().default(""),
+    r2SecretAccessKey: z.string().default(""),
+    r2Bucket: z.string().default(""),
   });
 
 export type Config = z.infer<typeof configSchema>;
@@ -68,5 +100,20 @@ export function loadConfig(): Config {
     crawlSensitive: process.env.FLEX_CRAWL_SENSITIVE || undefined,
     skipEndpoints: process.env.FLEX_SKIP_ENDPOINTS || undefined,
     customers: process.env.FLEX_CUSTOMERS || undefined,
+    flexHrDirectDump: process.env.FLEX_HR_DIRECT_DUMP || undefined,
+    flexHrOwnerWallet: process.env.FLEX_HR_OWNER_WALLET || undefined,
+    flexHrWorkspaceName: process.env.FLEX_HR_WORKSPACE_NAME || undefined,
+    flexHrMemberWallets: process.env.FLEX_HR_MEMBER_WALLETS || undefined,
+    flexHrImportParallel: process.env.FLEX_HR_IMPORT_PARALLEL || undefined,
+    flexHrImportDryRun: process.env.FLEX_HR_IMPORT_DRY_RUN || undefined,
+    flexHrKeepScratch: process.env.FLEX_HR_KEEP_SCRATCH || undefined,
+    flexHrScratchRoot: process.env.FLEX_HR_SCRATCH_ROOT || undefined,
+    databaseUrl: process.env.DB_SETUP_URL || process.env.DATABASE_URL || undefined,
+    storageBackend: process.env.STORAGE_BACKEND || undefined,
+    localUploadDir: process.env.LOCAL_UPLOAD_DIR || undefined,
+    r2Endpoint: process.env.R2_ENDPOINT || undefined,
+    r2AccessKeyId: process.env.R2_ACCESS_KEY_ID || undefined,
+    r2SecretAccessKey: process.env.R2_SECRET_ACCESS_KEY || undefined,
+    r2Bucket: process.env.R2_BUCKET || undefined,
   });
 }

--- a/apps/flex-cli/src/flexhr/import.ts
+++ b/apps/flex-cli/src/flexhr/import.ts
@@ -86,57 +86,58 @@ export async function importCustomerToFlexHr({
   const dbPath = path.join(sourceDir, "flex-ax.db");
   const sqlite = new Database(dbPath, { readonly: true });
   const client = new pg.Client({ connectionString: config.databaseUrl });
-  await client.connect();
-
-  const storage = createFlexHrStorage(config);
-  if (config.flexHrImportDryRun) {
-    await validateStorageDryRun(storage, customerIdHash, logger);
-  }
-
-  let report: CrawlReport | null = null;
+  let storage: ReturnType<typeof createFlexHrStorage> | null = null;
   try {
-    report = JSON.parse(await readFile(path.join(sourceDir, "crawl-report.json"), "utf-8")) as CrawlReport;
-  } catch {
-    report = null;
-  }
-
-  const counters = {
-    workspacesInserted: 0,
-    workspacesExisting: 0,
-    membersInserted: 0,
-    membersExisting: 0,
-    employeesInserted: 0,
-    employeesExisting: 0,
-    botInserted: 0,
-    botExisting: 0,
-    formsInserted: 0,
-    formsExisting: 0,
-    approvalsInserted: 0,
-    approvalsExisting: 0,
-    filesConsidered: 0,
-    filesSkipped: 0,
-    filesFailed: 0,
-    filesR2Uploaded: 0,
-    filesR2Existing: 0,
-    filesDbInserted: 0,
-    filesDbExisting: 0,
-  };
-
-  const bump = (
-    result: pg.QueryResult,
-    insertedCounter: keyof typeof counters,
-    existingCounter: keyof typeof counters,
-  ): void => {
-    if (result.rowCount && result.rowCount > 0) {
-      counters[insertedCounter]++;
-    } else {
-      counters[existingCounter]++;
+    await client.connect();
+    storage = createFlexHrStorage(config);
+    if (config.flexHrImportDryRun) {
+      await validateStorageDryRun(storage, customerIdHash, logger);
     }
-  };
 
-  let metadataCommitted = false;
-  try {
-    await client.query("BEGIN");
+    let report: CrawlReport | null = null;
+    try {
+      report = JSON.parse(await readFile(path.join(sourceDir, "crawl-report.json"), "utf-8")) as CrawlReport;
+    } catch {
+      report = null;
+    }
+
+    const counters = {
+      workspacesInserted: 0,
+      workspacesExisting: 0,
+      membersInserted: 0,
+      membersExisting: 0,
+      employeesInserted: 0,
+      employeesExisting: 0,
+      botInserted: 0,
+      botExisting: 0,
+      formsInserted: 0,
+      formsExisting: 0,
+      approvalsInserted: 0,
+      approvalsExisting: 0,
+      filesConsidered: 0,
+      filesSkipped: 0,
+      filesFailed: 0,
+      filesR2Uploaded: 0,
+      filesR2Existing: 0,
+      filesDbInserted: 0,
+      filesDbExisting: 0,
+    };
+
+    const bump = (
+      result: pg.QueryResult,
+      insertedCounter: keyof typeof counters,
+      existingCounter: keyof typeof counters,
+    ): void => {
+      if (result.rowCount && result.rowCount > 0) {
+        counters[insertedCounter]++;
+      } else {
+        counters[existingCounter]++;
+      }
+    };
+
+    let metadataCommitted = false;
+    try {
+      await client.query("BEGIN");
 
     await client.query(
       `INSERT INTO accounts (wallet_address, display_name) VALUES ($1, NULL)
@@ -357,6 +358,7 @@ export async function importCustomerToFlexHr({
       });
       return;
     }
+    const activeStorage = storage;
 
     const fileRows = sqlite
       .prepare(
@@ -371,7 +373,8 @@ export async function importCustomerToFlexHr({
     const deriveInstanceId = (row: FileRow): string | null => {
       if (row.instance_id) return row.instance_id;
       if (!row.local_path) return null;
-      const match = row.local_path.match(/(?:^|\/)attachments\/([^/]+)\//);
+      const normalizedLocalPath = normalizeLocalPath(row.local_path);
+      const match = normalizedLocalPath.match(/(?:^|\/)attachments\/([^/]+)\//);
       if (match && instanceIds.has(match[1])) return match[1];
       return null;
     };
@@ -408,7 +411,8 @@ export async function importCustomerToFlexHr({
             return null;
           }
 
-          const match = file.local_path.match(/(?:^|\/)(attachments|templates|instances)\/(.+)$/);
+          const normalizedLocalPath = normalizeLocalPath(file.local_path);
+          const match = normalizedLocalPath.match(/(?:^|\/)(attachments|templates|instances)\/(.+)$/);
           if (!match) {
             throw new Error(`local_path outside known subdirs: ${file.local_path}`);
           }
@@ -422,14 +426,14 @@ export async function importCustomerToFlexHr({
           let fileSize = file.file_size ?? 0;
           const mime = guessMime(file.file_name, file.mime_type);
 
-          const head = await storage.head(storageKey);
+          const head = await activeStorage.head(storageKey);
           if (head.exists) {
             fileSize = head.size ?? fileSize;
             counters.filesR2Existing++;
           } else {
             const fileStat = await stat(absolutePath);
             fileSize = fileStat.size;
-            await storage.put(storageKey, createReadStream(absolutePath), {
+            await activeStorage.put(storageKey, createReadStream(absolutePath), {
               contentType: mime,
               contentLength: fileSize,
             });
@@ -481,20 +485,21 @@ export async function importCustomerToFlexHr({
       }
     }
 
-    logger.info("flex-hr direct dump 완료", {
-      customerIdHash,
-      workspaceName,
-      templates: report?.templates?.totalCount ?? templates.length,
-      instances: report?.instances?.totalCount ?? instances.length,
-      filesUploaded: counters.filesR2Uploaded,
-      filesExisting: counters.filesR2Existing,
-      filesFailed: counters.filesFailed,
-    });
-  } catch (error) {
-    if (!metadataCommitted) {
-      await client.query("ROLLBACK").catch(() => undefined);
+      logger.info("flex-hr direct dump 완료", {
+        customerIdHash,
+        workspaceName,
+        templates: report?.templates?.totalCount ?? templates.length,
+        instances: report?.instances?.totalCount ?? instances.length,
+        filesUploaded: counters.filesR2Uploaded,
+        filesExisting: counters.filesR2Existing,
+        filesFailed: counters.filesFailed,
+      });
+    } catch (error) {
+      if (!metadataCommitted) {
+        await client.query("ROLLBACK").catch(() => undefined);
+      }
+      throw error;
     }
-    throw error;
   } finally {
     sqlite.close();
     await client.end();
@@ -524,12 +529,19 @@ async function validateStorageDryRun(
   logger: Logger,
 ): Promise<void> {
   const probeKey = `${customerIdHash}/__dry_run_probe__/${Date.now()}`;
-  await storage.head(probeKey);
+  await storage.put(probeKey, Buffer.from("dry-run"), {
+    contentType: "text/plain",
+    contentLength: Buffer.byteLength("dry-run"),
+  });
   logger.info("flex-hr storage dry-run 검증 완료", {
     customerIdHash,
     storageBackend: storage.backend,
     probe: probeKey,
   });
+}
+
+function normalizeLocalPath(localPath: string): string {
+  return path.posix.normalize(localPath.replace(/\\+/g, "/"));
 }
 
 function mapApprovalStatus(status: string | null): string {

--- a/apps/flex-cli/src/flexhr/import.ts
+++ b/apps/flex-cli/src/flexhr/import.ts
@@ -118,8 +118,8 @@ export async function importCustomerToFlexHr({
       filesConsidered: 0,
       filesSkipped: 0,
       filesFailed: 0,
-      filesR2Uploaded: 0,
-      filesR2Existing: 0,
+      filesStorageUploaded: 0,
+      filesStorageExisting: 0,
       filesDbInserted: 0,
       filesDbExisting: 0,
     };
@@ -437,7 +437,7 @@ export async function importCustomerToFlexHr({
           const head = await activeStorage.head(storageKey);
           if (head.exists) {
             fileSize = head.size ?? fileSize;
-            counters.filesR2Existing++;
+            counters.filesStorageExisting++;
           } else {
             const fileStat = await stat(absolutePath);
             fileSize = fileStat.size;
@@ -445,7 +445,7 @@ export async function importCustomerToFlexHr({
               contentType: mime,
               contentLength: fileSize,
             });
-            counters.filesR2Uploaded++;
+            counters.filesStorageUploaded++;
           }
 
           const drafterId = file.instance_id ? instanceDrafter.get(file.instance_id) : null;
@@ -498,8 +498,8 @@ export async function importCustomerToFlexHr({
         workspaceName,
         templates: report?.templates?.totalCount ?? templates.length,
         instances: report?.instances?.totalCount ?? instances.length,
-        filesUploaded: counters.filesR2Uploaded,
-        filesExisting: counters.filesR2Existing,
+        filesUploaded: counters.filesStorageUploaded,
+        filesExisting: counters.filesStorageExisting,
         filesFailed: counters.filesFailed,
       });
     } catch (error) {
@@ -509,6 +509,9 @@ export async function importCustomerToFlexHr({
       }
       throw importError;
     }
+  } catch (error) {
+    importError = error instanceof Error ? error : new Error(String(error));
+    throw importError;
   } finally {
     let cleanupError: Error | null = null;
     try {

--- a/apps/flex-cli/src/flexhr/import.ts
+++ b/apps/flex-cli/src/flexhr/import.ts
@@ -87,6 +87,7 @@ export async function importCustomerToFlexHr({
   const sqlite = new Database(dbPath, { readonly: true });
   const client = new pg.Client({ connectionString: config.databaseUrl });
   let storage: ReturnType<typeof createFlexHrStorage> | null = null;
+  let importError: Error | null = null;
   try {
     await client.connect();
     storage = createFlexHrStorage(config);
@@ -174,7 +175,14 @@ export async function importCustomerToFlexHr({
     await client.query(
       `INSERT INTO workspaces (id, owner_wallet, name, slug, business_number, address, phone)
        VALUES ($1, $2, $3, $4, $5, $6, $7)
-       ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name, updated_at = now()`,
+       ON CONFLICT (id) DO UPDATE SET
+         owner_wallet = EXCLUDED.owner_wallet,
+         name = EXCLUDED.name,
+         slug = EXCLUDED.slug,
+         business_number = EXCLUDED.business_number,
+         address = EXCLUDED.address,
+         phone = EXCLUDED.phone,
+         updated_at = now()`,
       [
         customerIdHash,
         config.flexHrOwnerWallet,
@@ -495,14 +503,29 @@ export async function importCustomerToFlexHr({
         filesFailed: counters.filesFailed,
       });
     } catch (error) {
+      importError = error instanceof Error ? error : new Error(String(error));
       if (!metadataCommitted) {
         await client.query("ROLLBACK").catch(() => undefined);
       }
-      throw error;
+      throw importError;
     }
   } finally {
-    sqlite.close();
-    await client.end();
+    let cleanupError: Error | null = null;
+    try {
+      sqlite.close();
+    } catch (error) {
+      cleanupError = error instanceof Error ? error : new Error(String(error));
+    }
+    try {
+      await client.end();
+    } catch (error) {
+      if (!cleanupError) {
+        cleanupError = error instanceof Error ? error : new Error(String(error));
+      }
+    }
+    if (cleanupError && !importError) {
+      throw cleanupError;
+    }
   }
 }
 
@@ -528,11 +551,12 @@ async function validateStorageDryRun(
   customerIdHash: string,
   logger: Logger,
 ): Promise<void> {
-  const probeKey = `${customerIdHash}/__dry_run_probe__/${Date.now()}`;
+  const probeKey = `${customerIdHash}/__dry_run_probe__`;
   await storage.put(probeKey, Buffer.from("dry-run"), {
     contentType: "text/plain",
     contentLength: Buffer.byteLength("dry-run"),
   });
+  await storage.delete(probeKey).catch(() => undefined);
   logger.info("flex-hr storage dry-run 검증 완료", {
     customerIdHash,
     storageBackend: storage.backend,

--- a/apps/flex-cli/src/flexhr/import.ts
+++ b/apps/flex-cli/src/flexhr/import.ts
@@ -1,0 +1,586 @@
+import { createReadStream } from "node:fs";
+import { readFile, stat } from "node:fs/promises";
+import path from "node:path";
+import Database from "better-sqlite3";
+import pg from "pg";
+import type { Config } from "../config/index.js";
+import type { Logger } from "../logger/index.js";
+import { createFlexHrStorage } from "./storage.js";
+
+const WALLET_RE = /^0x[0-9a-fA-F]{40}$/;
+
+const STATUS_MAP: Record<string, string> = {
+  DONE: "APPROVED",
+  APPROVED: "APPROVED",
+  COMPLETED: "APPROVED",
+  IN_PROGRESS: "PENDING",
+  PENDING: "PENDING",
+  WAITING: "PENDING",
+  DECLINED: "REJECTED",
+  REJECTED: "REJECTED",
+  CANCELLED: "CANCELLED",
+  CANCELED: "CANCELLED",
+  DRAFT: "DRAFT",
+};
+
+const EXT_MIME: Record<string, string> = {
+  pdf: "application/pdf",
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  svg: "image/svg+xml",
+  txt: "text/plain",
+  csv: "text/csv",
+  html: "text/html",
+  doc: "application/msword",
+  docx: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  xls: "application/vnd.ms-excel",
+  xlsx: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  ppt: "application/vnd.ms-powerpoint",
+  pptx: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  zip: "application/zip",
+  json: "application/json",
+  hwp: "application/x-hwp",
+  hwpx: "application/x-hwpx",
+};
+
+interface ImportCustomerOptions {
+  sourceDir: string;
+  customerIdHash: string;
+  config: Config;
+  logger: Logger;
+}
+
+interface CrawlReport {
+  templates?: { totalCount?: number };
+  instances?: { totalCount?: number };
+}
+
+interface FileRow {
+  file_key: string;
+  file_name: string | null;
+  local_path: string | null;
+  file_size: number | null;
+  mime_type: string | null;
+  instance_id: string | null;
+}
+
+interface UploadOutcome {
+  file: FileRow;
+  key: string;
+  size: number;
+  mime: string;
+  uploaderId: string;
+}
+
+export async function importCustomerToFlexHr({
+  sourceDir,
+  customerIdHash,
+  config,
+  logger,
+}: ImportCustomerOptions): Promise<void> {
+  validateDirectDumpConfig(config);
+
+  const dbPath = path.join(sourceDir, "flex-ax.db");
+  const sqlite = new Database(dbPath, { readonly: true });
+  const client = new pg.Client({ connectionString: config.databaseUrl });
+  await client.connect();
+
+  const storage = createFlexHrStorage(config);
+  if (config.flexHrImportDryRun) {
+    await validateStorageDryRun(storage, customerIdHash, logger);
+  }
+
+  let report: CrawlReport | null = null;
+  try {
+    report = JSON.parse(await readFile(path.join(sourceDir, "crawl-report.json"), "utf-8")) as CrawlReport;
+  } catch {
+    report = null;
+  }
+
+  const counters = {
+    workspacesInserted: 0,
+    workspacesExisting: 0,
+    membersInserted: 0,
+    membersExisting: 0,
+    employeesInserted: 0,
+    employeesExisting: 0,
+    botInserted: 0,
+    botExisting: 0,
+    formsInserted: 0,
+    formsExisting: 0,
+    approvalsInserted: 0,
+    approvalsExisting: 0,
+    filesConsidered: 0,
+    filesSkipped: 0,
+    filesFailed: 0,
+    filesR2Uploaded: 0,
+    filesR2Existing: 0,
+    filesDbInserted: 0,
+    filesDbExisting: 0,
+  };
+
+  const bump = (
+    result: pg.QueryResult,
+    insertedCounter: keyof typeof counters,
+    existingCounter: keyof typeof counters,
+  ): void => {
+    if (result.rowCount && result.rowCount > 0) {
+      counters[insertedCounter]++;
+    } else {
+      counters[existingCounter]++;
+    }
+  };
+
+  let metadataCommitted = false;
+  try {
+    await client.query("BEGIN");
+
+    await client.query(
+      `INSERT INTO accounts (wallet_address, display_name) VALUES ($1, NULL)
+       ON CONFLICT (wallet_address) DO NOTHING`,
+      [config.flexHrOwnerWallet],
+    );
+
+    const sqliteCustomer = sqlite.prepare("SELECT * FROM customers LIMIT 1").get() as
+      | {
+          name?: string;
+          business_reg_number?: string;
+          phone_number?: string;
+          address_full?: string;
+        }
+      | undefined;
+
+    const workspaceName =
+      config.flexHrWorkspaceName || sqliteCustomer?.name || `Flex Workspace ${customerIdHash}`;
+    const workspaceSlug = `flex-${customerIdHash.toLowerCase()}`;
+
+    const slugOwner = await client.query<{ id: string }>(
+      "SELECT id FROM workspaces WHERE slug = $1 AND id <> $2",
+      [workspaceSlug, customerIdHash],
+    );
+    if (slugOwner.rowCount && slugOwner.rowCount > 0) {
+      throw new Error(
+        `slug "${workspaceSlug}" is already used by workspace ${slugOwner.rows[0].id}`,
+      );
+    }
+
+    const workspaceExisted = await client.query("SELECT 1 FROM workspaces WHERE id = $1", [
+      customerIdHash,
+    ]);
+    await client.query(
+      `INSERT INTO workspaces (id, owner_wallet, name, slug, business_number, address, phone)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name, updated_at = now()`,
+      [
+        customerIdHash,
+        config.flexHrOwnerWallet,
+        workspaceName,
+        workspaceSlug,
+        sqliteCustomer?.business_reg_number ?? null,
+        sqliteCustomer?.address_full ?? null,
+        sqliteCustomer?.phone_number ?? null,
+      ],
+    );
+    if (workspaceExisted.rowCount && workspaceExisted.rowCount > 0) {
+      counters.workspacesExisting++;
+    } else {
+      counters.workspacesInserted++;
+    }
+
+    for (const memberWallet of config.flexHrMemberWallets) {
+      if (memberWallet === config.flexHrOwnerWallet) continue;
+      await client.query(
+        `INSERT INTO accounts (wallet_address, display_name) VALUES ($1, NULL)
+         ON CONFLICT (wallet_address) DO NOTHING`,
+        [memberWallet],
+      );
+      const result = await client.query(
+        `INSERT INTO workspace_members (workspace_id, wallet_address, role)
+         VALUES ($1, $2, 'member')
+         ON CONFLICT DO NOTHING`,
+        [customerIdHash, memberWallet],
+      );
+      bump(result, "membersInserted", "membersExisting");
+    }
+
+    const employeeId = (rawUserId: string) => `${customerIdHash}:${rawUserId}`;
+    const upsertEmployee = async (
+      id: string,
+      employeeNumber: string,
+      name: string,
+      status: "ACTIVE" | "SYSTEM",
+    ): Promise<pg.QueryResult> => {
+      const result = await client.query(
+        `INSERT INTO employees (id, workspace_id, employee_number, name, status)
+         VALUES ($1, $2, $3, $4, $5)
+         ON CONFLICT DO NOTHING`,
+        [id, customerIdHash, employeeNumber, name, status],
+      );
+      if (!result.rowCount) {
+        const ok = await client.query(
+          "SELECT 1 FROM employees WHERE id = $1 AND workspace_id = $2",
+          [id, customerIdHash],
+        );
+        if (!ok.rowCount) {
+          throw new Error(`employee upsert conflict: ${id}`);
+        }
+      }
+      return result;
+    };
+
+    const users = sqlite.prepare("SELECT id, name FROM users").all() as { id: string; name: string }[];
+    for (const user of users) {
+      const result = await upsertEmployee(
+        employeeId(user.id),
+        `FLEX-${user.id}`,
+        user.name || user.id,
+        "ACTIVE",
+      );
+      bump(result, "employeesInserted", "employeesExisting");
+    }
+
+    const botId = `SYSTEM-FLEX-IMPORT-${customerIdHash}`;
+    const botResult = await upsertEmployee(
+      botId,
+      "__flex_import__",
+      "Flex Import Bot",
+      "SYSTEM",
+    );
+    bump(botResult, "botInserted", "botExisting");
+
+    const templates = sqlite.prepare("SELECT id, name, category, raw FROM templates").all() as {
+      id: string;
+      name: string;
+      category: string | null;
+      raw: string | null;
+    }[];
+    for (const template of templates) {
+      let fields: unknown = [];
+      if (template.raw) {
+        try {
+          fields = JSON.parse(template.raw)?.detail?.inputFields ?? [];
+        } catch {
+          fields = [];
+        }
+      }
+      const result = await client.query(
+        `INSERT INTO approval_forms (id, workspace_id, name, category, fields)
+         VALUES ($1, $2, $3, $4, $5::jsonb)
+         ON CONFLICT DO NOTHING`,
+        [
+          template.id,
+          customerIdHash,
+          template.name,
+          template.category ?? "Uncategorized",
+          JSON.stringify(fields),
+        ],
+      );
+      if (!result.rowCount) {
+        const ok = await client.query(
+          "SELECT 1 FROM approval_forms WHERE id = $1 AND workspace_id = $2",
+          [template.id, customerIdHash],
+        );
+        if (!ok.rowCount) {
+          throw new Error(`approval form upsert conflict: ${template.id}`);
+        }
+      }
+      bump(result, "formsInserted", "formsExisting");
+    }
+
+    const instances = sqlite
+      .prepare(
+        "SELECT id, document_number, template_id, drafter_id, drafted_at, status, content_html, raw FROM instances",
+      )
+      .all() as {
+      id: string;
+      document_number: string;
+      template_id: string;
+      drafter_id: string | null;
+      drafted_at: string;
+      status: string;
+      content_html: string | null;
+      raw: string | null;
+    }[];
+
+    const knownUserIds = new Set(users.map((user) => user.id));
+    for (const instance of instances) {
+      if (instance.drafter_id && !knownUserIds.has(instance.drafter_id)) {
+        const result = await upsertEmployee(
+          employeeId(instance.drafter_id),
+          `FLEX-${instance.drafter_id}`,
+          instance.drafter_id,
+          "ACTIVE",
+        );
+        knownUserIds.add(instance.drafter_id);
+        bump(result, "employeesInserted", "employeesExisting");
+      }
+    }
+
+    for (const instance of instances) {
+      const requesterId = instance.drafter_id ? employeeId(instance.drafter_id) : botId;
+      const result = await client.query(
+        `INSERT INTO approvals
+          (id, workspace_id, requester_id, form_id, type, title, content, status, form_data, created_at, updated_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8::approval_status, $9::jsonb, $10, $10)
+         ON CONFLICT DO NOTHING`,
+        [
+          instance.id,
+          customerIdHash,
+          requesterId,
+          instance.template_id,
+          "FLEX_WORKFLOW",
+          titleFromRaw(instance.raw, instance.document_number || instance.id),
+          instance.content_html,
+          mapApprovalStatus(instance.status),
+          safeJson(instance.raw),
+          instance.drafted_at,
+        ],
+      );
+      bump(result, "approvalsInserted", "approvalsExisting");
+    }
+
+    if (config.flexHrImportDryRun) {
+      await client.query("ROLLBACK");
+    } else {
+      await client.query("COMMIT");
+      metadataCommitted = true;
+    }
+
+    if (config.flexHrImportDryRun) {
+      logger.info("flex-hr direct dump dry-run 완료", {
+        customerIdHash,
+        workspaceName,
+        storageBackend: storage.backend,
+      });
+      return;
+    }
+
+    const fileRows = sqlite
+      .prepare(
+        `SELECT f.file_key, f.file_name, f.local_path, f.file_size, f.mime_type,
+                a.instance_id
+         FROM files f
+         LEFT JOIN attachments a ON a.file_key = f.file_key`,
+      )
+      .all() as FileRow[];
+
+    const instanceIds = new Set(instances.map((instance) => instance.id));
+    const deriveInstanceId = (row: FileRow): string | null => {
+      if (row.instance_id) return row.instance_id;
+      if (!row.local_path) return null;
+      const match = row.local_path.match(/(?:^|\/)attachments\/([^/]+)\//);
+      if (match && instanceIds.has(match[1])) return match[1];
+      return null;
+    };
+
+    const byKey = new Map<string, FileRow>();
+    for (const row of fileRows) {
+      const previous = byKey.get(row.file_key);
+      if (!previous || (!previous.instance_id && row.instance_id)) {
+        byKey.set(row.file_key, row);
+      }
+    }
+    for (const [key, row] of byKey) {
+      if (!row.instance_id) {
+        byKey.set(key, { ...row, instance_id: deriveInstanceId(row) });
+      }
+    }
+
+    const files = Array.from(byKey.values());
+    counters.filesConsidered = files.length;
+
+    const instanceDrafter = new Map<string, string | null>();
+    for (const instance of instances) {
+      instanceDrafter.set(instance.id, instance.drafter_id);
+    }
+
+    const sourceRoot = path.resolve(sourceDir);
+    const uploadOutcomes = await mapConcurrent(
+      files,
+      config.flexHrImportParallel,
+      async (file): Promise<UploadOutcome | null> => {
+        try {
+          if (!file.local_path) {
+            counters.filesSkipped++;
+            return null;
+          }
+
+          const match = file.local_path.match(/(?:^|\/)(attachments|templates|instances)\/(.+)$/);
+          if (!match) {
+            throw new Error(`local_path outside known subdirs: ${file.local_path}`);
+          }
+
+          const absolutePath = path.resolve(sourceRoot, `${match[1]}/${match[2]}`);
+          if (absolutePath !== sourceRoot && !absolutePath.startsWith(sourceRoot + path.sep)) {
+            throw new Error(`path escapes source directory: ${file.local_path}`);
+          }
+
+          const storageKey = `${customerIdHash}/files/${file.file_key}`;
+          let fileSize = file.file_size ?? 0;
+          const mime = guessMime(file.file_name, file.mime_type);
+
+          const head = await storage.head(storageKey);
+          if (head.exists) {
+            fileSize = head.size ?? fileSize;
+            counters.filesR2Existing++;
+          } else {
+            const fileStat = await stat(absolutePath);
+            fileSize = fileStat.size;
+            await storage.put(storageKey, createReadStream(absolutePath), {
+              contentType: mime,
+              contentLength: fileSize,
+            });
+            counters.filesR2Uploaded++;
+          }
+
+          const drafterId = file.instance_id ? instanceDrafter.get(file.instance_id) : null;
+          return {
+            file,
+            key: storageKey,
+            size: fileSize,
+            mime,
+            uploaderId: drafterId ? employeeId(drafterId) : botId,
+          };
+        } catch (error) {
+          counters.filesFailed++;
+          logger.error("파일 업로드 실패", {
+            customerIdHash,
+            fileKey: file.file_key,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          return null;
+        }
+      },
+    );
+
+    for (const outcome of uploadOutcomes) {
+      if (!outcome) continue;
+      const result = await client.query(
+        `INSERT INTO file_uploads
+          (workspace_id, uploaded_by_id, approval_id, file_name, original_name, mime_type, size, path, access_level)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'WORKSPACE')
+         ON CONFLICT (workspace_id, path) DO NOTHING`,
+        [
+          customerIdHash,
+          outcome.uploaderId,
+          outcome.file.instance_id ?? null,
+          outcome.file.file_name ?? outcome.file.file_key,
+          outcome.file.file_name ?? outcome.file.file_key,
+          outcome.mime,
+          outcome.size,
+          outcome.key,
+        ],
+      );
+      if (result.rowCount && result.rowCount > 0) {
+        counters.filesDbInserted++;
+      } else {
+        counters.filesDbExisting++;
+      }
+    }
+
+    logger.info("flex-hr direct dump 완료", {
+      customerIdHash,
+      workspaceName,
+      templates: report?.templates?.totalCount ?? templates.length,
+      instances: report?.instances?.totalCount ?? instances.length,
+      filesUploaded: counters.filesR2Uploaded,
+      filesExisting: counters.filesR2Existing,
+      filesFailed: counters.filesFailed,
+    });
+  } catch (error) {
+    if (!metadataCommitted) {
+      await client.query("ROLLBACK").catch(() => undefined);
+    }
+    throw error;
+  } finally {
+    sqlite.close();
+    await client.end();
+  }
+}
+
+function validateDirectDumpConfig(config: Config): void {
+  if (!config.flexHrOwnerWallet) {
+    throw new Error("FLEX_HR_OWNER_WALLET is required when FLEX_HR_DIRECT_DUMP=true");
+  }
+  if (!WALLET_RE.test(config.flexHrOwnerWallet)) {
+    throw new Error("FLEX_HR_OWNER_WALLET must be a 0x-prefixed 40 hex wallet address");
+  }
+  for (const memberWallet of config.flexHrMemberWallets) {
+    if (!WALLET_RE.test(memberWallet)) {
+      throw new Error(`FLEX_HR_MEMBER_WALLETS contains an invalid wallet address: ${memberWallet}`);
+    }
+  }
+  if (!config.databaseUrl) {
+    throw new Error("DATABASE_URL or DB_SETUP_URL is required when FLEX_HR_DIRECT_DUMP=true");
+  }
+}
+
+async function validateStorageDryRun(
+  storage: ReturnType<typeof createFlexHrStorage>,
+  customerIdHash: string,
+  logger: Logger,
+): Promise<void> {
+  const probeKey = `${customerIdHash}/__dry_run_probe__/${Date.now()}`;
+  await storage.head(probeKey);
+  logger.info("flex-hr storage dry-run 검증 완료", {
+    customerIdHash,
+    storageBackend: storage.backend,
+    probe: probeKey,
+  });
+}
+
+function mapApprovalStatus(status: string | null): string {
+  if (!status) return "PENDING";
+  return STATUS_MAP[status.toUpperCase()] ?? "PENDING";
+}
+
+function guessMime(fileName: string | null, existing: string | null): string {
+  if (existing) return existing;
+  if (!fileName) return "application/octet-stream";
+  const ext = fileName.split(".").pop()?.toLowerCase() ?? "";
+  return EXT_MIME[ext] ?? "application/octet-stream";
+}
+
+function titleFromRaw(raw: string | null, fallback: string): string {
+  if (!raw) return fallback;
+  try {
+    const parsed = JSON.parse(raw) as { document?: { title?: unknown } };
+    if (typeof parsed.document?.title === "string" && parsed.document.title.trim()) {
+      return parsed.document.title.trim();
+    }
+  } catch {
+    return fallback;
+  }
+  return fallback;
+}
+
+function safeJson(raw: string | null): string {
+  if (!raw) return "{}";
+  try {
+    JSON.parse(raw);
+    return raw;
+  } catch {
+    return "{}";
+  }
+}
+
+async function mapConcurrent<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const output = new Array<R>(items.length);
+  let cursor = 0;
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (true) {
+      const index = cursor++;
+      if (index >= items.length) return;
+      output[index] = await fn(items[index], index);
+    }
+  });
+  await Promise.all(workers);
+  return output;
+}

--- a/apps/flex-cli/src/flexhr/import.ts
+++ b/apps/flex-cli/src/flexhr/import.ts
@@ -409,6 +409,7 @@ export async function importCustomerToFlexHr({
     }
 
     const sourceRoot = path.resolve(sourceDir);
+    const uploadFailures: string[] = [];
     const uploadOutcomes = await mapConcurrent(
       files,
       config.flexHrImportParallel,
@@ -458,10 +459,12 @@ export async function importCustomerToFlexHr({
           };
         } catch (error) {
           counters.filesFailed++;
+          const message = error instanceof Error ? error.message : String(error);
+          uploadFailures.push(`${file.file_key}: ${message}`);
           logger.error("파일 업로드 실패", {
             customerIdHash,
             fileKey: file.file_key,
-            error: error instanceof Error ? error.message : String(error),
+            error: message,
           });
           return null;
         }
@@ -493,15 +496,21 @@ export async function importCustomerToFlexHr({
       }
     }
 
-      logger.info("flex-hr direct dump 완료", {
-        customerIdHash,
-        workspaceName,
-        templates: report?.templates?.totalCount ?? templates.length,
-        instances: report?.instances?.totalCount ?? instances.length,
-        filesUploaded: counters.filesStorageUploaded,
-        filesExisting: counters.filesStorageExisting,
-        filesFailed: counters.filesFailed,
-      });
+    if (uploadFailures.length > 0) {
+      throw new Error(
+        `file upload phase failed for ${uploadFailures.length} file(s); first failure: ${uploadFailures[0]}`,
+      );
+    }
+
+    logger.info("flex-hr direct dump 완료", {
+      customerIdHash,
+      workspaceName,
+      templates: report?.templates?.totalCount ?? templates.length,
+      instances: report?.instances?.totalCount ?? instances.length,
+      filesUploaded: counters.filesStorageUploaded,
+      filesExisting: counters.filesStorageExisting,
+      filesFailed: counters.filesFailed,
+    });
     } catch (error) {
       importError = error instanceof Error ? error : new Error(String(error));
       if (!metadataCommitted) {

--- a/apps/flex-cli/src/flexhr/storage.ts
+++ b/apps/flex-cli/src/flexhr/storage.ts
@@ -2,7 +2,12 @@ import { promises as fs, createWriteStream } from "node:fs";
 import path from "node:path";
 import { Readable, pipeline } from "node:stream";
 import { promisify } from "node:util";
-import { HeadObjectCommand, PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import {
+  DeleteObjectCommand,
+  HeadObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
 import type { Config } from "../config/index.js";
 
 const pipelineP = promisify(pipeline);
@@ -24,6 +29,7 @@ export interface FlexHrStorage {
   backend: "local" | "r2";
   put(key: string, body: PutBody, opts?: PutOptions): Promise<void>;
   head(key: string): Promise<HeadResult>;
+  delete(key: string): Promise<void>;
 }
 
 function createR2Storage(config: Config): FlexHrStorage {
@@ -78,6 +84,11 @@ function createR2Storage(config: Config): FlexHrStorage {
         throw error;
       }
     },
+    async delete(key) {
+      await client.send(
+        new DeleteObjectCommand({ Bucket: config.r2Bucket, Key: key }),
+      );
+    },
   };
 }
 
@@ -115,6 +126,16 @@ function createLocalStorage(root: string): FlexHrStorage {
       } catch (error) {
         if ((error as NodeJS.ErrnoException)?.code === "ENOENT") {
           return { exists: false };
+        }
+        throw error;
+      }
+    },
+    async delete(key) {
+      try {
+        await fs.unlink(resolveKey(key));
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException)?.code === "ENOENT") {
+          return;
         }
         throw error;
       }

--- a/apps/flex-cli/src/flexhr/storage.ts
+++ b/apps/flex-cli/src/flexhr/storage.ts
@@ -1,0 +1,130 @@
+import { promises as fs, createWriteStream } from "node:fs";
+import path from "node:path";
+import { Readable, pipeline } from "node:stream";
+import { promisify } from "node:util";
+import { HeadObjectCommand, PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import type { Config } from "../config/index.js";
+
+const pipelineP = promisify(pipeline);
+
+export interface HeadResult {
+  exists: boolean;
+  size?: number;
+  contentType?: string;
+}
+
+export type PutBody = Buffer | Uint8Array | string | Readable;
+
+export interface PutOptions {
+  contentType?: string;
+  contentLength?: number;
+}
+
+export interface FlexHrStorage {
+  backend: "local" | "r2";
+  put(key: string, body: PutBody, opts?: PutOptions): Promise<void>;
+  head(key: string): Promise<HeadResult>;
+}
+
+function createR2Storage(config: Config): FlexHrStorage {
+  if (
+    !config.r2Endpoint ||
+    !config.r2AccessKeyId ||
+    !config.r2SecretAccessKey ||
+    !config.r2Bucket
+  ) {
+    throw new Error(
+      "R2 backend requires R2_ENDPOINT, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_BUCKET",
+    );
+  }
+
+  const client = new S3Client({
+    region: "auto",
+    endpoint: config.r2Endpoint,
+    credentials: {
+      accessKeyId: config.r2AccessKeyId,
+      secretAccessKey: config.r2SecretAccessKey,
+    },
+    forcePathStyle: true,
+  });
+
+  return {
+    backend: "r2",
+    async put(key, body, opts) {
+      await client.send(
+        new PutObjectCommand({
+          Bucket: config.r2Bucket,
+          Key: key,
+          Body: body,
+          ContentType: opts?.contentType,
+          ContentLength: opts?.contentLength,
+        }),
+      );
+    },
+    async head(key) {
+      try {
+        const result = await client.send(
+          new HeadObjectCommand({ Bucket: config.r2Bucket, Key: key }),
+        );
+        return {
+          exists: true,
+          size: result.ContentLength,
+          contentType: result.ContentType,
+        };
+      } catch (error) {
+        if ((error as { $metadata?: { httpStatusCode?: number } })?.$metadata?.httpStatusCode === 404) {
+          return { exists: false };
+        }
+        throw error;
+      }
+    },
+  };
+}
+
+function createLocalStorage(root: string): FlexHrStorage {
+  const resolvedRoot = path.resolve(root);
+
+  function resolveKey(key: string): string {
+    const full = path.resolve(resolvedRoot, key);
+    const relative = path.relative(resolvedRoot, full);
+    if (
+      relative === "" ||
+      path.isAbsolute(relative) ||
+      relative.split(path.sep)[0] === ".."
+    ) {
+      throw new Error(`key escapes storage root: ${key}`);
+    }
+    return full;
+  }
+
+  return {
+    backend: "local",
+    async put(key, body) {
+      const full = resolveKey(key);
+      await fs.mkdir(path.dirname(full), { recursive: true });
+      if (body instanceof Readable) {
+        await pipelineP(body, createWriteStream(full));
+      } else {
+        await fs.writeFile(full, body);
+      }
+    },
+    async head(key) {
+      try {
+        const stat = await fs.stat(resolveKey(key));
+        return { exists: true, size: stat.size };
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException)?.code === "ENOENT") {
+          return { exists: false };
+        }
+        throw error;
+      }
+    },
+  };
+}
+
+export function createFlexHrStorage(config: Config): FlexHrStorage {
+  if (config.storageBackend === "r2") {
+    return createR2Storage(config);
+  }
+  return createLocalStorage(config.localUploadDir);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       '@aws-sdk/client-s3':
         specifier: ^3.1037.0
         version: 3.1037.0
-      '@aws-sdk/s3-request-presigner':
-        specifier: ^3.1037.0
-        version: 3.1037.0
       better-sqlite3:
         specifier: ^12.8.0
         version: 12.8.0
@@ -222,10 +219,6 @@ packages:
     resolution: {integrity: sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/s3-request-presigner@3.1037.0':
-    resolution: {integrity: sha512-rZQS8DxrqPYXzOvaoysf6L4fHmgFbndZz3GfUMhlHG1iWmcQqH7v0AGhpjyNBY3cYAX8+CAkOkD4VUrntnHNbQ==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/signature-v4-multi-region@3.996.22':
     resolution: {integrity: sha512-/rXhMXteD+BqhFd0nYprAgcZ/KtU+963uftPqd3tiFcFfooHZINXUGtOmo2SQjRVauCTNqIEzkwuSETdZFqTTA==}
     engines: {node: '>=20.0.0'}
@@ -244,10 +237,6 @@ packages:
 
   '@aws-sdk/util-endpoints@3.996.8':
     resolution: {integrity: sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/util-format-url@3.972.10':
-    resolution: {integrity: sha512-DEKiHNJVtNxdyTeQspzY+15Po/kHm6sF0Cs4HV9Q2+lplB63+DrvdeiSoOSdWEWAoO2RcY1veoXVDz2tWxWCgQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-locate-window@3.965.5':
@@ -1538,17 +1527,6 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/s3-request-presigner@3.1037.0':
-    dependencies:
-      '@aws-sdk/signature-v4-multi-region': 3.996.22
-      '@aws-sdk/types': 3.973.8
-      '@aws-sdk/util-format-url': 3.972.10
-      '@smithy/middleware-endpoint': 4.4.32
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/smithy-client': 4.12.13
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
   '@aws-sdk/signature-v4-multi-region@3.996.22':
     dependencies:
       '@aws-sdk/middleware-sdk-s3': 3.972.34
@@ -1585,13 +1563,6 @@ snapshots:
       '@smithy/types': 4.14.1
       '@smithy/url-parser': 4.2.14
       '@smithy/util-endpoints': 3.4.2
-      tslib: 2.8.1
-
-  '@aws-sdk/util-format-url@3.972.10':
-    dependencies:
-      '@aws-sdk/types': 3.973.8
-      '@smithy/querystring-builder': 4.2.14
-      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/util-locate-window@3.965.5':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,12 +14,21 @@ importers:
 
   apps/flex-cli:
     dependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.1037.0
+        version: 3.1037.0
+      '@aws-sdk/s3-request-presigner':
+        specifier: ^3.1037.0
+        version: 3.1037.0
       better-sqlite3:
         specifier: ^12.8.0
         version: 12.8.0
       dotenv:
         specifier: ^16.4.7
         version: 16.6.1
+      pg:
+        specifier: ^8.20.0
+        version: 8.20.0
       playwright:
         specifier: ^1.50.1
         version: 1.58.2
@@ -33,6 +42,9 @@ importers:
       '@types/node':
         specifier: ^22.13.5
         version: 22.19.15
+      '@types/pg':
+        specifier: ^8.20.0
+        version: 8.20.0
       rimraf:
         specifier: ^6.0.1
         version: 6.1.3
@@ -94,6 +106,173 @@ importers:
         version: 5.9.3
 
 packages:
+
+  '@aws-crypto/crc32@5.2.0':
+    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/crc32c@5.2.0':
+    resolution: {integrity: sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==}
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    resolution: {integrity: sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==}
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/client-s3@3.1037.0':
+    resolution: {integrity: sha512-DBmA1jAW8ST6C4srBxeL1/RLIir/d8WOm4s4mi59mGp6mBktHM59Kwb7GuURaCO60cotuce5zr0sKpMLPcBQyA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.5':
+    resolution: {integrity: sha512-lMPlYlYfQdNZhlkJgnkmESwrY+hNh3PljmZ+37oAqLNdJ6rnILAwFSyc6B3bJeDOtMORNnMQIej0aTRuOlDyhQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/crc64-nvme@3.972.7':
+    resolution: {integrity: sha512-QUagVVBbC8gODCF6e1aV0mE2TXWB9Opz4k8EJFdNrujUVQm5R4AjJa1mpOqzwOuROBzqJU9zawzig7M96L8Ejg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.31':
+    resolution: {integrity: sha512-X/yGB73LmDW/6MdDJGCDzZBUXnM3ys4vs9l+5ZTJmiEswDdP1OjeoAFlFjVGS9o4KB2wZWQ9KOfdVNSSK6Ep3w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.33':
+    resolution: {integrity: sha512-c0ZF+lwoWVvX5iCaGKL5T/4DnIw88CGqxA0BcBs3U86mIp5EZYPVg+KSPkMXOyokmADvNewiMUfSG2uFwjRp0g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.35':
+    resolution: {integrity: sha512-jsU4u/cRkKFLKQS0k918FQ27fzXLG5ENiLWQMYE6581zLeI2hWh04ptlrvZMB3wJT/5d+vSzJk74X1CMFr4y8Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.35':
+    resolution: {integrity: sha512-5oa3j0cA50jPqgNhZ9XdJVopuzUf1klRb28/2MfLYWWiPi9DRVvbrBWT+DidbHTT36520VuXZJahQwR+YgSjrg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.36':
+    resolution: {integrity: sha512-4nT2T8Z7vH8KE9EdjEsuIlHpZSlcaK2PrKbQBjuUGU46BCCzF3WvP0u0Uiosni3Ykmmn4rWLVawoOCLotUtCbg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.31':
+    resolution: {integrity: sha512-eKeT4MXumpBJsrDLCYcSzIkFPVTFn/es7It2oogp2OhU/ic7P/+xzFpQx9ZhwtXS57Mc5S42BPWi7lHmvs/nYg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.35':
+    resolution: {integrity: sha512-bCuBdfnj0KGDMdLp6utMTLiJcFN2ek9EgZinxQZZSc3FxjJ/HSqeqab2cjbnoNfy8RM6suDCsRkmVY1izp9I+A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.35':
+    resolution: {integrity: sha512-swW6Bwvl8lanyEMtZOWE/oR6yqcRQH4HTQZUVsnDVgoXvRjRywpYpLv2BWwjUFyjPrqsdX6FeTkf4tMSe/qFTQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-bucket-endpoint@3.972.10':
+    resolution: {integrity: sha512-Vbc2frZH7wXlMNd+ZZSXUEs/l1Sv8Jj4zUnIfwrYF5lwaLdXHZ9xx4U3rjUcaye3HRhFVc+E5DbBxpRAbB16BA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-expect-continue@3.972.10':
+    resolution: {integrity: sha512-2Yn0f1Qiq/DjxYR3wfI3LokXnjOhFM7Ssn4LTdFDIxRMCE6I32MAsVnhPX1cUZsuVA9tiZtwwhlSLAtFGxAZlQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-flexible-checksums@3.974.13':
+    resolution: {integrity: sha512-b6QUe2hQX9XsnCzp6mtzVaERhganDKeb8lmGL6pVhr7rRVH9S9keDFW7uKytuuqmcY5943FixoGqn/QL+sbUBA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-host-header@3.972.10':
+    resolution: {integrity: sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-location-constraint@3.972.10':
+    resolution: {integrity: sha512-rI3NZvJcEvjoD0+0PI0iUAwlPw2IlSlhyvgBK/3WkKJQE/YiKFedd9dMN2lVacdNxPNhxL/jzQaKQdrGtQagjQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-logger@3.972.10':
+    resolution: {integrity: sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-recursion-detection@3.972.11':
+    resolution: {integrity: sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.34':
+    resolution: {integrity: sha512-/UL96JKjsjdodcRRMKl99tLQvK6Oi9ptLC9iU1yiTF/ruaDX0mtBBtnLNZDxIZRJOCVOtB49ed1YaTadqygk8Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-ssec@3.972.10':
+    resolution: {integrity: sha512-Gli9A0u8EVVb+5bFDGS/QbSVg28w/wpEidg1ggVcSj65BDTdGR6punsOcVjqdiu1i42WHWo51MCvARPIIz9juw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-user-agent@3.972.35':
+    resolution: {integrity: sha512-hOFWNOjVmOocpRlrU04nYxjMOeoe0Obu5AXEuhB8zblMCPl3cG1hdluQCZERRKFyhMQjwZnDbhSHjoMUjetFGw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.3':
+    resolution: {integrity: sha512-SivE6GP228IVgfsrr2c/vqTg95X0Qj39Yw4uIrcddpkUzIltNMoNOR62leHOLhODfjv9K8X2mPTwS69A5kT0nQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/region-config-resolver@3.972.13':
+    resolution: {integrity: sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/s3-request-presigner@3.1037.0':
+    resolution: {integrity: sha512-rZQS8DxrqPYXzOvaoysf6L4fHmgFbndZz3GfUMhlHG1iWmcQqH7v0AGhpjyNBY3cYAX8+CAkOkD4VUrntnHNbQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.22':
+    resolution: {integrity: sha512-/rXhMXteD+BqhFd0nYprAgcZ/KtU+963uftPqd3tiFcFfooHZINXUGtOmo2SQjRVauCTNqIEzkwuSETdZFqTTA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1036.0':
+    resolution: {integrity: sha512-aNSJ6jjDYayxN9ZA1JpycVScX93Lx03kKZ1EXt3DGOTahcWVLJj3oLAlop0xKP+vP2Ga2t49p1tEaMkTbCCaZA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.8':
+    resolution: {integrity: sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-arn-parser@3.972.3':
+    resolution: {integrity: sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-endpoints@3.996.8':
+    resolution: {integrity: sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-format-url@3.972.10':
+    resolution: {integrity: sha512-DEKiHNJVtNxdyTeQspzY+15Po/kHm6sF0Cs4HV9Q2+lplB63+DrvdeiSoOSdWEWAoO2RcY1veoXVDz2tWxWCgQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    resolution: {integrity: sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-user-agent-browser@3.972.10':
+    resolution: {integrity: sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==}
+
+  '@aws-sdk/util-user-agent-node@3.973.21':
+    resolution: {integrity: sha512-Av4UHTcAWgdvbN0IP9pbtf4Qa1+6LtJqQdZWj5pLn5J67w0pnJJAZZ+7JPPcj2KN3378zD2JDM9DwJKEyvyMTQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      aws-crt: '>=1.0.0'
+    peerDependenciesMeta:
+      aws-crt:
+        optional: true
+
+  '@aws-sdk/xml-builder@3.972.19':
+    resolution: {integrity: sha512-Cw8IOMdBUEIl8ZlhRC3Dc/E64D5B5/8JhV6vhPLiPfJwcRC84S6F8aBOIi/N4vR9ZyA4I5Cc0Ateb/9EHaJXeQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.2.4':
+    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+    engines: {node: '>=18.0.0'}
 
   '@esbuild/aix-ppc64@0.27.4':
     resolution: {integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==}
@@ -251,6 +430,221 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@nodable/entities@2.1.0':
+    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
+
+  '@smithy/chunked-blob-reader-native@4.2.3':
+    resolution: {integrity: sha512-jA5k5Udn7Y5717L86h4EIv06wIr3xn8GM1qHRi/Nf31annXcXHJjBKvgztnbn2TxH3xWrPBfgwHsOwZf0UmQWw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/chunked-blob-reader@5.2.2':
+    resolution: {integrity: sha512-St+kVicSyayWQca+I1rGitaOEH6uKgE8IUWoYnnEX26SWdWQcL6LvMSD19Lg+vYHKdT9B2Zuu7rd3i6Wnyb/iw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/config-resolver@4.4.17':
+    resolution: {integrity: sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/core@3.23.17':
+    resolution: {integrity: sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.2.14':
+    resolution: {integrity: sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-codec@4.2.14':
+    resolution: {integrity: sha512-erZq0nOIpzfeZdCyzZjdJb4nVSKLUmSkaQUVkRGQTXs30gyUGeKnrYEg+Xe1W5gE3aReS7IgsvANwVPxSzY6Pw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-browser@4.2.14':
+    resolution: {integrity: sha512-8IelTCtTctWRbb+0Dcy+C0aICh1qa0qWXqgjcXDmMuCvPJRnv26hiDZoAau2ILOniki65mCPKqOQs/BaWvO4CQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-config-resolver@4.3.14':
+    resolution: {integrity: sha512-sqHiHpYRYo3FJlaIxD1J8PhbcmJAm7IuM16mVnwSkCToD7g00IBZzKuiLNMGmftULmEUX6/UAz8/NN5uMP8bVA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-node@4.2.14':
+    resolution: {integrity: sha512-Ht/8BuGlKfFTy0H3+8eEu0vdpwGztCnaLLXtpXNdQqiR7Hj4vFScU3T436vRAjATglOIPjJXronY+1WxxNLSiw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-universal@4.2.14':
+    resolution: {integrity: sha512-lWyt4T2XQZUZgK3tQ3Wn0w3XBvZsK/vjTuJl6bXbnGZBHH0ZUSONTYiK9TgjTTzU54xQr3DRFwpjmhp0oLm3gg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.3.17':
+    resolution: {integrity: sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/hash-blob-browser@4.2.15':
+    resolution: {integrity: sha512-0PJ4Al3fg2nM4qKrAIxyNcApgqHAXcBkN8FeizOz69z0rb26uZ6lMESYtxegaTlXB5Hj84JfwMPavMrwDMjucA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/hash-node@4.2.14':
+    resolution: {integrity: sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/hash-stream-node@4.2.14':
+    resolution: {integrity: sha512-tw4GANWkZPb6+BdD4Fgucqzey2+r73Z/GRo9zklsCdwrnxxumUV83ZIaBDdudV4Ylazw3EPTiJZhpX42105ruQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/invalid-dependency@4.2.14':
+    resolution: {integrity: sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/is-array-buffer@4.2.2':
+    resolution: {integrity: sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/md5-js@4.2.14':
+    resolution: {integrity: sha512-V2v0vx+h0iUSNG1Alt+GNBMSLGCrl9iVsdd+Ap67HPM9PN479x12V8LkuMoKImNZxn3MXeuyUjls+/7ZACZghA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-content-length@4.2.14':
+    resolution: {integrity: sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-endpoint@4.4.32':
+    resolution: {integrity: sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-retry@4.5.5':
+    resolution: {integrity: sha512-wnYOpB5vATFKWrY2Z9Alb0KhjZI6AbzU6Fbz3Hq2GnURdRYWB4q+qWivQtSTwXcmWUA3MZ6krfwL6Cq5MAbxsA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-serde@4.2.20':
+    resolution: {integrity: sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-stack@4.2.14':
+    resolution: {integrity: sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-config-provider@4.3.14':
+    resolution: {integrity: sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.6.1':
+    resolution: {integrity: sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/property-provider@4.2.14':
+    resolution: {integrity: sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/protocol-http@5.3.14':
+    resolution: {integrity: sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-builder@4.2.14':
+    resolution: {integrity: sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-parser@4.2.14':
+    resolution: {integrity: sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/service-error-classification@4.3.0':
+    resolution: {integrity: sha512-9jKsBYQRPR0xBLgc2415RsA5PIcP2sis4oBdN9s0D13cg1B1284mNTjx9Yc+BEERXzuPm5ObktI96OxsKh8E9A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/shared-ini-file-loader@4.4.9':
+    resolution: {integrity: sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.3.14':
+    resolution: {integrity: sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/smithy-client@4.12.13':
+    resolution: {integrity: sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.14.1':
+    resolution: {integrity: sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/url-parser@4.2.14':
+    resolution: {integrity: sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-base64@4.3.2':
+    resolution: {integrity: sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-browser@4.2.2':
+    resolution: {integrity: sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-node@4.2.3':
+    resolution: {integrity: sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-buffer-from@4.2.2':
+    resolution: {integrity: sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-config-provider@4.2.2':
+    resolution: {integrity: sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-browser@4.3.49':
+    resolution: {integrity: sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-node@4.2.54':
+    resolution: {integrity: sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-endpoints@3.4.2':
+    resolution: {integrity: sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-hex-encoding@4.2.2':
+    resolution: {integrity: sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-middleware@4.2.14':
+    resolution: {integrity: sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-retry@4.3.4':
+    resolution: {integrity: sha512-FY1UQQ1VFmMwiYp1GVS4MeaGD5O0blLNYK0xCRHU+mJgeoH/hSY8Ld8sJWKQ6uznkh14HveRGQJncgPyNl9J+A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-stream@4.5.25':
+    resolution: {integrity: sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-uri-escape@4.2.2':
+    resolution: {integrity: sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@4.2.2':
+    resolution: {integrity: sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-waiter@4.2.16':
+    resolution: {integrity: sha512-GtclrKoZ3Lt7jPQ7aTIYKfjY92OgceScftVnkTsG8e1KV8rkvZgN+ny6YSRhd9hxB8rZtwVbmln7NTvE5O3GmQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/uuid@1.1.2':
+    resolution: {integrity: sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==}
+    engines: {node: '>=18.0.0'}
+
   '@turbo/darwin-64@2.9.1':
     resolution: {integrity: sha512-d1zTcIf6VWT7cdfjhi0X36C2PRsUi2HdEwYzVgkLHmuuYtL+1Y1Zu3JdlouoB/NjG2vX3q4NnKLMNhDOEweoIg==}
     cpu: [x64]
@@ -287,6 +681,9 @@ packages:
   '@types/node@22.19.15':
     resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
 
+  '@types/pg@8.20.0':
+    resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -310,6 +707,9 @@ packages:
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
@@ -390,6 +790,13 @@ packages:
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  fast-xml-builder@1.1.5:
+    resolution: {integrity: sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==}
+
+  fast-xml-parser@5.7.1:
+    resolution: {integrity: sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==}
+    hasBin: true
 
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
@@ -549,9 +956,47 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
+
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
+
+  pg-cloudflare@1.3.0:
+    resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
+
+  pg-connection-string@2.12.0:
+    resolution: {integrity: sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.13.0:
+    resolution: {integrity: sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.13.0:
+    resolution: {integrity: sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.20.0:
+    resolution: {integrity: sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
 
   playwright-core@1.58.2:
     resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
@@ -562,6 +1007,22 @@ packages:
     resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
     engines: {node: '>=18'}
     hasBin: true
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
 
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
@@ -622,12 +1083,19 @@ packages:
   simple-get@4.0.1:
     resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
 
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
+
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
+
+  strnum@2.2.3:
+    resolution: {integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==}
 
   tar-fs@2.1.4:
     resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
@@ -638,6 +1106,9 @@ packages:
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tsx@4.21.0:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
@@ -678,10 +1149,478 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
+
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
+
+  '@aws-crypto/crc32@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      tslib: 2.8.1
+
+  '@aws-crypto/crc32c@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      tslib: 2.8.1
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-locate-window': 3.965.5
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-locate-window': 3.965.5
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-s3@3.1037.0':
+    dependencies:
+      '@aws-crypto/sha1-browser': 5.2.0
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.5
+      '@aws-sdk/credential-provider-node': 3.972.36
+      '@aws-sdk/middleware-bucket-endpoint': 3.972.10
+      '@aws-sdk/middleware-expect-continue': 3.972.10
+      '@aws-sdk/middleware-flexible-checksums': 3.974.13
+      '@aws-sdk/middleware-host-header': 3.972.10
+      '@aws-sdk/middleware-location-constraint': 3.972.10
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.11
+      '@aws-sdk/middleware-sdk-s3': 3.972.34
+      '@aws-sdk/middleware-ssec': 3.972.10
+      '@aws-sdk/middleware-user-agent': 3.972.35
+      '@aws-sdk/region-config-resolver': 3.972.13
+      '@aws-sdk/signature-v4-multi-region': 3.996.22
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@aws-sdk/util-user-agent-browser': 3.972.10
+      '@aws-sdk/util-user-agent-node': 3.973.21
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/core': 3.23.17
+      '@smithy/eventstream-serde-browser': 4.2.14
+      '@smithy/eventstream-serde-config-resolver': 4.3.14
+      '@smithy/eventstream-serde-node': 4.2.14
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/hash-blob-browser': 4.2.15
+      '@smithy/hash-node': 4.2.14
+      '@smithy/hash-stream-node': 4.2.14
+      '@smithy/invalid-dependency': 4.2.14
+      '@smithy/md5-js': 4.2.14
+      '@smithy/middleware-content-length': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-retry': 4.5.5
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.49
+      '@smithy/util-defaults-mode-node': 4.2.54
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.4
+      '@smithy/util-stream': 4.5.25
+      '@smithy/util-utf8': 4.2.2
+      '@smithy/util-waiter': 4.2.16
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/core@3.974.5':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/xml-builder': 3.972.19
+      '@smithy/core': 3.23.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.4
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/crc64-nvme@3.972.7':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.31':
+    dependencies:
+      '@aws-sdk/core': 3.974.5
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.33':
+    dependencies:
+      '@aws-sdk/core': 3.974.5
+      '@aws-sdk/types': 3.973.8
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-stream': 4.5.25
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.35':
+    dependencies:
+      '@aws-sdk/core': 3.974.5
+      '@aws-sdk/credential-provider-env': 3.972.31
+      '@aws-sdk/credential-provider-http': 3.972.33
+      '@aws-sdk/credential-provider-login': 3.972.35
+      '@aws-sdk/credential-provider-process': 3.972.31
+      '@aws-sdk/credential-provider-sso': 3.972.35
+      '@aws-sdk/credential-provider-web-identity': 3.972.35
+      '@aws-sdk/nested-clients': 3.997.3
+      '@aws-sdk/types': 3.973.8
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-login@3.972.35':
+    dependencies:
+      '@aws-sdk/core': 3.974.5
+      '@aws-sdk/nested-clients': 3.997.3
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-node@3.972.36':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.31
+      '@aws-sdk/credential-provider-http': 3.972.33
+      '@aws-sdk/credential-provider-ini': 3.972.35
+      '@aws-sdk/credential-provider-process': 3.972.31
+      '@aws-sdk/credential-provider-sso': 3.972.35
+      '@aws-sdk/credential-provider-web-identity': 3.972.35
+      '@aws-sdk/types': 3.973.8
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-process@3.972.31':
+    dependencies:
+      '@aws-sdk/core': 3.974.5
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.35':
+    dependencies:
+      '@aws-sdk/core': 3.974.5
+      '@aws-sdk/nested-clients': 3.997.3
+      '@aws-sdk/token-providers': 3.1036.0
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-web-identity@3.972.35':
+    dependencies:
+      '@aws-sdk/core': 3.974.5
+      '@aws-sdk/nested-clients': 3.997.3
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/middleware-bucket-endpoint@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-arn-parser': 3.972.3
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-expect-continue@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-flexible-checksums@3.974.13':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@aws-crypto/crc32c': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/core': 3.974.5
+      '@aws-sdk/crc64-nvme': 3.972.7
+      '@aws-sdk/types': 3.973.8
+      '@smithy/is-array-buffer': 4.2.2
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-stream': 4.5.25
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-host-header@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-location-constraint@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-logger@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-recursion-detection@3.972.11':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.34':
+    dependencies:
+      '@aws-sdk/core': 3.974.5
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-arn-parser': 3.972.3
+      '@smithy/core': 3.23.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.2.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-stream': 4.5.25
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-ssec@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-user-agent@3.972.35':
+    dependencies:
+      '@aws-sdk/core': 3.974.5
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@smithy/core': 3.23.17
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-retry': 4.3.4
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.3':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.5
+      '@aws-sdk/middleware-host-header': 3.972.10
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.11
+      '@aws-sdk/middleware-user-agent': 3.972.35
+      '@aws-sdk/region-config-resolver': 3.972.13
+      '@aws-sdk/signature-v4-multi-region': 3.996.22
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@aws-sdk/util-user-agent-browser': 3.972.10
+      '@aws-sdk/util-user-agent-node': 3.973.21
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/core': 3.23.17
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/hash-node': 4.2.14
+      '@smithy/invalid-dependency': 4.2.14
+      '@smithy/middleware-content-length': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-retry': 4.5.5
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.49
+      '@smithy/util-defaults-mode-node': 4.2.54
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.4
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/region-config-resolver@3.972.13':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/s3-request-presigner@3.1037.0':
+    dependencies:
+      '@aws-sdk/signature-v4-multi-region': 3.996.22
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-format-url': 3.972.10
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.22':
+    dependencies:
+      '@aws-sdk/middleware-sdk-s3': 3.972.34
+      '@aws-sdk/types': 3.973.8
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1036.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.5
+      '@aws-sdk/nested-clients': 3.997.3
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/types@3.973.8':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-arn-parser@3.972.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/util-endpoints@3.996.8':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-endpoints': 3.4.2
+      tslib: 2.8.1
+
+  '@aws-sdk/util-format-url@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/querystring-builder': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-browser@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-node@3.973.21':
+    dependencies:
+      '@aws-sdk/middleware-user-agent': 3.972.35
+      '@aws-sdk/types': 3.973.8
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.19':
+    dependencies:
+      '@smithy/types': 4.14.1
+      fast-xml-parser: 5.7.1
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.2.4': {}
 
   '@esbuild/aix-ppc64@0.27.4':
     optional: true
@@ -761,6 +1700,341 @@ snapshots:
   '@esbuild/win32-x64@0.27.4':
     optional: true
 
+  '@nodable/entities@2.1.0': {}
+
+  '@smithy/chunked-blob-reader-native@4.2.3':
+    dependencies:
+      '@smithy/util-base64': 4.3.2
+      tslib: 2.8.1
+
+  '@smithy/chunked-blob-reader@5.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/config-resolver@4.4.17':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.2.2
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      tslib: 2.8.1
+
+  '@smithy/core@3.23.17':
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-stream': 4.5.25
+      '@smithy/util-utf8': 4.2.2
+      '@smithy/uuid': 1.1.2
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.2.14':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      tslib: 2.8.1
+
+  '@smithy/eventstream-codec@4.2.14':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.14.1
+      '@smithy/util-hex-encoding': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-browser@4.2.14':
+    dependencies:
+      '@smithy/eventstream-serde-universal': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-config-resolver@4.3.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-node@4.2.14':
+    dependencies:
+      '@smithy/eventstream-serde-universal': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-universal@4.2.14':
+    dependencies:
+      '@smithy/eventstream-codec': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.3.17':
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/querystring-builder': 4.2.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-base64': 4.3.2
+      tslib: 2.8.1
+
+  '@smithy/hash-blob-browser@4.2.15':
+    dependencies:
+      '@smithy/chunked-blob-reader': 5.2.2
+      '@smithy/chunked-blob-reader-native': 4.2.3
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/hash-node@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/hash-stream-node@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/invalid-dependency@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/md5-js@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/middleware-content-length@4.2.14':
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/middleware-endpoint@4.4.32':
+    dependencies:
+      '@smithy/core': 3.23.17
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-middleware': 4.2.14
+      tslib: 2.8.1
+
+  '@smithy/middleware-retry@4.5.5':
+    dependencies:
+      '@smithy/core': 3.23.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/service-error-classification': 4.3.0
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.4
+      '@smithy/uuid': 1.1.2
+      tslib: 2.8.1
+
+  '@smithy/middleware-serde@4.2.20':
+    dependencies:
+      '@smithy/core': 3.23.17
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/middleware-stack@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/node-config-provider@4.3.14':
+    dependencies:
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.6.1':
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/querystring-builder': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/property-provider@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/protocol-http@5.3.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/querystring-builder@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      '@smithy/util-uri-escape': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/querystring-parser@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/service-error-classification@4.3.0':
+    dependencies:
+      '@smithy/types': 4.14.1
+
+  '@smithy/shared-ini-file-loader@4.4.9':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.3.14':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.2
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-hex-encoding': 4.2.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-uri-escape': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/smithy-client@4.12.13':
+    dependencies:
+      '@smithy/core': 3.23.17
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-stream': 4.5.25
+      tslib: 2.8.1
+
+  '@smithy/types@4.14.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/url-parser@4.2.14':
+    dependencies:
+      '@smithy/querystring-parser': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-base64@4.3.2':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-browser@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-node@4.2.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@4.2.2':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-config-provider@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-defaults-mode-browser@4.3.49':
+    dependencies:
+      '@smithy/property-provider': 4.2.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-defaults-mode-node@4.2.54':
+    dependencies:
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-endpoints@3.4.2':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-hex-encoding@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-middleware@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-retry@4.3.4':
+    dependencies:
+      '@smithy/service-error-classification': 4.3.0
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-stream@4.5.25':
+    dependencies:
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/types': 4.14.1
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-hex-encoding': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-uri-escape@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@4.2.2':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-waiter@4.2.16':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/uuid@1.1.2':
+    dependencies:
+      tslib: 2.8.1
+
   '@turbo/darwin-64@2.9.1':
     optional: true
 
@@ -787,6 +2061,12 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/pg@8.20.0':
+    dependencies:
+      '@types/node': 22.19.15
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
+
   agent-base@7.1.4: {}
 
   balanced-match@4.0.4: {}
@@ -809,6 +2089,8 @@ snapshots:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
+
+  bowser@2.14.1: {}
 
   brace-expansion@5.0.5:
     dependencies:
@@ -901,6 +2183,17 @@ snapshots:
   expand-template@2.0.3: {}
 
   extend@3.0.2: {}
+
+  fast-xml-builder@1.1.5:
+    dependencies:
+      path-expression-matcher: 1.5.0
+
+  fast-xml-parser@5.7.1:
+    dependencies:
+      '@nodable/entities': 2.1.0
+      fast-xml-builder: 1.1.5
+      path-expression-matcher: 1.5.0
+      strnum: 2.2.3
 
   file-uri-to-path@1.0.0: {}
 
@@ -1080,10 +2373,47 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  path-expression-matcher@1.5.0: {}
+
   path-scurry@2.0.2:
     dependencies:
       lru-cache: 11.2.7
       minipass: 7.1.3
+
+  pg-cloudflare@1.3.0:
+    optional: true
+
+  pg-connection-string@2.12.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.13.0(pg@8.20.0):
+    dependencies:
+      pg: 8.20.0
+
+  pg-protocol@1.13.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.20.0:
+    dependencies:
+      pg-connection-string: 2.12.0
+      pg-pool: 3.13.0(pg@8.20.0)
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.3.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
 
   playwright-core@1.58.2: {}
 
@@ -1092,6 +2422,16 @@ snapshots:
       playwright-core: 1.58.2
     optionalDependencies:
       fsevents: 2.3.2
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
 
   prebuild-install@7.1.3:
     dependencies:
@@ -1177,11 +2517,15 @@ snapshots:
       once: 1.4.0
       simple-concat: 1.0.1
 
+  split2@4.2.0: {}
+
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
 
   strip-json-comments@2.0.1: {}
+
+  strnum@2.2.3: {}
 
   tar-fs@2.1.4:
     dependencies:
@@ -1199,6 +2543,8 @@ snapshots:
       readable-stream: 3.6.2
 
   tr46@0.0.3: {}
+
+  tslib@2.8.1: {}
 
   tsx@4.21.0:
     dependencies:
@@ -1238,5 +2584,7 @@ snapshots:
       webidl-conversions: 3.0.1
 
   wrappy@1.0.2: {}
+
+  xtend@4.0.2: {}
 
   zod@3.25.76: {}


### PR DESCRIPTION
## Summary

Adds a direct flex-hr dump mode to `flex-ax crawl` so the CLI can run:

- crawl
- SQLite export generation
- flex-hr metadata import
- storage validation / upload path

without depending on a sibling `db-agent-flex-hr-10780` checkout at runtime.

## What Changed

- added `FLEX_HR_DIRECT_DUMP` orchestration to the crawl command
- added direct-dump config for flex-hr DB, storage backend, wallets, scratch handling, and dry-run
- added an internal flex-hr import runtime for Postgres + storage integration
- added local/R2 storage handling for the direct dump path
- updated CLI/env docs for the new mode

## Validation

- `pnpm --filter flex-ax lint`
- `pnpm --filter flex-ax build`
- direct flex-hr import dry-run against the flex-hr production DB/R2 settings via Fly proxy
- end-to-end `crawl -> sqlite -> flex-hr dry-run` for customer `rjzQknqW87`

## Notes

- dry-run now validates R2 credentials/bucket access with a lightweight probe when `STORAGE_BACKEND=r2`
- the worktree still contains unrelated untracked local artifacts that are not part of this PR
