### PR TITLE
Fix flex-cli help UX for fresh installs

### DIFF
--- a/apps/flex-cli/package.json
+++ b/apps/flex-cli/package.json
@@ -17,7 +17,7 @@
     "install-skills": "tsx src/cli.ts install-skills",
     "build": "tsc -p tsconfig.build.json && node scripts/postbuild.cjs",
     "build:exe": "bun build --compile src/cli.ts --outfile bun-dist/flex-ax",
-    "test": "tsx --test src/**/*.test.ts",
+    "test": "tsx --test src/*.test.ts src/**/*.test.ts",
     "lint": "tsc --noEmit",
     "clean": "rimraf output dist"
   },

--- a/apps/flex-cli/src/cli-help.test.ts
+++ b/apps/flex-cli/src/cli-help.test.ts
@@ -1,0 +1,40 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { getCommandHelp, getTopLevelHelp, isHelpFlag } from "./cli-help.js";
+
+describe("isHelpFlag", () => {
+  it("recognizes supported help flags", () => {
+    assert.equal(isHelpFlag("--help"), true);
+    assert.equal(isHelpFlag("-h"), true);
+    assert.equal(isHelpFlag("--version"), false);
+  });
+});
+
+describe("getTopLevelHelp", () => {
+  it("mentions the local-dump flow and OUTPUT_DIR guidance", () => {
+    const help = getTopLevelHelp();
+    assert.match(help, /login -> status -> crawl -> import -> query/);
+    assert.match(help, /OUTPUT_DIR=<export-dir> flex-ax query/);
+    assert.doesNotMatch(help, /Unknown command/);
+  });
+});
+
+describe("getCommandHelp", () => {
+  it("returns login help without command execution", () => {
+    const help = getCommandHelp("login");
+    assert.ok(help);
+    assert.match(help, /Usage: flex-ax login/);
+    assert.match(help, /password-stdin/);
+  });
+
+  it("returns query help with OUTPUT_DIR guidance", () => {
+    const help = getCommandHelp("query");
+    assert.ok(help);
+    assert.match(help, /Usage: flex-ax query/);
+    assert.match(help, /OUTPUT_DIR=<export-dir>/);
+  });
+
+  it("returns null for unknown commands", () => {
+    assert.equal(getCommandHelp("missing"), null);
+  });
+});

