### PR TITLE
fix(flex-cli): restore exec permission after self-update swap

### DIFF
--- a/apps/flex-cli/package.json
+++ b/apps/flex-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flex-ax",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": true,
   "type": "module",
   "description": "flex HR SaaS AX CLI - discover, crawl, and manage flex data",

--- a/apps/flex-cli/src/commands/update.ts
+++ b/apps/flex-cli/src/commands/update.ts
@@ -1,5 +1,5 @@
 import { copyFile, createReadStream, createWriteStream, existsSync } from "node:fs";
-import { mkdir, readFile, rename, rm, stat } from "node:fs/promises";
+import { chmod, mkdir, readFile, rename, rm, stat } from "node:fs/promises";
 import { createHash } from "node:crypto";
 import { homedir } from "node:os";
 import path from "node:path";
@@ -306,6 +306,9 @@ async function replaceExecutable(payload: HelperPayload): Promise<void> {
     throw error;
   }
 
+  if (process.platform !== "win32") {
+    await chmod(payload.targetPath, 0o755);
+  }
   await ensureExecutableExists(payload.targetPath);
   await rm(backupPath, { force: true }).catch(() => {});
 }


### PR DESCRIPTION
## Summary
- After `flex-ax update` swaps the binary, the new file is left with `0644` permissions and the next invocation dies with `permission denied`.
- The download stream (`createWriteStream` in `downloadReleaseAsset`) creates the staged file with the default 0644 mode, and `replaceExecutable` only renames it into place — so the executable bit is lost.
- This patch chmods the target to `0o755` on POSIX platforms after the rename succeeds.

## Reproduction (before fix, on macOS arm64 against the published 0.7.0 release)
1. Build a Bun executable with version `0.6.5` and run `flex-ax update`.
2. Update completes, `selectAssetForCurrentPlatform` finds `flex-ax-darwin-arm64`, digest verifies, helper swaps the binary.
3. Resulting file: ``-rw-r--r-- size=64143394``.
4. Re-running it: `permission denied`.

## Verification (after fix)
- Built a 0.6.5 fake with this fix applied → `flex-ax update` against `flex-cli@0.7.0` release.
- Helper completed swap in ~2s.
- Resulting file: ``-rwxr-xr-x size=64143394`` ✓
- `./flex-ax-darwin-arm64 --version` → `flex-ax 0.7.1` ✓ (well, `0.7.0` from the released asset; the in-flight 0.6.5 helper is now 0.7.0 with the fix)
- Bumped `apps/flex-cli/package.json` version to `0.7.1` so the next tagged release (`flex-cli@0.7.1`) carries the fix.

## Notes
- Windows path is skipped via `process.platform !== "win32"` since POSIX execute bits don't apply there. The Windows binary smoke-tests already pass in CI as before.
- A user who has already self-updated to broken 0.7.0 needs to manually `chmod +x` once, or re-download the 0.7.1 asset, before they can run `flex-ax update` again.

## Test plan
- [x] Local end-to-end: 0.6.5 → 0.7.0 self-update on macOS arm64 produces an executable file
- [ ] CI: `Verify flex-cli Bun executable` matrix (macOS / Linux / Windows) passes
- [ ] After merge, tag `flex-cli@0.7.1` and verify the released asset (macOS) self-updates cleanly from 0.7.0