### PR TITLE
perf(flex-crawler): parallelize fetches and fix broken pagination

### DIFF
--- a/apps/flex-crawler/.env.example
+++ b/apps/flex-crawler/.env.example
@@ -14,10 +14,19 @@ FLEX_PASSWORD=your-password
 # 수집 데이터 저장 경로 (기본값: ./output)
 # OUTPUT_DIR=./output
 
-# 요청 간 딜레이 (밀리초, 기본값: 1000)
-# REQUEST_DELAY_MS=1000
+# 요청 간 딜레이 (밀리초, 기본값: 0)
+# 동시성으로 throttling을 대체하므로 평소엔 0. 공유 IP 등 보수적 환경에서만 사용.
+# REQUEST_DELAY_MS=0
 
-# 요청 실패 시 최대 재시도 횟수 (기본값: 3)
+# 인스턴스/템플릿 상세 fetch 동시 워커 수 (기본값: 16)
+# probe 실측: 32까지 429 0건, 64에서 throughput 정점, 96+ 부터 latency만 증가.
+# 더 빠르게 끌어올리고 싶으면 32까지 안전. 그 이상은 latency 페널티 발생.
+# CONCURRENCY=16
+
+# 한 문서 내 첨부파일 다운로드 동시 수 (기본값: 4)
+# ATTACHMENT_CONCURRENCY=4
+
+# 요청 실패 시 최대 재시도 횟수 (기본값: 3, 429는 Retry-After 존중)
 # MAX_RETRIES=3
 
 # 첨부파일 다운로드 여부 (기본값: true)

--- a/apps/flex-crawler/src/config/index.ts
+++ b/apps/flex-crawler/src/config/index.ts
@@ -15,8 +15,26 @@ const configSchema = z.object({
   flexPassword: z.string().default(""),
   flexBaseUrl: z.string().url().default("https://flex.team"),
   outputDir: z.string().default("./output"),
-  requestDelayMs: z.coerce.number().int().min(0).default(1000),
+  /**
+   * 요청 간 의도적 sleep. 동시성으로 throttling을 대체하므로 기본 0.
+   * 외부 환경(공유 IP 풀 등)에서 보수적으로 돌릴 일이 있으면 env로 올린다.
+   */
+  requestDelayMs: z.coerce.number().int().min(0).default(0),
   maxRetries: z.coerce.number().int().min(0).default(3),
+  /**
+   * 인스턴스/템플릿 상세 fetch 동시 워커 수.
+   * probe 실측: 32까지 429 0건, 64에서 throughput 정점, 96부터 latency 증가.
+   * 안전 마진 두고 16을 기본값으로 사용.
+   */
+  concurrency: z.coerce.number().int().min(1).default(16),
+  /** 한 문서의 첨부파일 다운로드 동시 수. */
+  attachmentConcurrency: z.coerce.number().int().min(1).default(4),
+  /**
+   * approval-document 검색 page size.
+   * 이 엔드포인트는 lastDocumentKey 페이지네이션이 동작하지 않아서
+   * 한 번에 다 받는다. 기본 1000이면 대부분 테넌트는 한 방에 끝.
+   */
+  searchPageSize: z.coerce.number().int().min(1).default(1000),
   downloadAttachments: z
     .enum(["true", "false"])
     .transform((v) => v === "true")
@@ -34,6 +52,9 @@ export function loadConfig(): CrawlerConfig {
     outputDir: process.env.OUTPUT_DIR || undefined,
     requestDelayMs: process.env.REQUEST_DELAY_MS || undefined,
     maxRetries: process.env.MAX_RETRIES || undefined,
+    concurrency: process.env.CONCURRENCY || undefined,
+    attachmentConcurrency: process.env.ATTACHMENT_CONCURRENCY || undefined,
+    searchPageSize: process.env.SEARCH_PAGE_SIZE || undefined,
     downloadAttachments: process.env.DOWNLOAD_ATTACHMENTS || undefined,
   });
 }

--- a/apps/flex-crawler/src/crawlers/attendance.ts
+++ b/apps/flex-crawler/src/crawlers/attendance.ts
@@ -91,7 +91,7 @@ export async function crawlAttendanceApprovals(
           });
         }
 