--- a/apps/flex-cli/src/cli-help.ts
+++ b/apps/flex-cli/src/cli-help.ts
@@ -1,0 +1,95 @@
+const TOP_LEVEL_COMMANDS = `Commands:
+  login           이메일/비밀번호 등록 (이메일은 ~/.flex-ax/config.json,
+                  비밀번호는 OS 키링; 검증 후 저장)
+                  비대화식: FLEX_EMAIL/FLEX_PASSWORD env 또는
+                  --password-stdin 으로 stdin 파이프 입력 가능
+  logout          OS 키링에서 비밀번호 삭제 (글로벌 config의 이메일은 보존)
+  status          현재 등록 상태 표시 (비밀번호 값은 마스킹)
+  crawl           카탈로그 기반 크롤링 → output/ 저장
+  import          크롤링 결과(JSON) → SQLite DB 변환
+  query "SQL"     DB 쿼리 실행 → JSON 출력 (read-only)
+                  --file <path>  SQL 파일 경로
+                  --var key=value  {{key}} 플레이스홀더 치환 (반복 가능)
+  file <fileKey>  파일 내용 출력 (--info로 메타데이터만)
+  workflow <sub>  결재 문서 작성/제출 (templates / describe / submit)
+  check-apis      하드코딩된 API 엔드포인트 상태 확인
+  install-skills  에이전트 스킬을 .claude/skills/에 설치
+  update          최신 버전으로 업데이트`;
+
+const TOP_LEVEL_NOTES = `Workflow:
+  login -> status -> crawl -> import -> query
+
+Multi-export query:
+  OUTPUT_DIR=<export-dir> flex-ax query "SELECT 1 AS x"
+  export 디렉터리가 여러 개면 OUTPUT_DIR로 사용할 대상 하나를 명시해야 합니다.
+
+Options:
+  --version, -v       버전 출력
+  --help, -h          도움말 출력
+  --password-stdin    (login 전용) 비밀번호를 stdin 파이프로 주입
+
+Env:
+  FLEX_EMAIL                  선택 — 지정 시 글로벌 config보다 우선
+                              (평소엔 flex-ax login 으로 한 번만 등록)
+  FLEX_PASSWORD               선택 — 지정 시 키링/프롬프트보다 우선
+                              (CI에서 사용)
+  FLEX_BASE_URL               기본 https://flex.team
+  FLEX_CUSTOMERS              크롤 대상 법인 customerIdHash (콤마 구분)
+  FLEX_AX_AUTO_UPDATE=false   기동 시 자동 업데이트 비활성화`;
+
+const COMMAND_HELP: Record<string, string> = {
+  login: `Usage: flex-ax login [--password-stdin]
+
+이메일/비밀번호를 등록합니다.
+--password-stdin 을 사용하면 stdin 파이프로 비밀번호를 주입할 수 있습니다.`,
+  logout: `Usage: flex-ax logout
+
+OS 키링에서 저장된 비밀번호를 삭제합니다.`,
+  status: `Usage: flex-ax status
+
+현재 등록된 로그인 상태를 표시합니다.`,
+  crawl: `Usage: flex-ax crawl
+
+카탈로그 기반으로 데이터를 수집해 output/ 아래에 저장합니다.`,
+  import: `Usage: flex-ax import
+
+크롤링 결과(JSON)를 SQLite로 변환합니다.
+export 디렉터리가 여러 개면 OUTPUT_DIR=<export-dir> 로 대상을 지정하세요.`,
+  query: `Usage: flex-ax query "SELECT ..."
+       flex-ax query --file queries/search.sql [--var key=value ...]
+
+SQL을 실행하고 결과를 JSON으로 출력합니다 (read-only).
+export 디렉터리가 여러 개면 OUTPUT_DIR=<export-dir> 로 대상을 지정하세요.
+스키마는 apps/flex-cli/src/db/schema.sql 을 참조하세요.`,
+  file: `Usage: flex-ax file <fileKey> [--info]
+
+수집된 파일 본문을 출력하거나 --info 로 메타데이터만 확인합니다.`,
+  workflow: `Usage: flex-ax workflow <templates|describe|submit> [...]
+
+결재 문서 작성/제출 워크플로를 실행합니다.`,
+  "check-apis": `Usage: flex-ax check-apis
+
+하드코딩된 API 엔드포인트 상태를 점검합니다.`,
+  "install-skills": `Usage: flex-ax install-skills
+
+에이전트 스킬을 설치합니다.`,
+  update: `Usage: flex-ax update
+
+최신 버전으로 업데이트합니다.`,
+};
+
+export function isHelpFlag(arg: string | undefined): boolean {
+  return arg === "--help" || arg === "-h";
+}
+
+export function getTopLevelHelp(): string {
+  return `Usage: flex-ax <command>
+
+${TOP_LEVEL_COMMANDS}
+
+${TOP_LEVEL_NOTES}`;
+}
+
+export function getCommandHelp(command: string): string | null {
+  return COMMAND_HELP[command] ?? null;
+}

--- a/apps/flex-cli/src/cli.ts
+++ b/apps/flex-cli/src/cli.ts
@@ -1,11 +1,35 @@
 import { FLEX_AX_VERSION } from "./version.js";
+import { getCommandHelp, getTopLevelHelp, isHelpFlag } from "./cli-help.js";
 
 const originalArgs = process.argv.slice(2);
