### PR TITLE
Bump flex-cli to 0.7.2

### DIFF
--- a/apps/flex-cli/package.json
+++ b/apps/flex-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flex-ax",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": true,
   "type": "module",
   "description": "flex HR SaaS AX CLI - discover, crawl, and manage flex data",


### PR DESCRIPTION
## Summary
- bump apps/flex-cli package version from 0.7.1 to 0.7.2 after the help UX fix landed without a release bump

## Validation
- pnpm --filter flex-ax lint
- pnpm --filter flex-ax test