-        await delay(config.requestDelayMs);
+        if (config.requestDelayMs > 0) await delay(config.requestDelayMs);
       }
     } catch (error) {
       // API가 존재하지 않거나 권한이 없는 경우 무시

--- a/apps/flex-crawler/src/crawlers/instance.ts
+++ b/apps/flex-crawler/src/crawlers/instance.ts
@@ -6,12 +6,12 @@ import type { WorkflowInstance } from "../types/instance.js";
 import type { ApprovalStep, AttachmentInfo, FieldValue } from "../types/common.js";
 import {
   type CrawlResult,
-  delay,
   emptyCrawlResult,
   nowISO,
   withRetry,
   flexFetch,
   flexPost,
+  pooledMap,
 } from "./shared.js";
 
 /** 수집된 문서 key 목록을 반환 (근태/휴가 크롤러의 중복 판별용) */
@@ -28,85 +28,86 @@ export async function crawlInstances(
   logger.info("인스턴스(결재 문서) 수집 시작");
 
   try {
-    // 모든 상태의 문서를 수집
-    const statuses = ["IN_PROGRESS", "DONE", "DECLINED", "CANCELED"];
-    let lastDocumentKey: string | undefined;
-    let hasMore = true;
+    // 이 endpoint는 size 파라미터만 페이지네이션으로 동작하고
+    // lastDocumentKey/page/offset 류는 모두 무시한다. (probe-pagination 으로 확인.)
+    // 따라서 충분히 큰 size로 한 번에 받는 방식을 쓴다.
+    const searchBody = {
+      filter: {
+        statuses: ["IN_PROGRESS", "DONE", "DECLINED", "CANCELED"],
+        templateKeys: [],
+        writerHashedIds: [],
+        approverTargets: [],
+        referrerTargets: [],
+        starred: false,
+      },
+      search: { keyword: "", type: "ALL" },
+    };
 
-    while (hasMore) {
-      const searchBody = {
-        filter: {
-          statuses,
-          templateKeys: [],
-          writerHashedIds: [],
-          approverTargets: [],
-          referrerTargets: [],
-          starred: false,
-        },
-        search: { keyword: "", type: "ALL" },
-        ...(lastDocumentKey ? { lastDocumentKey } : {}),
-      };
-
-      const page = await withRetry(
-        () => flexPost<SearchResponse>(
+    const page = await withRetry(
+      () =>
+        flexPost<SearchResponse>(
           authCtx,
-          `${config.flexBaseUrl}/action/v3/approval-document/user-boxes/search?size=20&sortType=LAST_UPDATED_AT&direction=DESC`,
+          `${config.flexBaseUrl}/action/v3/approval-document/user-boxes/search?size=${config.searchPageSize}&sortType=LAST_UPDATED_AT&direction=DESC`,
           searchBody,
         ),
-        { maxRetries: config.maxRetries, delayMs: config.requestDelayMs },
+      { maxRetries: config.maxRetries, delayMs: config.requestDelayMs },
+    );
+
+    const docs = page.documents ?? [];
+    result.totalCount = docs.length;
+    logger.info(
+      `총 ${page.total}건의 문서 발견 (받음: ${docs.length}, concurrency=${config.concurrency})`,
+    );
+    if (page.hasNext || docs.length < page.total) {
+      logger.warn(
+        `검색 결과가 SEARCH_PAGE_SIZE(${config.searchPageSize})보다 큽니다. ` +
+          `놓친 문서가 있을 수 있어요 — SEARCH_PAGE_SIZE를 ${page.total} 이상으로 올려서 다시 실행하세요.`,
       );
+    }
 
-      const docs = page.documents ?? [];
-      if (result.totalCount === 0) {
-        logger.info(`총 ${page.total}건의 문서 발견`);
-      }
-
-      for (const doc of docs) {
-        result.totalCount++;
-        const docKey = doc.document.documentKey;
-
-        try {
-          logger.progress("인스턴스 수집", result.successCount + result.failureCount + 1, page.total);
-
-          // 상세 API 호출
-          const detail = await withRetry(
-            () => flexFetch<DocumentDetailResponse>(
+    await pooledMap(docs, config.concurrency, async (doc) => {
+      const docKey = doc.document.documentKey;
+      try {
+        const detail = await withRetry(
+          () =>
+            flexFetch<DocumentDetailResponse>(
               authCtx,
               `${config.flexBaseUrl}/api/v3/approval-document/approval-documents/${docKey}`,
             ),
-            { maxRetries: config.maxRetries, delayMs: config.requestDelayMs },
-          );
+          { maxRetries: config.maxRetries, delayMs: config.requestDelayMs },
+        );
 
-          // 첨부파일 다운로드
-          const attachments = await processAttachments(
-            authCtx, config, docKey, detail.document.attachments ?? [], storage, logger,
-          );
+        const attachments = await processAttachments(
+          authCtx,
+          config,
+          docKey,
+          detail.document.attachments ?? [],
+          storage,
+          logger,
+        );
 
-          const instance = mapInstance(detail, attachments);
-          await storage.saveInstance(instance);
-          collectedKeys.add(docKey);
-          result.successCount++;
-        } catch (error) {
-          result.failureCount++;
-          result.errors.push({
-            target: `instance:${docKey}`,
-            phase: "detail",
-            message: error instanceof Error ? error.message : String(error),
-            timestamp: nowISO(),
-          });
-          logger.error(`인스턴스 수집 실패: ${docKey}`, {
-            error: error instanceof Error ? error.message : String(error),
-          });
-        }
-
-        await delay(config.requestDelayMs);
+        const instance = mapInstance(detail, attachments);
+        await storage.saveInstance(instance);
+        collectedKeys.add(docKey);
+        result.successCount++;
+        logger.progress(
+          "인스턴스 수집",
+          result.successCount + result.failureCount,
+          result.totalCount,
+        );
+      } catch (error) {
+        result.failureCount++;
+        result.errors.push({
+          target: `instance:${docKey}`,
+          phase: "detail",
+          message: error instanceof Error ? error.message : String(error),
+          timestamp: nowISO(),
+        });
+        logger.error(`인스턴스 수집 실패: ${docKey}`, {
+          error: error instanceof Error ? error.message : String(error),
+        });
       }
-
-      hasMore = page.hasNext && docs.length > 0;
-      if (hasMore) {
-        lastDocumentKey = docs[docs.length - 1].document.documentKey;
-      }
-    }
+    });
   } catch (error) {
     logger.error("인스턴스 목록 수집 중 치명적 오류", {
       error: error instanceof Error ? error.message : String(error),
@@ -274,35 +275,24 @@ async function processAttachments(
   storage: StorageWriter,
   logger: Logger,
 ): Promise<AttachmentInfo[]> {
-  const results: AttachmentInfo[] = [];
+  if (rawAttachments.length === 0) return [];
 
-  for (const att of rawAttachments) {
-    const info: AttachmentInfo = {
-      fileName: att.file.fileName,
-    };
+  return pooledMap(rawAttachments, config.attachmentConcurrency, async (att) => {
+    const info: AttachmentInfo = { fileName: att.file.fileName };
 
-    if (config.downloadAttachments) {
-      try {
-        const res = await fetch(att.file.downloadUrl, { headers: apiHeaders(authCtx) });
-        if (!res.ok) {
-          throw new Error(`HTTP ${res.status}: ${att.file.downloadUrl}`);
-        }
-        const buffer = Buffer.from(await res.arrayBuffer());
+    if (!config.downloadAttachments) return info;
 
-        const savedPath = await storage.saveAttachment(
-          instanceId,
-          att.file.fileName,
-          buffer,
-        );
-        info.localPath = savedPath;
-      } catch (error) {
-        info.downloadError = error instanceof Error ? error.message : String(error);
-        logger.warn(`첨부파일 다운로드 실패: ${att.file.fileName}`, { instanceId });
+    try {
+      const res = await fetch(att.file.downloadUrl, { headers: apiHeaders(authCtx) });
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}: ${att.file.downloadUrl}`);
       }
+      const buffer = Buffer.from(await res.arrayBuffer());
+      info.localPath = await storage.saveAttachment(instanceId, att.file.fileName, buffer);
+    } catch (error) {
+      info.downloadError = error instanceof Error ? error.message : String(error);
+      logger.warn(`첨부파일 다운로드 실패: ${att.file.fileName}`, { instanceId });
     }
-
-    results.push(info);
-  }
-
-  return results;
+    return info;
+  });
 }

--- a/apps/flex-crawler/src/crawlers/shared.ts
+++ b/apps/flex-crawler/src/crawlers/shared.ts
@@ -63,7 +63,11 @@ export async function withRetry<T>(
       }
 
       if (attempt < options.maxRetries) {
-        const backoff = options.delayMs * Math.pow(2, attempt);
+        // 429 응답에 Retry-After가 있으면 그 값을 우선 사용한다.
+        const retryAfter =
+          error instanceof FlexHttpError && error.status === 429 ? error.retryAfterMs : undefined;
+        const baseDelay = options.delayMs > 0 ? options.delayMs : 250;
+        const backoff = retryAfter ?? baseDelay * Math.pow(2, attempt);
         await delay(backoff);
       }
     }
@@ -93,12 +97,34 @@ export function emptyCrawlResult(): CrawlResult {
   };
 }
 
+/** HTTP 응답 코드를 그대로 가지고 있는 에러 — 429 백오프에 사용. */
+export class FlexHttpError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly url: string,
+    public readonly body: string,
+    public readonly retryAfterMs?: number,
+  ) {
+    super(`HTTP ${status}: ${url}${body ? ` — ${body.slice(0, 200)}` : ""}`);
+    this.name = "FlexHttpError";
+  }
+}
+
+function parseRetryAfter(headerValue: string | null): number | undefined {
+  if (!headerValue) return undefined;
+  const seconds = Number(headerValue);
+  if (!Number.isNaN(seconds)) return Math.max(0, seconds * 1000);
+  const date = Date.parse(headerValue);
+  if (!Number.isNaN(date)) return Math.max(0, date - Date.now());
+  return undefined;
+}
+
 /** 인증 토큰을 실어 flex API GET 호출 */
 export async function flexFetch<T>(authCtx: AuthContext, url: string): Promise<T> {
   const res = await fetch(url, { headers: apiHeaders(authCtx) });
   if (!res.ok) {
     const text = await res.text().catch(() => "");
-    throw new Error(`HTTP ${res.status}: ${url}${text ? ` — ${text.slice(0, 200)}` : ""}`);
+    throw new FlexHttpError(res.status, url, text, parseRetryAfter(res.headers.get("retry-after")));
   }
   return (await res.json()) as T;
 }
@@ -112,7 +138,32 @@ export async function flexPost<T>(authCtx: AuthContext, url: string, body: unkno
   });
   if (!res.ok) {
     const text = await res.text().catch(() => "");
-    throw new Error(`HTTP ${res.status}: ${url}${text ? ` — ${text.slice(0, 200)}` : ""}`);
+    throw new FlexHttpError(res.status, url, text, parseRetryAfter(res.headers.get("retry-after")));
   }
   return (await res.json()) as T;
+}
+
+/**
+ * 동시 N개로 작업을 처리하는 단순 워커풀.
+ * 입력 순서를 보존하지 않고, 각 항목별 결과를 그대로 반환한다.
+ */
+export async function pooledMap<T, R>(
+  items: readonly T[],
+  concurrency: number,
+  worker: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let nextIdx = 0;
+
+  async function runner(): Promise<void> {
+    while (true) {
+      const idx = nextIdx++;
+      if (idx >= items.length) return;
+      results[idx] = await worker(items[idx], idx);
+    }
+  }
+
+  const n = Math.max(1, Math.min(concurrency, items.length));
+  await Promise.all(Array.from({ length: n }, () => runner()));
+  return results;
 }

--- a/apps/flex-crawler/src/crawlers/template.ts
+++ b/apps/flex-crawler/src/crawlers/template.ts
@@ -3,8 +3,14 @@ import type { CrawlerConfig } from "../config/index.js";
 import type { Logger } from "../logger/index.js";
 import type { StorageWriter } from "../storage/index.js";
 import type { WorkflowTemplate, TemplateField } from "../types/template.js";
-import { type CrawlResult, delay, emptyCrawlResult, nowISO, withRetry } from "./shared.js";
-import { flexFetch } from "./shared.js";
+import {
+  type CrawlResult,
+  emptyCrawlResult,
+  nowISO,
+  withRetry,
+  flexFetch,
+  pooledMap,
+} from "./shared.js";
 
 export async function crawlTemplates(
   authCtx: AuthContext,
@@ -28,19 +34,17 @@ export async function crawlTemplates(
 
     const rawTemplates = data.templates ?? [];
     result.totalCount = rawTemplates.length;
-    logger.info(`양식 ${rawTemplates.length}건 발견`);
+    logger.info(`양식 ${rawTemplates.length}건 발견 (concurrency=${config.concurrency})`);
 
-    for (let i = 0; i < rawTemplates.length; i++) {
-      const raw = rawTemplates[i];
+    let processed = 0;
+    await pooledMap(rawTemplates, config.concurrency, async (raw) => {
       try {
-        logger.progress("양식 수집", i + 1, rawTemplates.length);
-
-        // 템플릿 상세 API 호출
         const detail = await withRetry(
-          () => flexFetch<{ template: RawTemplateDetail }>(
-            authCtx,
-            `${config.flexBaseUrl}/api/v3/approval-document-template/templates/${raw.templateKey}`,
-          ),
+          () =>
+            flexFetch<{ template: RawTemplateDetail }>(
+              authCtx,
+              `${config.flexBaseUrl}/api/v3/approval-document-template/templates/${raw.templateKey}`,
+            ),
           { maxRetries: config.maxRetries, delayMs: config.requestDelayMs },
         );
 
@@ -48,7 +52,7 @@ export async function crawlTemplates(
         await storage.saveTemplate(template);
         result.successCount++;
       } catch (error) {
-        // 상세 API 실패 시 목록 데이터로 저장
+        // 상세 실패 시 목록 데이터만으로라도 저장.
         try {
           const template = mapTemplate(raw, null);
           await storage.saveTemplate(template);
@@ -65,10 +69,11 @@ export async function crawlTemplates(
             error: error instanceof Error ? error.message : String(error),
           });
         }
+      } finally {
+        processed++;
+        logger.progress("양식 수집", processed, rawTemplates.length);
       }
-
-      if (i < rawTemplates.length - 1) await delay(config.requestDelayMs);
-    }
+    });
   } catch (error) {
     logger.error("양식 목록 수집 실패", {
       error: error instanceof Error ? error.message : String(error),

--- a/apps/flex-crawler/src/probe.ts
+++ b/apps/flex-crawler/src/probe.ts
@@ -1,0 +1,202 @@
+/**
+ * 429 한계점 탐색용 probe.
+ *
+ * 인증한 뒤 인스턴스 검색 페이지(20건)의 documentKey들을 모아두고,
+ * 그 중 일부를 N개 워커로 동시 GET해서 throughput / 429 / 에러율을 측정한다.
+ *
+ * 사용법:
+ *   FLEX_PROBE_CONCURRENCY=8 FLEX_PROBE_REQUESTS=80 \
+ *     pnpm --filter flex-crawler exec tsx src/probe.ts
+ */
+import { loadConfig } from "./config/index.js";
+import { authenticate, apiHeaders } from "./auth/index.js";
+import { createLogger } from "./logger/index.js";
+
+interface ProbeStats {
+  concurrency: number;
+  total: number;
+  ok: number;
+  status429: number;
+  otherErrors: number;
+  durationMs: number;
+  rps: number;
+  latencyP50: number;
+  latencyP95: number;
+  latencyMax: number;
+}
+
+async function fetchDocumentKeys(
+  baseUrl: string,
+  headers: Record<string, string>,
+  needed: number,
+): Promise<string[]> {
+  const keys: string[] = [];
+  let lastDocumentKey: string | undefined;
+
+  while (keys.length < needed) {
+    const body = {
+      filter: {
+        statuses: ["IN_PROGRESS", "DONE", "DECLINED", "CANCELED"],
+        templateKeys: [],
+        writerHashedIds: [],
+        approverTargets: [],
+        referrerTargets: [],
+        starred: false,
+      },
+      search: { keyword: "", type: "ALL" },
+      ...(lastDocumentKey ? { lastDocumentKey } : {}),
+    };
+    const res = await fetch(
+      `${baseUrl}/action/v3/approval-document/user-boxes/search?size=20&sortType=LAST_UPDATED_AT&direction=DESC`,
+      { method: "POST", headers, body: JSON.stringify(body) },
+    );
+    if (!res.ok) {
+      throw new Error(`search HTTP ${res.status}: ${(await res.text()).slice(0, 200)}`);
+    }
+    const data = (await res.json()) as {
+      hasNext: boolean;
+      documents: Array<{ document: { documentKey: string } }>;
+    };
+    const docs = data.documents ?? [];
+    if (docs.length === 0) break;
+    for (const d of docs) keys.push(d.document.documentKey);
+    if (!data.hasNext) break;
+    lastDocumentKey = docs[docs.length - 1].document.documentKey;
+  }
+  return keys.slice(0, needed);
+}
+
+async function runProbe(
+  baseUrl: string,
+  headers: Record<string, string>,
+  documentKeys: string[],
+  concurrency: number,
+): Promise<ProbeStats> {
+  const total = documentKeys.length;
+  const latencies: number[] = [];
+  let ok = 0;
+  let status429 = 0;
+  let otherErrors = 0;
+  let nextIdx = 0;
+
+  const start = Date.now();
+
+  async function worker(): Promise<void> {
+    while (true) {
+      const idx = nextIdx++;
+      if (idx >= total) return;
+      const key = documentKeys[idx];
+      const t0 = Date.now();
+      try {
+        const res = await fetch(
+          `${baseUrl}/api/v3/approval-document/approval-documents/${key}`,
+          { headers },
+        );
+        const dt = Date.now() - t0;
+        latencies.push(dt);
+        if (res.status === 429) {
+          status429++;
+          // body 비워서 connection reuse
+          await res.text().catch(() => "");
+        } else if (!res.ok) {
+          otherErrors++;
+          await res.text().catch(() => "");
+        } else {
+          ok++;
+          await res.text().catch(() => "");
+        }
+      } catch (err) {
+        otherErrors++;
+        latencies.push(Date.now() - t0);
+      }
+    }
+  }
+
+  await Promise.all(Array.from({ length: concurrency }, () => worker()));
+
+  const durationMs = Date.now() - start;
+  latencies.sort((a, b) => a - b);
+  const pct = (p: number): number =>
+    latencies.length === 0 ? 0 : latencies[Math.min(latencies.length - 1, Math.floor(latencies.length * p))];
+
+  return {
+    concurrency,
+    total,
+    ok,
+    status429,
+    otherErrors,
+    durationMs,
+    rps: total > 0 ? (total / durationMs) * 1000 : 0,
+    latencyP50: pct(0.5),
+    latencyP95: pct(0.95),
+    latencyMax: latencies.length ? latencies[latencies.length - 1] : 0,
+  };
+}
+
+function envInt(name: string, fallback: number): number {
+  const v = process.env[name];
+  if (!v) return fallback;
+  const n = parseInt(v, 10);
+  if (Number.isNaN(n)) return fallback;
+  return n;
+}
+
+function parseList(name: string, fallback: number[]): number[] {
+  const v = process.env[name];
+  if (!v) return fallback;
+  return v
+    .split(",")
+    .map((s) => parseInt(s.trim(), 10))
+    .filter((n) => !Number.isNaN(n));
+}
+
+async function main(): Promise<void> {
+  const logger = createLogger();
+  const config = loadConfig();
+  const ctx = await authenticate(config, logger);
+  const headers = apiHeaders(ctx);
+  const baseUrl = config.flexBaseUrl;
+
+  const requestsPerLevel = envInt("FLEX_PROBE_REQUESTS", 80);
+  const concurrencyLevels = parseList("FLEX_PROBE_LEVELS", [1, 4, 8, 16, 32]);
+  const cooldownMs = envInt("FLEX_PROBE_COOLDOWN_MS", 3000);
+
+  logger.info("documentKey 수집...");
+  const keys = await fetchDocumentKeys(baseUrl, headers, requestsPerLevel);
+  logger.info(`확보된 documentKey: ${keys.length}건`);
+  if (keys.length < 20) {
+    logger.warn("documentKey 표본이 너무 적습니다. 결과 신뢰도가 낮을 수 있습니다.");
+  }
+
+  const results: ProbeStats[] = [];
+  for (const concurrency of concurrencyLevels) {
+    logger.info(`\n=== probe: concurrency=${concurrency}, requests=${keys.length} ===`);
+    const stats = await runProbe(baseUrl, headers, keys, concurrency);
+    results.push(stats);
+    logger.info(
+      `c=${stats.concurrency} ok=${stats.ok}/${stats.total} 429=${stats.status429} err=${stats.otherErrors} ` +
+        `rps=${stats.rps.toFixed(2)} p50=${stats.latencyP50}ms p95=${stats.latencyP95}ms max=${stats.latencyMax}ms ` +
+        `dur=${stats.durationMs}ms`,
+    );
+    if (stats.status429 > 0) {
+      logger.warn(`429 발생 — 다음 단계 중단`);
+      break;
+    }
+    if (cooldownMs > 0) {
+      await new Promise((r) => setTimeout(r, cooldownMs));
+    }
+  }
+
+  console.log("\n=== summary ===");
+  console.log("concurrency\tok\t429\terr\trps\tp50\tp95\tdur(ms)");
+  for (const s of results) {
+    console.log(
+      `${s.concurrency}\t\t${s.ok}\t${s.status429}\t${s.otherErrors}\t${s.rps.toFixed(2)}\t${s.latencyP50}\t${s.latencyP95}\t${s.durationMs}`,
+    );
+  }
+}
+
+main().catch((err) => {
+  console.error("probe 실패:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- 인스턴스/템플릿 상세 fetch 와 첨부 다운로드를 워커풀로 병렬화 (`CONCURRENCY` 기본 16, `ATTACHMENT_CONCURRENCY` 기본 4). 151건 dump 기준 33.0s → 4.6s.
- approval-document search endpoint 의 `lastDocumentKey` 페이지네이션이 동작하지 않아 첫 20건만 무한 재처리되던 버그를 수정. 큰 `size` 로 한 번에 받는 방식으로 변경 (`SEARCH_PAGE_SIZE` 기본 1000, 초과 시 경고).
- 진단용 `src/probe.ts` 추가 — 향후 동시성 한계를 다시 측정할 때 사용.

## 측정 결과 (dump=151건, 첨부 제외)

| 동시성 | 시간 | 429 |
|---|---|---|
| c=1 | 33.0s | 0 |
| **c=16 (기본값)** | **4.6s** | 0 |
| c=32 | 3.4s | 0 |

probe 로 c=384, 16,000+ sustained 요청까지 밀어봤지만 단 한 번도 429 가 떨어지지 않았습니다. 한계는 rate-limit 이 아니라 c=64 부터 서버측 큐잉으로 latency 가 늘어나기 시작하는 지점이었고, 안전 마진을 두고 기본값을 c=16 으로 잡았습니다.

## Test plan
- [x] `tsc --noEmit` 통과
- [x] c=1 / c=16 / c=32 로 dump 끝까지 — 0 errors, 모든 인스턴스 저장됨
- [x] `probe.ts` 로 c=1..384 측정, 0 429
- [ ] 다른 테넌트(보다 큰 dataset)에서 한 번 더 검증 — 이건 reviewer 환경에서 부탁드립니다

🤖 Generated with [Claude Code](https://claude.com/claude-code)