-const command = originalArgs[0];
+const rawArgs = process.argv.slice(2);
+const command = rawArgs[0];
+const wantsTopLevelHelp = !command || command === "help" || isHelpFlag(command);
+const wantsCommandHelp = !wantsTopLevelHelp && rawArgs.slice(1).some((arg) => isHelpFlag(arg));
 
 if (command === "--version" || command === "-v") {
   console.log(`flex-ax ${FLEX_AX_VERSION}`);
   process.exit(0);
+}
+
+if (wantsTopLevelHelp) {
+  if (command === "help" && rawArgs[1]) {
+    const commandHelp = getCommandHelp(rawArgs[1]);
+    if (commandHelp) {
+      console.log(commandHelp);
+      process.exit(0);
+    }
+  }
+  console.log(getTopLevelHelp());
+  process.exit(0);
+}
+
+if (wantsCommandHelp) {
+  const commandHelp = getCommandHelp(command);
+  if (commandHelp) {
+    console.log(commandHelp);
+    process.exit(0);
+  }
 }
 
 await import("dotenv/config");
@@ -77,40 +101,7 @@ switch (command) {
     break;
   }
   default:
-    if (command && command !== "help") {
-      console.error(`[FLEX-AX:ERROR] Unknown command: ${command}`);
-    }
-    console.log(`Usage: flex-ax <command>
-
-Commands:
-  login           이메일/비밀번호 등록 (이메일은 ~/.flex-ax/config.json,
-                  비밀번호는 OS 키링; 검증 후 저장)
-                  비대화식: FLEX_EMAIL/FLEX_PASSWORD env 또는
-                  --password-stdin 으로 stdin 파이프 입력 가능
-  logout          OS 키링에서 비밀번호 삭제 (글로벌 config의 이메일은 보존)
-  status          현재 등록 상태 표시 (비밀번호 값은 마스킹)
-  crawl           카탈로그 기반 크롤링 → output/ 저장
-  import          크롤링 결과(JSON) → SQLite DB 변환
-  query "SQL"     DB 쿼리 실행 → JSON 출력 (read-only)
-                  --file <path>  SQL 파일 경로
-                  --var key=value  {{key}} 플레이스홀더 치환 (반복 가능)
-  file <fileKey>  파일 내용 출력 (--info로 메타데이터만)
-  workflow <sub>  결재 문서 작성/제출 (templates / describe / submit)
-  check-apis      하드코딩된 API 엔드포인트 상태 확인
-  install-skills  에이전트 스킬을 .claude/skills/에 설치
-  update          최신 버전으로 업데이트
-
-Options:
-  --version, -v       버전 출력
-  --password-stdin    (login 전용) 비밀번호를 stdin 파이프로 주입
-
-Env:
-  FLEX_EMAIL                  선택 — 지정 시 글로벌 config보다 우선
-                              (평소엔 \`flex-ax login\`으로 한 번만 등록)
-  FLEX_PASSWORD               선택 — 지정 시 키링/프롬프트보다 우선
-                              (CI에서 사용)
-  FLEX_BASE_URL               기본 https://flex.team
-  FLEX_CUSTOMERS              크롤 대상 법인 customerIdHash (콤마 구분)
-  FLEX_AX_AUTO_UPDATE=false   기동 시 자동 업데이트 비활성화`);
-    process.exit(command === "help" ? 0 : 1);
+    console.error(`[FLEX-AX:ERROR] Unknown command: ${command}`);
+    console.log(getTopLevelHelp());
+    process.exit(1);
 }


### PR DESCRIPTION
## Summary
- intercept top-level and subcommand help flags before command execution
- add centralized CLI help text with local-dump workflow and OUTPUT_DIR guidance
- cover the help text path with tests and update the test script to include root-level test files

## Root cause
The CLI dispatcher treated unknown help flags as commands and had no subcommand help path, so exploratory help calls could fall through into command execution or error output.

## Validation
- pnpm --filter flex-ax test
- pnpm --filter flex-ax lint
- pnpm --filter flex-ax exec tsx src/cli.ts --help
- pnpm --filter flex-ax exec tsx src/cli.ts query --help

Fixes #35