### PR TITLE
feat(flex-cli): add `workflow` subcommand for creating approval documents

### DIFF
--- a/apps/flex-cli/package.json
+++ b/apps/flex-cli/package.json
@@ -26,6 +26,7 @@
     "better-sqlite3": "^12.8.0",
     "dotenv": "^16.4.7",
     "semver": "^7.7.4",
+    "yaml": "^2.6.1",
     "zod": "^3.24.2"
   },
   "engines": {

--- a/apps/flex-cli/src/auth/index.ts
+++ b/apps/flex-cli/src/auth/index.ts
@@ -172,7 +172,8 @@ export async function performLogin(
     sessionHeaders,
   );
 
-  console.log("[FLEX-AX:AUTH] 로그인 성공");
+  // logger와 동일하게 stderr로 — stdout은 명령 결과물 전용으로 비워둔다
+  process.stderr.write("[FLEX-AX:AUTH] 로그인 성공\n");
   return {
     baseUrl,
     deviceId,

--- a/apps/flex-cli/src/cli.ts
+++ b/apps/flex-cli/src/cli.ts
@@ -51,6 +51,11 @@ switch (command) {
     await runFile();
     break;
   }
+  case "workflow": {
+    const { runWorkflow } = await import("./commands/workflow.js");
+    await runWorkflow();
+    break;
+  }
   case "check-apis": {
     const { runCheckApis } = await import("./commands/check-apis.js");
     await runCheckApis();
@@ -90,6 +95,7 @@ Commands:
                   --file <path>  SQL 파일 경로
                   --var key=value  {{key}} 플레이스홀더 치환 (반복 가능)
   file <fileKey>  파일 내용 출력 (--info로 메타데이터만)
+  workflow <sub>  결재 문서 작성/제출 (templates / describe / submit)
   check-apis      하드코딩된 API 엔드포인트 상태 확인
   install-skills  에이전트 스킬을 .claude/skills/에 설치
   update          최신 버전으로 업데이트

--- a/apps/flex-cli/src/commands/workflow.ts
+++ b/apps/flex-cli/src/commands/workflow.ts
@@ -9,7 +9,7 @@ import {
   type AuthContext,
   type Corporation,
 } from "../auth/index.js";
-import { listAvailableTemplates, findTemplate } from "../workflow/templates.js";
+import { listAvailableTemplates, findTemplate, decodeEmoji } from "../workflow/templates.js";
 import { resolvePolicy } from "../workflow/policy.js";
 import { uploadAttachment } from "../workflow/file.js";
 import {
@@ -190,8 +190,9 @@ async function cmdTemplates(args: string[]): Promise<void> {
     // 마지막 컬럼으로 보낸다.
     for (const t of templates) {
       const tags = t.tags?.map((tg) => tg.name).join(",") ?? "";
+      const emoji = decodeEmoji(t.emoji);
       console.log(
-        `${t.templateKey}\t${t.name}${tags ? "\t[" + tags + "]" : ""}${t.emoji ? "\t" + t.emoji : ""}`,
+        `${t.templateKey}\t${t.name}${tags ? "\t[" + tags + "]" : ""}${emoji ? "\t" + emoji : ""}`,
       );
     }
   } finally {

--- a/apps/flex-cli/src/commands/workflow.ts
+++ b/apps/flex-cli/src/commands/workflow.ts
@@ -1,0 +1,385 @@
+import path from "node:path";
+import { loadConfig, type Config } from "../config/index.js";
+import { createLogger, type Logger } from "../logger/index.js";
+import {
+  authenticate,
+  cleanup,
+  listCorporations,
+  switchCustomer,
+  type AuthContext,
+  type Corporation,
+} from "../auth/index.js";
+import { listAvailableTemplates, findTemplate } from "../workflow/templates.js";
+import { resolvePolicy } from "../workflow/policy.js";
+import { uploadAttachment } from "../workflow/file.js";
+import {
+  createDraft,
+  registerAttachments,
+  submitDocument,
+  type DocumentPayload,
+} from "../workflow/document.js";
+import {
+  readInputFile,
+  renderInputTemplate,
+  serializeFieldValue,
+  type WorkflowInput,
+} from "../workflow/io.js";
+import type { ResolvedPolicy, UploadedAttachment } from "../workflow/types.js";
+
+/**
+ * `flex-ax workflow {templates|describe|submit}` 디스패처.
+ * cli.ts 에서 case 하나로 받아 여기로 위임한다.
+ */
+export async function runWorkflow(): Promise<void> {
+  // process.argv = [node, cli.js, "workflow", <sub>, ...rest]
+  const [sub, ...rest] = process.argv.slice(3);
+
+  switch (sub) {
+    case "templates":
+      await cmdTemplates(rest);
+      return;
+    case "describe":
+      await cmdDescribe(rest);
+      return;
+    case "submit":
+      await cmdSubmit(rest);
+      return;
+    case undefined:
+    case "help":
+    case "--help":
+    case "-h":
+      printUsage();
+      process.exit(sub === undefined ? 1 : 0);
+      return;
+    default:
+      console.error(`[FLEX-AX:WORKFLOW:ERROR] 알 수 없는 서브커맨드: ${sub}`);
+      printUsage();
+      process.exit(1);
+  }
+}
+
+function printUsage(): void {
+  console.log(`Usage: flex-ax workflow <subcommand>
+
+Subcommands:
+  templates                       작성 가능한 양식 목록 출력
+  describe <key|이름> [> file]    양식 명세를 입력 YAML 형태로 출력
+  submit <file>                   채운 YAML로 결재 문서 작성/제출
+
+Options (모든 서브커맨드 공통):
+  --customer <customerIdHash>     다중 법인일 때 대상 법인 지정
+  --draft                         (submit 전용) 임시저장까지만 (제출 호출 생략)
+  --dry-run                       (submit 전용) 호출하지 않고 페이로드만 stdout
+
+Examples:
+  flex-ax workflow templates
+  flex-ax workflow describe "비용 결제 요청" > request.yaml
+  flex-ax workflow submit ./request.yaml --draft
+`);
+}
+
+// --- 옵션 파서 (각 서브커맨드 공통) ---
+
+interface CommonOpts {
+  customer?: string;
+  draft: boolean;
+  dryRun: boolean;
+  positional: string[];
+}
+
+function parseOpts(args: string[]): CommonOpts {
+  const opts: CommonOpts = { draft: false, dryRun: false, positional: [] };
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === "--customer") {
+      opts.customer = args[++i];
+    } else if (a === "--draft") {
+      opts.draft = true;
+    } else if (a === "--dry-run") {
+      opts.dryRun = true;
+    } else {
+      opts.positional.push(a);
+    }
+  }
+  return opts;
+}
+
+// --- 공통: 인증 + 법인 전환 ---
+
+async function setupAuth(
+  opts: CommonOpts,
+  logger: Logger,
+): Promise<{ authCtx: AuthContext; config: Config; corp: Corporation }> {
+  let config: Config;
+  try {
+    config = loadConfig();
+  } catch (error) {
+    logger.error("설정 로딩 실패", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    process.exit(1);
+  }
+
+  const authCtx = await authenticate(config, logger);
+
+  let corporations: Corporation[];
+  try {
+    corporations = await listCorporations(authCtx, config.flexBaseUrl);
+  } catch (error) {
+    await cleanup(authCtx);
+    throw error;
+  }
+
+  if (corporations.length === 0) {
+    await cleanup(authCtx);
+    logger.error("작성 가능한 법인이 없습니다");
+    process.exit(1);
+  }
+
+  // --customer > FLEX_CUSTOMERS env > 단일 법인 자동선택 > 다중인데 미지정이면 에러
+  let target: Corporation;
+  if (opts.customer) {
+    const found = corporations.find((c) => c.customerIdHash === opts.customer);
+    if (!found) {
+      await cleanup(authCtx);
+      logger.error("--customer로 지정한 법인이 접근 가능 목록에 없습니다", {
+        requested: opts.customer,
+        available: corporations.map((c) => c.customerIdHash),
+      });
+      process.exit(1);
+    }
+    target = found;
+  } else if (config.customers.length === 1) {
+    const found = corporations.find((c) => c.customerIdHash === config.customers[0]);
+    if (!found) {
+      await cleanup(authCtx);
+      logger.error("FLEX_CUSTOMERS env로 지정한 법인이 접근 가능 목록에 없습니다");
+      process.exit(1);
+    }
+    target = found;
+  } else if (corporations.length === 1) {
+    target = corporations[0];
+  } else {
+    await cleanup(authCtx);
+    logger.error("법인이 여러 개입니다 — --customer <customerIdHash> 로 명시하세요", {
+      candidates: corporations.map((c) => ({ id: c.customerIdHash, name: c.name })),
+    });
+    process.exit(1);
+  }
+
+  await switchCustomer(authCtx, config.flexBaseUrl, target.customerIdHash, target.userIdHash);
+  logger.info("법인 컨텍스트 설정", { name: target.name, customerIdHash: target.customerIdHash });
+
+  return { authCtx, config, corp: target };
+}
+
+// --- 서브커맨드 구현 ---
+
+async function cmdTemplates(args: string[]): Promise<void> {
+  const logger = createLogger("WORKFLOW");
+  const opts = parseOpts(args);
+
+  const { authCtx, config } = await setupAuth(opts, logger);
+  try {
+    const templates = await listAvailableTemplates(authCtx, config.flexBaseUrl);
+    if (templates.length === 0) {
+      console.log("(작성 가능한 양식이 없습니다)");
+      return;
+    }
+    // 안정적으로 grep 가능하도록 한 줄에 한 양식 — emoji는 일부 터미널에서 폭이 어긋나므로
+    // 마지막 컬럼으로 보낸다.
+    for (const t of templates) {
+      const tags = t.tags?.map((tg) => tg.name).join(",") ?? "";
+      console.log(
+        `${t.templateKey}\t${t.name}${tags ? "\t[" + tags + "]" : ""}${t.emoji ? "\t" + t.emoji : ""}`,
+      );
+    }
+  } finally {
+    await cleanup(authCtx);
+  }
+}
+
+async function cmdDescribe(args: string[]): Promise<void> {
+  const logger = createLogger("WORKFLOW");
+  const opts = parseOpts(args);
+  const query = opts.positional[0];
+  if (!query) {
+    logger.error("describe 대상 양식을 지정하세요 (templateKey 또는 이름)");
+    process.exit(1);
+  }
+
+  const { authCtx, config } = await setupAuth(opts, logger);
+  try {
+    const templates = await listAvailableTemplates(authCtx, config.flexBaseUrl);
+    const template = findTemplate(templates, query);
+    logger.info("양식 매칭", { name: template.name, templateKey: template.templateKey });
+    const policy = await resolvePolicy(authCtx, config.flexBaseUrl, template);
+    process.stdout.write(renderInputTemplate(policy));
+  } finally {
+    await cleanup(authCtx);
+  }
+}
+
+async function cmdSubmit(args: string[]): Promise<void> {
+  const logger = createLogger("WORKFLOW");
+  const opts = parseOpts(args);
+  const filePath = opts.positional[0];
+  if (!filePath) {
+    logger.error("submit 입력 파일을 지정하세요 (예: flex-ax workflow submit ./request.yaml)");
+    process.exit(1);
+  }
+
+  // 파일 먼저 읽고 검증 — 인증 실패보다 입력 검증 실패가 먼저 보이는 게 디버깅 친화적.
+  const input = await readInputFile(filePath);
+
+  const { authCtx, config } = await setupAuth(opts, logger);
+  try {
+    const templates = await listAvailableTemplates(authCtx, config.flexBaseUrl);
+    const template = findTemplate(templates, input.templateKey);
+    const policy = await resolvePolicy(authCtx, config.flexBaseUrl, template);
+    logger.info("양식 매칭", { name: template.name, templateKey: template.templateKey });
+
+    const payload = buildPayload(input, policy);
+    validateRequiredFields(input, policy);
+
+    if (opts.dryRun) {
+      // dry-run은 attachments 업로드도 건너뛴다 — 호출 0건. 페이로드 모양만 stdout으로 덤프.
+      const stub: DocumentPayload = { ...payload, attachments: [] };
+      console.log(JSON.stringify(serializeForDryRun(stub, input.attachments), null, 2));
+      return;
+    }
+
+    // 첨부파일 업로드 (있을 때만)
+    const uploaded: UploadedAttachment[] = [];
+    for (let i = 0; i < input.attachments.length; i++) {
+      const file = path.resolve(path.dirname(path.resolve(filePath)), input.attachments[i]);
+      logger.info(`첨부 ${i + 1}/${input.attachments.length} 업로드`, { file });
+      const att = await uploadAttachment(authCtx, config.flexBaseUrl, file);
+      uploaded.push(att);
+    }
+    payload.attachments = uploaded;
+
+    // draft 생성 → 첨부 등록 (영구 fileKey 변환)
+    const { documentKey } = await createDraft(authCtx, config.flexBaseUrl, payload);
+    logger.info("draft 생성", { documentKey });
+    if (uploaded.length > 0) {
+      payload.attachments = await registerAttachments(
+        authCtx,
+        config.flexBaseUrl,
+        documentKey,
+        payload,
+      );
+      logger.info("영구 fileKey 변환 완료", { count: payload.attachments.length });
+    }
+
+    if (opts.draft) {
+      console.log(`[FLEX-AX:WORKFLOW] 임시저장 완료: documentKey=${documentKey}`);
+      console.log(
+        `[FLEX-AX:WORKFLOW] UI에서 마저 작성: ${config.flexBaseUrl}/workflow/archive/my?documentKey=${documentKey}`,
+      );
+      return;
+    }
+
+    const result = await submitDocument(authCtx, config.flexBaseUrl, documentKey, payload);
+    console.log(
+      `[FLEX-AX:WORKFLOW] 제출 완료: code=${result.code} status=${result.status} documentKey=${result.documentKey}`,
+    );
+  } finally {
+    await cleanup(authCtx);
+  }
+}
+
+// --- payload 빌더 ---
+
+function buildPayload(input: WorkflowInput, policy: ResolvedPolicy): DocumentPayload {
+  // YAML 의 한글 이름 → policy의 inputFieldIdHash 매핑 사전 구축
+  const byName = new Map(policy.fields.map((f) => [f.name, f]));
+
+  const inputs: Array<{ inputFieldIdHash: string; value: string }> = [];
+
+  // 정책에 정의된 모든 필드를 순서대로 발행 — 사용자가 빈 값으로 둔 필드도 빈 문자열로 보낸다.
+  // 그래야 prefill 처리/required 검증이 서버에서 일관되게 동작한다.
+  for (const field of policy.fields) {
+    const raw = input.fields[field.name];
+    let value = serializeFieldValue(field, raw);
+
+    // 사용자가 값을 비웠지만 prefill 가능한 경우 (이름/조직) 자동 채움
+    if (
+      (raw === undefined || raw === "" || raw === null) &&
+      field.prefill?.defaultValue &&
+      field.type === "STRING"
+    ) {
+      value = field.prefill.defaultValue;
+    }
+    inputs.push({ inputFieldIdHash: field.inputFieldIdHash, value });
+  }
+
+  // YAML 에는 있지만 policy에 없는 필드는 사용자 오타 가능성이 높음 → 경고성 에러
+  const policyNames = new Set(policy.fields.map((f) => f.name));
+  for (const key of Object.keys(input.fields)) {
+    if (!policyNames.has(key)) {
+      throw new Error(
+        `양식에 존재하지 않는 필드입니다: "${key}". 사용 가능한 필드: ${[...policyNames].join(", ")}`,
+      );
+    }
+  }
+
+  return {
+    templateKey: policy.templateKey,
+    title: input.title,
+    content: input.content && input.content.length > 0 ? input.content : policy.defaultContent,
+    inputs,
+    attachments: [], // submit 시 채워짐
+    approvalLines: input.approvalProcess.lines.map((l) => ({
+      step: l.step,
+      actors: l.actors.map((a) => ({ type: a.type, value: a.value })),
+    })),
+    referrers: input.approvalProcess.referrers.map((r) => ({
+      type: r.type,
+      value: r.value,
+      notificationSetting: r.notificationSetting,
+    })),
+    matchingData: input.approvalProcess.matchingData,
+    options: input.approvalProcess.options ?? policy.options,
+  };
+}
+
+function validateRequiredFields(input: WorkflowInput, policy: ResolvedPolicy): void {
+  const missing: string[] = [];
+  for (const field of policy.fields) {
+    if (!field.required) continue;
+    if (field.prefill?.defaultValue) continue; // prefill로 자동 채워질 거라 검사 면제
+    const v = input.fields[field.name];
+    if (v === undefined || v === null || v === "") missing.push(field.name);
+    else if (Array.isArray(v) && v.length === 0) missing.push(field.name);
+  }
+  if (missing.length > 0) {
+    throw new Error(`필수 필드가 비어 있습니다: ${missing.join(", ")}`);
+  }
+}
+
+function serializeForDryRun(
+  payload: DocumentPayload,
+  attachments: string[],
+): unknown {
+  return {
+    documentKey: "<assigned-on-create>",
+    document: {
+      templateKey: payload.templateKey,
+      title: payload.title,
+      content: payload.content,
+      inputs: payload.inputs,
+      attachments: attachments.map((p) => ({
+        path: p,
+        note: "dry-run 이라 업로드는 건너뜀",
+      })),
+    },
+    approvalProcess: {
+      lines: payload.approvalLines,
+      referrers: payload.referrers,
+      matchingData: payload.matchingData,
+      options: payload.options,
+    },
+  };
+}
+

--- a/apps/flex-cli/src/logger/index.ts
+++ b/apps/flex-cli/src/logger/index.ts
@@ -44,26 +44,29 @@ function writeLogLine(line: string): void {
 export function createLogger(prefix?: string): Logger {
   const tag = prefix ? `[FLEX-AX:${prefix}]` : "";
 
+  // 모든 진행 로그(info/warn/error/progress)는 stderr로 보낸다.
+  // stdout은 명령의 "결과물"(query 결과 JSON, workflow describe YAML, workflow templates 목록 등)
+  // 전용으로 남겨야 redirect/pipe 시 결과물이 로그로 오염되지 않는다.
   return {
     info(message, meta) {
       const line = `[${timestamp()}] INFO  ${tag} ${message}${formatMeta(meta)}`;
-      console.log(line);
+      process.stderr.write(`${line}\n`);
       writeLogLine(line);
     },
     warn(message, meta) {
       const line = `[${timestamp()}] WARN  ${tag} ${message}${formatMeta(meta)}`;
-      console.warn(line);
+      process.stderr.write(`${line}\n`);
       writeLogLine(line);
     },
     error(message, meta) {
       const line = `[${timestamp()}] ERROR ${tag} ${message}${formatMeta(meta)}`;
-      console.error(line);
+      process.stderr.write(`${line}\n`);
       writeLogLine(line);
     },
     progress(phase, current, total) {
       const totalStr = total != null ? `/${total}` : "";
       const line = `[${timestamp()}] ${phase}: ${current}${totalStr}`;
-      process.stdout.write(`\r${line}`);
+      process.stderr.write(`\r${line}`);
       writeLogLine(line);
     },
   };

--- a/apps/flex-cli/src/workflow/document.ts
+++ b/apps/flex-cli/src/workflow/document.ts
@@ -1,0 +1,171 @@
+import type { AuthContext } from "../auth/index.js";
+import { postJson } from "./http.js";
+import type { ApprovalLine, Referrer, ResolvedPolicy, UploadedAttachment } from "./types.js";
+
+/**
+ * draft/submit 페이로드의 "공통 본문" 한 덩어리.
+ *
+ * 둘은 endpoint와 attachments의 uploaded 플래그만 다르고 나머지는 동일하므로
+ * caller가 두 번 만들지 않도록 한 번에 빌드한다.
+ */
+export interface DocumentPayload {
+  templateKey: string;
+  title: string;
+  /** HTML 문자열. 빈 문자열이면 양식 default가 들어감 */
+  content: string;
+  inputs: Array<{ inputFieldIdHash: string; value: string }>;
+  attachments: UploadedAttachment[];
+  approvalLines: ApprovalLine[];
+  referrers: Referrer[];
+  matchingData: ResolvedPolicy["matchingData"];
+  options: Record<string, unknown>;
+}
+
+interface DraftCreateResponse {
+  draft?: {
+    document?: {
+      documentKey?: string;
+      attachments?: Array<{
+        idHash?: string;
+        file?: { fileKey?: string; fileName?: string; downloadUrl?: string };
+      }>;
+    };
+  };
+}
+
+interface SubmitResponse {
+  document?: {
+    documentKey?: string;
+    code?: string;
+    status?: string;
+  };
+  approvalProcess?: { status?: string };
+}
+
+/**
+ * 빈 attachments 로 draft를 생성한다. 첫 호출이라 documentKey가 응답으로 내려옴.
+ */
+export async function createDraft(
+  authCtx: AuthContext,
+  baseUrl: string,
+  payload: DocumentPayload,
+): Promise<{ documentKey: string }> {
+  const body = serializePayload(payload, { uploadedFlag: true });
+  const res = await postJson<DraftCreateResponse>(
+    authCtx,
+    `${baseUrl}/api/v3/approval-document/approval-documents/draft`,
+    body,
+  );
+  const documentKey = res.draft?.document?.documentKey;
+  if (!documentKey) {
+    throw new Error("draft 생성 응답에 documentKey가 없습니다");
+  }
+  return { documentKey };
+}
+
+/**
+ * 임시 fileKey로 attachments를 등록하고 응답에서 영구 fileKey를 추출한다.
+ *
+ * 서버는 이 호출에서 S3 임시 객체를 영구 저장소로 이동시키고 새 fileKey를 발급한다.
+ * 두 fileKey는 1:1 대응되며 attachments 배열 순서가 보존된다고 가정한다.
+ */
+export async function registerAttachments(
+  authCtx: AuthContext,
+  baseUrl: string,
+  documentKey: string,
+  payload: DocumentPayload,
+): Promise<UploadedAttachment[]> {
+  if (payload.attachments.length === 0) return [];
+
+  const body = serializePayload(payload, { uploadedFlag: false });
+  const res = await postJson<DraftCreateResponse>(
+    authCtx,
+    `${baseUrl}/api/v3/approval-document/approval-documents/draft?documentKey=${encodeURIComponent(documentKey)}`,
+    body,
+  );
+
+  const respAttachments = res.draft?.document?.attachments ?? [];
+  if (respAttachments.length !== payload.attachments.length) {
+    throw new Error(
+      `draft 응답의 attachments 개수가 요청과 다릅니다: req=${payload.attachments.length}, resp=${respAttachments.length}`,
+    );
+  }
+
+  return payload.attachments.map((att, idx) => {
+    const perm = respAttachments[idx]?.file?.fileKey;
+    if (!perm) {
+      throw new Error(
+        `attachment ${idx} (${att.name})에 영구 fileKey가 발급되지 않았습니다`,
+      );
+    }
+    return { ...att, permFileKey: perm };
+  });
+}
+
+/**
+ * 결재 상신. 응답에서 발급된 문서번호(code)를 돌려준다.
+ */
+export async function submitDocument(
+  authCtx: AuthContext,
+  baseUrl: string,
+  documentKey: string,
+  payload: DocumentPayload,
+): Promise<{ documentKey: string; code: string; status: string }> {
+  const body = serializePayload(payload, { uploadedFlag: true });
+  const res = await postJson<SubmitResponse>(
+    authCtx,
+    `${baseUrl}/api/v3/approval-document/approval-documents?documentKey=${encodeURIComponent(documentKey)}`,
+    body,
+  );
+  const code = res.document?.code;
+  if (!code) {
+    throw new Error("submit 응답에 문서번호(code)가 없습니다");
+  }
+  return {
+    documentKey: res.document?.documentKey ?? documentKey,
+    code,
+    status: res.document?.status ?? "UNKNOWN",
+  };
+}
+
+/**
+ * draft/submit 페이로드 직렬화.
+ *
+ * uploadedFlag=false 는 "이 fileKey는 임시 fileKey라 영구로 변환해줘" 신호이고,
+ * uploadedFlag=true 는 "이미 영구 fileKey로 굳었다" 신호다.
+ * 후자에 임시 fileKey를 실으면 서버가 거부한다.
+ */
+function serializePayload(
+  payload: DocumentPayload,
+  opts: { uploadedFlag: boolean },
+): unknown {
+  const attachments = payload.attachments.map((att) => ({
+    name: att.name,
+    fileKey: opts.uploadedFlag ? (att.permFileKey ?? att.fileKey) : att.fileKey,
+    uploaded: opts.uploadedFlag,
+  }));
+
+  return {
+    document: {
+      templateKey: payload.templateKey,
+      title: payload.title,
+      content: payload.content,
+      inputs: payload.inputs,
+      attachments,
+    },
+    approvalProcess: {
+      lines: payload.approvalLines.map((l) => ({
+        step: l.step,
+        actors: l.actors.map((a) => ({
+          resolveTarget: { type: a.type, value: a.value },
+        })),
+      })),
+      referrers: payload.referrers.map((r) => ({
+        resolveTarget: { type: r.type, value: r.value },
+        notificationSetting: r.notificationSetting,
+      })),
+      option: payload.options,
+      matchingData: payload.matchingData,
+    },
+  };
+}

--- a/apps/flex-cli/src/workflow/document.ts
+++ b/apps/flex-cli/src/workflow/document.ts
@@ -25,12 +25,14 @@ interface DraftCreateResponse {
   draft?: {
     document?: {
       documentKey?: string;
-      attachments?: Array<{
-        idHash?: string;
-        file?: { fileKey?: string; fileName?: string; downloadUrl?: string };
-      }>;
+      attachments?: DraftAttachmentResp[];
     };
   };
+}
+
+interface DraftAttachmentResp {
+  idHash?: string;
+  file?: { fileKey?: string; fileName?: string; downloadUrl?: string };
 }
 
 interface SubmitResponse {
@@ -91,8 +93,15 @@ export async function registerAttachments(
     );
   }
 
+  // 매칭 우선순위:
+  //   1) idx 매칭의 fileName이 일치 → 인덱스 그대로
+  //   2) 동일 인덱스의 fileName이 다르면 같은 이름의 응답 항목으로 fallback
+  //      (서버가 정렬을 바꾸는 케이스 대비)
+  //   3) 응답에 fileName 자체가 없으면 인덱스 매칭에 의존 (캡처 시점엔 항상 있었음)
+  // 동일 이름 다중 첨부 케이스는 first-match로 떨어진다 — CLI에서 같은 파일을 두 번
+  // 명시하는 건 사용자 책임 영역이라 1차 구현은 여기까지만 방어한다.
   return payload.attachments.map((att, idx) => {
-    const perm = respAttachments[idx]?.file?.fileKey;
+    const perm = pickPermFileKey(respAttachments, idx, att.name);
     if (!perm) {
       throw new Error(
         `attachment ${idx} (${att.name})에 영구 fileKey가 발급되지 않았습니다`,
@@ -100,6 +109,20 @@ export async function registerAttachments(
     }
     return { ...att, permFileKey: perm };
   });
+}
+
+function pickPermFileKey(
+  resp: DraftAttachmentResp[],
+  idx: number,
+  expectedName: string,
+): string | undefined {
+  const direct = resp[idx];
+  if (direct?.file?.fileKey && (!direct.file.fileName || direct.file.fileName === expectedName)) {
+    return direct.file.fileKey;
+  }
+  const byName = resp.find((r) => r.file?.fileName === expectedName && r.file?.fileKey);
+  if (byName?.file?.fileKey) return byName.file.fileKey;
+  return direct?.file?.fileKey;
 }
 
 /**

--- a/apps/flex-cli/src/workflow/file.ts
+++ b/apps/flex-cli/src/workflow/file.ts
@@ -1,0 +1,103 @@
+import { readFile, stat } from "node:fs/promises";
+import path from "node:path";
+import type { AuthContext } from "../auth/index.js";
+import { getJson, postJson, putRaw } from "./http.js";
+import type { PreSignedUrlResponse, UploadedAttachment } from "./types.js";
+
+/**
+ * 워크플로우 첨부파일 업로드 3단계.
+ *   1) pre-signed URL 발급 → temp fileKey + S3 PUT URL
+ *   2) S3에 파일 바이트를 직접 PUT
+ *   3) 서버에 verify 호출 → S3 객체 존재 확인 + verifiedAt 마킹
+ *
+ * 주의: 여기서 받는 fileKey는 "임시" 키다. draft에 attachments[fileKey, uploaded:false]
+ * 형태로 한 번 등록한 뒤 응답에서 영구 fileKey를 꺼내는 변환 단계는 document.ts 가 담당.
+ */
+export async function uploadAttachment(
+  authCtx: AuthContext,
+  baseUrl: string,
+  filePath: string,
+): Promise<UploadedAttachment> {
+  const absolute = path.resolve(filePath);
+  const stats = await stat(absolute);
+  if (!stats.isFile()) {
+    throw new Error(`첨부 대상이 일반 파일이 아닙니다: ${filePath}`);
+  }
+  const name = path.basename(absolute);
+  const mimeType = guessMimeType(name);
+  const bytes = await readFile(absolute);
+
+  const presigned = await postJson<PreSignedUrlResponse>(
+    authCtx,
+    `${baseUrl}/api/v2/file/users/me/files/temporary/pre-signed-url`,
+    {
+      name,
+      size: stats.size,
+      sourceType: "WORKFLOW_TASK_ATTACHMENT",
+      sensitiveFile: false,
+      mimeType,
+    },
+  );
+
+  await putRaw(presigned.uploadUrl, bytes, mimeType);
+
+  // verify 응답이 200이면 이후 draft에 fileKey를 등록할 수 있다는 신호.
+  // 응답 본문은 verifiedAt 정도만 들어 있어 굳이 들고 다닐 필요 없으므로 throw away.
+  await getJson<unknown>(
+    authCtx,
+    `${baseUrl}/api/v2/file/users/me/files/temporary/${encodeURIComponent(presigned.fileKey)}/pre-signed-url/verify`,
+  );
+
+  return {
+    fileKey: presigned.fileKey,
+    name,
+    size: stats.size,
+    mimeType,
+  };
+}
+
+/**
+ * 확장자로 MIME을 추정한다. 공식 mime-db를 통째로 끌어오는 대신
+ * 워크플로우 첨부에서 흔한 12개 정도만 다루고 나머지는 octet-stream으로 떨어진다.
+ *
+ * application/octet-stream 으로 보내도 서버는 접수하지만, 미리보기/검색에서 손해를 보므로
+ * 자주 쓰는 포맷은 명시한다.
+ */
+function guessMimeType(filename: string): string {
+  const ext = path.extname(filename).toLowerCase();
+  switch (ext) {
+    case ".pdf":
+      return "application/pdf";
+    case ".png":
+      return "image/png";
+    case ".jpg":
+    case ".jpeg":
+      return "image/jpeg";
+    case ".gif":
+      return "image/gif";
+    case ".webp":
+      return "image/webp";
+    case ".heic":
+      return "image/heic";
+    case ".txt":
+      return "text/plain";
+    case ".csv":
+      return "text/csv";
+    case ".xls":
+      return "application/vnd.ms-excel";
+    case ".xlsx":
+      return "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+    case ".doc":
+      return "application/msword";
+    case ".docx":
+      return "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+    case ".ppt":
+      return "application/vnd.ms-powerpoint";
+    case ".pptx":
+      return "application/vnd.openxmlformats-officedocument.presentationml.presentation";
+    case ".zip":
+      return "application/zip";
+    default:
+      return "application/octet-stream";
+  }
+}

--- a/apps/flex-cli/src/workflow/http.ts
+++ b/apps/flex-cli/src/workflow/http.ts
@@ -1,0 +1,68 @@
+import { apiHeaders, HttpError, type AuthContext } from "../auth/index.js";
+
+/**
+ * workflow/* 모듈 전용 HTTP helper.
+ *
+ * crawlers/shared.ts 의 flexFetch/flexPost 도 비슷한 일을 하지만 두 가지 이유로 별도로 둔다:
+ *   1) crawl은 read 전용이라 4xx 분기/typed 에러가 거의 필요 없는 반면, 워크플로우 작성은
+ *      필수 필드 누락·결재선 미해석 등에서 4xx를 정확히 구분해야 한다 → HttpError로 통일.
+ *   2) S3 pre-signed PUT은 인증 헤더 없이 raw body만 보내야 한다 → 별도 함수로 분리.
+ */
+
+interface HttpOptions {
+  /** 추가/오버라이드할 헤더 */
+  headers?: Record<string, string>;
+}
+
+export async function getJson<T>(
+  authCtx: AuthContext,
+  url: string,
+  opts: HttpOptions = {},
+): Promise<T> {
+  const res = await fetch(url, { headers: apiHeaders(authCtx, opts.headers) });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new HttpError(res.status, `GET ${url}`, text);
+  }
+  return (await res.json()) as T;
+}
+
+export async function postJson<T>(
+  authCtx: AuthContext,
+  url: string,
+  body: unknown,
+  opts: HttpOptions = {},
+): Promise<T> {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: apiHeaders(authCtx, opts.headers),
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new HttpError(res.status, `POST ${url}`, text);
+  }
+  return (await res.json()) as T;
+}
+
+/**
+ * S3 pre-signed URL에 raw 바이트를 PUT한다.
+ * 인증 헤더는 동봉하지 않고 (URL 자체에 AWS 서명이 들어있음) content-type만 일치시킨다.
+ */
+export async function putRaw(
+  url: string,
+  body: Uint8Array,
+  contentType: string,
+): Promise<void> {
+  // BodyInit 으로의 좁힘 — @types/node의 Uint8Array는 Generic으로 들고 다니지만 (ArrayBufferLike)
+  // DOM 의 BufferSource 는 ArrayBuffer 한정이라 직대입이 거부된다. 런타임 호환은 보장됨.
+  const res = await fetch(url, {
+    method: "PUT",
+    headers: { "content-type": contentType },
+    body: body as BodyInit,
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new HttpError(res.status, `PUT ${url}`, text);
+  }
+}

--- a/apps/flex-cli/src/workflow/io.ts
+++ b/apps/flex-cli/src/workflow/io.ts
@@ -1,0 +1,270 @@
+import { readFile } from "node:fs/promises";
+import YAML from "yaml";
+import { z } from "zod";
+import { parseFieldOptions } from "./policy.js";
+import type {
+  ApprovalLine,
+  InputFieldMeta,
+  Referrer,
+  ResolvedPolicy,
+} from "./types.js";
+
+/**
+ * 사용자가 작성하는 입력 YAML.
+ *
+ * fields는 양식 한글 이름 → 값으로 매핑한다 (idHash 노출 회피).
+ * approvalProcess 의 actors는 userIdHash 직입력이지만 describe가 각 항목에 displayName
+ * 코멘트를 자동 첨부하므로 사람이 보기에 충분히 명확하다.
+ */
+// RELATIVE_DEPT_HEAD 의 value 같은 항목은 "1" 처럼 숫자로만 보이면 YAML이 number로
+// 파싱하기 때문에, value 필드는 string|number 모두 받고 string으로 정규화한다.
+const valueAsString = z
+  .union([z.string(), z.number()])
+  .transform((v) => String(v))
+  .pipe(z.string().min(1));
+
+export const inputSchema = z.object({
+  templateKey: z.string().min(1),
+  title: z.string().min(1),
+  content: z.string().optional(),
+  fields: z.record(z.string(), z.unknown()).default({}),
+  attachments: z.array(z.string()).default([]),
+  approvalProcess: z.object({
+    lines: z
+      .array(
+        z.object({
+          step: z.number().int(),
+          actors: z
+            .array(
+              z.object({
+                type: z.string().default("USER"),
+                value: valueAsString,
+              }),
+            )
+            .min(1),
+        }),
+      )
+      .min(1),
+    referrers: z
+      .array(
+        z.object({
+          type: z.string().default("USER"),
+          value: valueAsString,
+          notificationSetting: z.string().default("START_AND_END"),
+        }),
+      )
+      .default([]),
+    matchingData: z.object({
+      matchedAt: z.string().min(1),
+      matchHistoryId: z.string().min(1),
+    }),
+    options: z.record(z.string(), z.unknown()).optional(),
+  }),
+});
+
+export type WorkflowInput = z.infer<typeof inputSchema>;
+
+export async function readInputFile(filePath: string): Promise<WorkflowInput> {
+  const text = await readFile(filePath, "utf-8");
+  let parsed: unknown;
+  try {
+    parsed = YAML.parse(text);
+  } catch (error) {
+    throw new Error(
+      `YAML 파싱 실패 (${filePath}): ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  const result = inputSchema.safeParse(parsed);
+  if (!result.success) {
+    const issues = result.error.issues
+      .map((i) => `  - ${i.path.join(".")}: ${i.message}`)
+      .join("\n");
+    throw new Error(`입력 파일 스키마 검증 실패 (${filePath}):\n${issues}`);
+  }
+  return result.data;
+}
+
+/**
+ * YAML 필드 값(임의 타입)을 서버 페이로드에 들어가는 문자열로 직렬화한다.
+ *
+ * 서버는 필드 값을 모두 string으로 받으며, MULTISELECT/SELECT는 JSON 배열 문자열을,
+ * AMOUNT_OF_MONEY는 숫자를 문자열화한 값을, DATE는 ISO 날짜를 기대한다.
+ * 사용자가 YAML에서 자연스럽게 적은 값(`["PL KR"]`, `10000`, `2026-04-29` 등)을
+ * 서버가 원하는 모양으로 한 번에 변환한다.
+ */
+export function serializeFieldValue(field: InputFieldMeta, raw: unknown): string {
+  // 빈 값 처리 — required 필드의 빈 값은 caller가 사전에 차단한다고 가정.
+  if (raw === undefined || raw === null || raw === "") {
+    if (field.type === "MULTISELECT" || field.type === "TASK_REFERENCE") return "[]";
+    return "";
+  }
+
+  switch (field.type) {
+    case "MULTISELECT": {
+      const arr = Array.isArray(raw) ? raw : [raw];
+      return JSON.stringify(arr.map((x) => String(x)));
+    }
+    case "SELECT": {
+      // SELECT도 서버는 JSON 배열로 받는다 (관찰: `[\"기타\"]`)
+      const arr = Array.isArray(raw) ? raw : [raw];
+      return JSON.stringify(arr.map((x) => String(x)));
+    }
+    case "TASK_REFERENCE": {
+      const arr = Array.isArray(raw) ? raw : [raw];
+      return JSON.stringify(arr);
+    }
+    case "AMOUNT_OF_MONEY":
+      return String(raw);
+    case "DATE":
+      // 사용자가 YAML에 `2026-04-29` 로 적으면 yaml 파서가 Date 객체로 만들어줄 수 있어
+      // ISO 문자열로 정규화한다.
+      if (raw instanceof Date) return raw.toISOString().slice(0, 10);
+      return String(raw);
+    default:
+      return String(raw);
+  }
+}
+
+/**
+ * resolve-policy 응답을 사용자가 채울 빈 YAML 문서로 렌더링한다.
+ *
+ * yaml 패키지의 Document API로 코멘트를 다는 대신 직접 문자열로 만든다 — 결재선 actor
+ * 옆에 ` # 노윤경 (Operation)` 같은 주석을 한 줄에 정확히 붙이는 것이 Document API보다
+ * 템플릿 리터럴이 훨씬 단순하다. 본문 외 부분은 yaml.stringify에 위임.
+ */
+export function renderInputTemplate(policy: ResolvedPolicy): string {
+  const fieldsBlock = renderFieldsBlock(policy.fields);
+  const linesBlock = renderApprovalLinesBlock(policy.approvalLines);
+  const referrersBlock = renderReferrersBlock(policy.referrers);
+
+  // matchingData / options는 그대로 통과 → yaml.stringify 위임
+  const matchingDataYaml = indent(
+    YAML.stringify({ matchingData: policy.matchingData }, { lineWidth: 0 }).trimEnd(),
+    "  ",
+  );
+  const optionsYaml = indent(
+    YAML.stringify({ options: policy.options }, { lineWidth: 0 }).trimEnd(),
+    "  ",
+  );
+
+  return `# ${policy.emoji ? policy.emoji + " " : ""}${policy.templateName}
+# templateKey: ${policy.templateKey}
+#
+# 'fields' 와 'attachments' 를 채워 \`flex-ax workflow submit <file>\` 으로 제출하세요.
+# approvalProcess 는 양식 기본값입니다 — 결재자를 변경하려면 actors의 userIdHash를 수정하세요.
+
+templateKey: ${policy.templateKey}
+title: ""
+# content: ""              # 비워두면 양식 기본 본문이 사용됩니다
+
+fields:
+${fieldsBlock}
+
+attachments: []
+# attachments:
+#   - ./receipts/april.pdf
+
+approvalProcess:
+  lines:
+${linesBlock}
+  referrers:
+${referrersBlock}
+${matchingDataYaml}
+${optionsYaml}
+`;
+}
+
+function renderFieldsBlock(fields: InputFieldMeta[]): string {
+  if (fields.length === 0) return "  {}";
+  const lines: string[] = [];
+  for (const f of fields) {
+    const requiredTag = f.required ? "필수" : "선택";
+    const typeTag = f.type;
+    const optionsHint = describeOptions(f);
+    const prefillHint = f.prefill?.defaultValue
+      ? ` / prefill="${f.prefill.defaultValue}"`
+      : "";
+    lines.push(
+      `  # [${requiredTag}] ${typeTag}${optionsHint}${prefillHint}`,
+    );
+    const placeholder = defaultPlaceholderFor(f);
+    lines.push(`  ${quoteKeyIfNeeded(f.name)}: ${placeholder}`);
+  }
+  return lines.join("\n");
+}
+
+function describeOptions(field: InputFieldMeta): string {
+  const opts = parseFieldOptions(field);
+  if (!opts || opts.length === 0) return "";
+  return ` / options: ${opts.join(", ")}`;
+}
+
+function defaultPlaceholderFor(field: InputFieldMeta): string {
+  // prefill 이 있는 필드(이름/조직 등)는 그 값을 그대로 채워준다 — UI도 동일하게 동작.
+  if (field.prefill?.defaultValue) {
+    return JSON.stringify(field.prefill.defaultValue);
+  }
+  switch (field.type) {
+    case "MULTISELECT":
+    case "TASK_REFERENCE":
+      return "[]";
+    case "AMOUNT_OF_MONEY":
+      return "0";
+    case "DATE":
+      return '""';
+    default:
+      return '""';
+  }
+}
+
+function renderApprovalLinesBlock(lines: ApprovalLine[]): string {
+  if (lines.length === 0) return "    []";
+  const out: string[] = [];
+  for (const line of lines) {
+    out.push(`    - step: ${line.step}`);
+    out.push(`      actors:`);
+    for (const actor of line.actors) {
+      const comment = actor.displayName ? `  # ${actor.displayName}` : "";
+      // type이 USER가 아닐 경우만 명시 — 90%의 경우 USER라 노이즈 줄임
+      if (actor.type === "USER") {
+        out.push(`        - { value: ${quoteValue(actor.value)} }${comment}`);
+      } else {
+        out.push(
+          `        - { type: ${actor.type}, value: ${quoteValue(actor.value)} }${comment}`,
+        );
+      }
+    }
+  }
+  return out.join("\n");
+}
+
+function renderReferrersBlock(refs: Referrer[]): string {
+  if (refs.length === 0) return "    []";
+  const out: string[] = [];
+  for (const r of refs) {
+    const comment = r.displayName ? `  # ${r.displayName}` : "";
+    out.push(
+      `    - { type: ${r.type}, value: ${quoteValue(r.value)}, notificationSetting: ${r.notificationSetting} }${comment}`,
+    );
+  }
+  return out.join("\n");
+}
+
+function quoteValue(v: string): string {
+  // 영숫자/_/-만 있으면 따옴표 없이, 아니면 JSON 인코딩
+  if (/^[A-Za-z0-9_-]+$/.test(v)) return v;
+  return JSON.stringify(v);
+}
+
+function quoteKeyIfNeeded(key: string): string {
+  // YAML 키에 콜론이나 시작 특수문자가 있으면 인용 — 한글/공백/괄호는 무인용으로 통과 가능.
+  if (/[:#&*!|>'"%@`,\[\]\{\}]/.test(key)) return JSON.stringify(key);
+  return key;
+}
+
+function indent(text: string, prefix: string): string {
+  return text
+    .split("\n")
+    .map((line) => (line.length > 0 ? prefix + line : line))
+    .join("\n");
+}

--- a/apps/flex-cli/src/workflow/io.ts
+++ b/apps/flex-cli/src/workflow/io.ts
@@ -2,6 +2,7 @@ import { readFile } from "node:fs/promises";
 import YAML from "yaml";
 import { z } from "zod";
 import { parseFieldOptions } from "./policy.js";
+import { decodeEmoji } from "./templates.js";
 import type {
   ApprovalLine,
   InputFieldMeta,
@@ -147,7 +148,8 @@ export function renderInputTemplate(policy: ResolvedPolicy): string {
     "  ",
   );
 
-  return `# ${policy.emoji ? policy.emoji + " " : ""}${policy.templateName}
+  const emoji = decodeEmoji(policy.emoji);
+  return `# ${emoji ? emoji + " " : ""}${policy.templateName}
 # templateKey: ${policy.templateKey}
 #
 # 'fields' 와 'attachments' 를 채워 \`flex-ax workflow submit <file>\` 으로 제출하세요.

--- a/apps/flex-cli/src/workflow/policy.ts
+++ b/apps/flex-cli/src/workflow/policy.ts
@@ -1,0 +1,131 @@
+import type { AuthContext } from "../auth/index.js";
+import { postJson } from "./http.js";
+import type {
+  ApprovalLine,
+  AvailableTemplate,
+  InputFieldMeta,
+  MatchingData,
+  Referrer,
+  ResolvedPolicy,
+} from "./types.js";
+
+/**
+ * resolve-policy 응답을 우리가 필요한 모양으로 정규화한다.
+ *
+ * 서버 응답은 wrapper가 깊고(approvalProcess.lines[].actors[].resolvedTarget…)
+ * draft/submit 페이로드가 요구하는 모양(resolveTarget — d 빠짐)과 1글자 다르다.
+ * 그 사소한 차이를 caller마다 다시 풀어쓰면 사고나기 좋아서 한 번에 정규화한다.
+ */
+export async function resolvePolicy(
+  authCtx: AuthContext,
+  baseUrl: string,
+  template: AvailableTemplate,
+): Promise<ResolvedPolicy> {
+  const url = `${baseUrl}/action/v3/approval-document-template/templates/${template.templateKey}/resolve-policy`;
+  const raw = await postJson<RawResolvePolicyResponse>(authCtx, url, {});
+
+  const fields = (raw.template?.inputFields ?? []).map<InputFieldMeta>((f) => ({
+    inputFieldIdHash: f.idHash,
+    name: f.name,
+    displayOrder: f.displayOrder,
+    type: f.type,
+    required: !!f.required,
+    data: f.data,
+    prefill: f.prefill,
+  }));
+  fields.sort((a, b) => a.displayOrder - b.displayOrder);
+
+  // resolve-policy 응답은 결재선/referrers 를 approvalPolicyMatched.matchedStep 안에 둔다.
+  // 반면 draft/submit 페이로드에서는 approvalProcess.lines / approvalProcess.referrers /
+  // approvalProcess.matchingData 로 평탄화돼 들어간다. 그 비대칭을 한 번에 정규화한다.
+  const matched = raw.approvalPolicyMatched;
+  if (!matched) {
+    throw new Error(
+      `resolve-policy 응답에 approvalPolicyMatched 가 없습니다 (templateKey=${template.templateKey})`,
+    );
+  }
+
+  const stepActors = matched.matchedStep?.stepActors ?? [];
+  const approvalLines: ApprovalLine[] = stepActors.map((l) => ({
+    step: l.step,
+    actors: (l.actors ?? []).map((a) => ({
+      type: a.resolveTarget?.type ?? "USER",
+      value: a.resolveTarget?.value ?? "",
+      // resolve-policy 응답은 displayName을 주지 않는다. describe 출력에서 이름 주석을
+      // 넣으려면 별도 user lookup이 필요한데, YAGNI 에 따라 1차 구현은 hash만 노출.
+    })),
+  }));
+
+  const referrers: Referrer[] = (matched.matchedStep?.referrers ?? []).map((r) => ({
+    type: r.resolveTarget?.type ?? "USER",
+    value: r.resolveTarget?.value ?? "",
+    notificationSetting: r.notificationSetting ?? "START_AND_END",
+  }));
+
+  // 응답 키는 matchMetadata, 요청 키는 matchingData — 내부에서는 요청 모양(matchingData)으로 통일.
+  const matchingData: MatchingData = matched.matchMetadata ?? {
+    matchedAt: "",
+    matchHistoryId: "",
+  };
+  if (!matchingData.matchHistoryId) {
+    throw new Error(
+      `resolve-policy 응답에 matchMetadata 가 없습니다 (templateKey=${template.templateKey})`,
+    );
+  }
+
+  return {
+    templateKey: template.templateKey,
+    templateName: template.name,
+    emoji: template.emoji,
+    defaultContent: raw.template?.content ?? "",
+    fields,
+    approvalLines,
+    referrers,
+    matchingData,
+    options: matched.option ?? { approvalStepEditEnabled: true },
+  };
+}
+
+// --- raw API 응답 타입 ---
+
+interface RawResolvePolicyResponse {
+  template?: {
+    templateKey?: string;
+    content?: string;
+    inputFields?: Array<{
+      idHash: string;
+      name: string;
+      displayOrder: number;
+      type: string;
+      data?: string;
+      required?: boolean;
+      prefill?: { defaultValue: string; type: string };
+    }>;
+  };
+  approvalPolicyMatched?: {
+    matchMetadata?: MatchingData;
+    option?: Record<string, unknown>;
+    matchedStep?: {
+      stepActors?: Array<{
+        step: number;
+        actors?: Array<{ resolveTarget?: { type: string; value: string } }>;
+      }>;
+      referrers?: Array<{
+        resolveTarget?: { type: string; value: string };
+        notificationSetting?: string;
+      }>;
+    };
+  };
+}
+
+/** SELECT/MULTISELECT 같은 enum 필드의 선택지를 파싱한다 (서버는 JSON 문자열로 줌) */
+export function parseFieldOptions(field: InputFieldMeta): string[] | null {
+  if (!field.data) return null;
+  try {
+    const parsed = JSON.parse(field.data);
+    if (Array.isArray(parsed)) return parsed.map((x) => String(x));
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/flex-cli/src/workflow/templates.ts
+++ b/apps/flex-cli/src/workflow/templates.ts
@@ -1,0 +1,57 @@
+import type { AuthContext } from "../auth/index.js";
+import { getJson } from "./http.js";
+import type { AvailableTemplate } from "./types.js";
+
+interface AvailableTemplatesResponse {
+  templates?: AvailableTemplate[];
+}
+
+/**
+ * 작성자가 실제로 작성 가능한 양식 목록을 조회한다.
+ *
+ * crawl은 `/api/v3/approval-document-template/templates` 를 쓰지만 그쪽은
+ * "관리자가 보는 모든 양식" 이라 사용자에게 권한이 없는 양식까지 나온다.
+ * 작성 플로우에서는 권한 필터된 `available-templates` 가 맞다.
+ */
+export async function listAvailableTemplates(
+  authCtx: AuthContext,
+  baseUrl: string,
+): Promise<AvailableTemplate[]> {
+  const data = await getJson<AvailableTemplatesResponse>(
+    authCtx,
+    `${baseUrl}/api/v3/approval-document-template/available-templates`,
+  );
+  return data.templates ?? [];
+}
+
+/**
+ * 사용자가 입력한 키 또는 이름으로 양식 한 건을 찾는다.
+ *
+ * 매칭 우선순위:
+ *   1) templateKey 완전 일치
+ *   2) name 완전 일치 (대소문자 무시)
+ *   3) name이 부분 일치하는 후보가 정확히 1건이면 그것
+ *
+ * 부분 일치 후보가 2건 이상이면 사용자에게 명시적 선택을 요구하기 위해 에러로 던진다.
+ */
+export function findTemplate(
+  templates: AvailableTemplate[],
+  query: string,
+): AvailableTemplate {
+  const exactKey = templates.find((t) => t.templateKey === query);
+  if (exactKey) return exactKey;
+
+  const lowerQuery = query.toLowerCase();
+  const exactName = templates.find((t) => t.name.toLowerCase() === lowerQuery);
+  if (exactName) return exactName;
+
+  const partial = templates.filter((t) => t.name.toLowerCase().includes(lowerQuery));
+  if (partial.length === 1) return partial[0];
+  if (partial.length > 1) {
+    throw new Error(
+      `"${query}" 와(과) 부분 일치하는 양식이 ${partial.length}개입니다. ` +
+        `templateKey나 정확한 이름을 사용하세요: ${partial.map((t) => `"${t.name}"`).join(", ")}`,
+    );
+  }
+  throw new Error(`"${query}" 에 매칭되는 양식이 없습니다 (${templates.length}개 중)`);
+}

--- a/apps/flex-cli/src/workflow/templates.ts
+++ b/apps/flex-cli/src/workflow/templates.ts
@@ -7,6 +7,25 @@ interface AvailableTemplatesResponse {
 }
 
 /**
+ * 서버는 emoji를 `"U+1F5D2-U+FE0F"` 같은 코드포인트 문자열로 내려준다.
+ * 출력 시점에 실제 글자로 디코딩한다 — 디코딩 실패는 원본을 그대로 돌려줘
+ * 사용자가 적어도 어떤 양식인지 식별 가능하도록 한다.
+ */
+export function decodeEmoji(encoded: string | undefined): string {
+  if (!encoded) return "";
+  const codepoints = encoded
+    .split("-")
+    .map((s) => parseInt(s.replace(/^U\+/i, ""), 16))
+    .filter((n) => Number.isFinite(n));
+  if (codepoints.length === 0) return encoded;
+  try {
+    return String.fromCodePoint(...codepoints);
+  } catch {
+    return encoded;
+  }
+}
+
+/**
  * 작성자가 실제로 작성 가능한 양식 목록을 조회한다.
  *
  * crawl은 `/api/v3/approval-document-template/templates` 를 쓰지만 그쪽은

--- a/apps/flex-cli/src/workflow/types.ts
+++ b/apps/flex-cli/src/workflow/types.ts
@@ -1,0 +1,107 @@
+/**
+ * 워크플로우 결재 문서 작성에 필요한 내부 타입 정의.
+ *
+ * 서버 응답을 그대로 옮겨두면 inner 객체 분기가 코드 곳곳에 퍼지므로,
+ * 우리가 다루는 좁은 모양으로 한 번 정규화한 뒤 모듈 간 공유한다.
+ */
+
+/** GET /api/v3/approval-document-template/available-templates 응답 한 항목 */
+export interface AvailableTemplate {
+  templateKey: string;
+  name: string;
+  emoji?: string;
+  description?: string;
+  tags?: Array<{ idHash: string; name: string; displayOrder?: number }>;
+}
+
+/** resolve-policy 응답에서 추출한 입력 필드 메타데이터 */
+export interface InputFieldMeta {
+  /** 서버 페이로드의 `inputFieldIdHash`로 그대로 들어가는 키 */
+  inputFieldIdHash: string;
+  /** YAML/UI에 노출되는 사람-친화 이름. 한 양식 안에서 유일하다고 가정한다. */
+  name: string;
+  displayOrder: number;
+  /**
+   * 서버가 정의한 필드 타입.
+   * STRING / SELECT / MULTISELECT / DATE / AMOUNT_OF_MONEY / TASK_REFERENCE / ...
+   * 실제 캡처에서 본 값들을 narrow type으로 좁혀두지 않은 이유는
+   * 새 양식이 추가될 때마다 코드 변경 없이 통과시키기 위해서다.
+   */
+  type: string;
+  required: boolean;
+  /** SELECT/MULTISELECT의 선택지 등 양식별 보조 데이터 (서버가 JSON 문자열로 줌) */
+  data?: string;
+  /** name·dept 등 작성자 컨텍스트로 자동 채워지는 prefill 정보 */
+  prefill?: {
+    defaultValue: string;
+    type: string; // NAME / DEPARTMENT / NONE / DEFAULT
+  };
+}
+
+/** 결재선 한 단계의 actor */
+export interface ApprovalActor {
+  /** USER, RELATIVE_DEPT_HEAD 등 — 서버 enum을 그대로 통과시킨다 */
+  type: string;
+  value: string;
+  /** describe 출력에서 주석으로 노출하기 위한 사람 이름 */
+  displayName?: string;
+}
+
+export interface ApprovalLine {
+  step: number;
+  actors: ApprovalActor[];
+}
+
+export interface Referrer {
+  type: string;
+  value: string;
+  displayName?: string;
+  /** START / END / START_AND_END / NONE — 서버 enum 그대로 */
+  notificationSetting: string;
+}
+
+/**
+ * resolve-policy가 결재선 매칭에 쓴 컨텍스트. submit 페이로드에 그대로 동봉해야
+ * 서버가 "이 결재선은 이 매칭에서 나온 것"이라고 인식한다.
+ */
+export interface MatchingData {
+  matchedAt: string;
+  matchHistoryId: string;
+}
+
+/** 양식 한 개에 대한 작성 가능한 모양으로 정규화된 정책 */
+export interface ResolvedPolicy {
+  templateKey: string;
+  templateName: string;
+  emoji?: string;
+  /** UI에서 보이는 본문 placeholder (HTML). 사용자가 미지정 시 default로 쓴다 */
+  defaultContent: string;
+  fields: InputFieldMeta[];
+  approvalLines: ApprovalLine[];
+  referrers: Referrer[];
+  matchingData: MatchingData;
+  /** approvalProcess.option 그대로 통과 — 1차 구현에서는 caller가 건드리지 않는다 */
+  options: Record<string, unknown>;
+}
+
+/** pre-signed-url 발급 응답 */
+export interface PreSignedUrlResponse {
+  fileKey: string;
+  name: string;
+  mimeType: string;
+  size: number;
+  uploadMethod: string; // "PRE_SIGNED"
+  uploadUrl: string;
+  sourceType: string;
+}
+
+/** 업로드 완료 후 영구 fileKey를 들고 있는 attachment 표현 */
+export interface UploadedAttachment {
+  /** 업로드 직후 받은 임시 fileKey — draft 1회 갱신 후에는 영구 fileKey로 교체된다 */
+  fileKey: string;
+  name: string;
+  size: number;
+  mimeType: string;
+  /** draft 응답에서 받아 저장 — submit 페이로드에 들어가는 영구 키 */
+  permFileKey?: string;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       semver:
         specifier: ^7.7.4
         version: 7.7.4
+      yaml:
+        specifier: ^2.6.1
+        version: 2.8.3
       zod:
         specifier: ^3.24.2
         version: 3.25.76
@@ -757,6 +760,11 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
@@ -1365,5 +1373,7 @@ snapshots:
       webidl-conversions: 3.0.1
 
   wrappy@1.0.2: {}
+
+  yaml@2.8.3: {}
 
   zod@3.25.76: {}


### PR DESCRIPTION
## Summary

기존엔 read 전용이던 flex-cli에 결재 문서 작성 경로 추가. 비용 결제 요청 같은 워크플로우 양식을 비대화식으로 채워 첨부파일과 함께 제출할 수 있다. 설계는 #29 에서 합의된 결정 그대로.

```
flex-ax workflow templates              # 작성 가능한 양식 목록
flex-ax workflow describe <key|이름>    # YAML 입력 템플릿 출력
flex-ax workflow submit <file>          # 채운 YAML 로 작성·제출
                                        #   --draft / --dry-run / --customer
```

호출 시퀀스 (#29 캡처 기반):

```
resolve-policy
  → (per attachment) pre-signed-url + S3 PUT + verify
  → draft 생성
  → 첨부 등록 호출에서 영구 fileKey 변환
  → submit (--draft 면 생략)
```

## 부수 변경

- **logger 출력을 stdout → stderr 로 이전.** `workflow describe` 의 YAML 결과나 `query` 결과 같은 stdout 전용 출력이 진행 로그와 섞이지 않도록 분리. 명령 결과를 파일로 redirect 하는 사용 패턴이 깨끗해진다. 사용자에게 보이는 TTY 출력은 동일.
- `[FLEX-AX:AUTH] 로그인 성공` 한 줄도 같은 이유로 stderr 로 이전.
- `yaml@2.6.1` 의존성 추가 (입력 YAML 파싱).

## 설계 결정 (#29 와 일치)

1. **결재선 actor 입력 형식 → 주석으로** — describe 출력의 actors 옆에 hash 만 노출. resolve-policy 응답이 displayName 을 주지 않는 케이스가 있어 1차 구현은 hash 만, 사람 매칭은 사용자가 자체 이메일/노션 등으로 하도록 둠 (YAGNI).
2. **content HTML 기본값 → resolve-policy default 그대로** — 비우면 양식의 작성 가이드를 잃으므로 default 송출.
3. **flex-ax workflow 네임스페이스 → 현재 구조 유지** — 추후 `approve`/`reject`/`recall` 같은 동사 자연 흡수 가능.
4. **draft 1회 압축** — UI 의 디바운스 기인 다회 갱신을 1 회 draft (영구 fileKey 변환만) + submit 으로 압축. 검증 통과.
5. **첨부 0개** — pre-signed/PUT/verify 단계 전체 스킵.

## 응답 스키마 차이 (캡처와 다른 점)

캡처 시점 본문에서는 `approvalProcess.matchingData` 처럼 평탄한 모양이 보였지만, 실 호출에서 resolve-policy 응답은 `approvalPolicyMatched.matchedStep.stepActors` 와 `approvalPolicyMatched.matchMetadata` 로 한 단계 더 nested 되어 내려왔다. 응답·요청 키 모양이 비대칭이라 (`matchMetadata` 응답 / `matchingData` 요청) 내부에서는 요청 모양으로 통일해서 파싱한다.

## Test plan

- [x] `pnpm build` 통과
- [x] `pnpm tsx src/cli.ts workflow templates --customer <id>` — 양식 목록 출력
- [x] `pnpm tsx src/cli.ts workflow describe "비용 결제 요청" --customer <id>` — YAML 입력 템플릿 stdout, INFO 로그 stderr 로 분리
- [x] `pnpm tsx src/cli.ts workflow submit <file> --dry-run` — 변환된 페이로드 stdout JSON 출력 (호출 0건)
- [x] `pnpm tsx src/cli.ts workflow submit <file> --draft` — 첨부 0개 / 첨부 1개 모두에서 draft 생성 + 영구 fileKey 변환 검증 (제출 호출 생략)
- [ ] 실제 submit 은 #29 검증 시 이미 결재 2건 (2026-168, 2026-169) 발급으로 끝까지 통과 확인됨. 본 PR 머지 후 추가 1건으로 회기 검증 권장.

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)