### PR TITLE
fix(flex-cli): replace better-sqlite3 with bun:sqlite to fix Windows import crash

### DIFF
--- a/.github/workflows/release-flex-cli.yml
+++ b/.github/workflows/release-flex-cli.yml
@@ -73,6 +73,16 @@ jobs:
           ${{ matrix.smoke }} status
         working-directory: artifacts
 
+      - name: Smoke test import + query (regression for #41)
+        shell: bash
+        working-directory: artifacts
+        run: |
+          mkdir -p sample/instances sample/templates sample/attendance
+          echo '{"startedAt":"2024-01-01T00:00:00Z","durationMs":0}' > sample/crawl-report.json
+          OUTPUT_DIR=sample ${{ matrix.smoke }} import
+          test -f sample/flex-ax.db
+          OUTPUT_DIR=sample ${{ matrix.smoke }} query "SELECT count(*) AS n FROM templates"
+
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.outfile }}

--- a/.github/workflows/verify-flex-cli-bun.yml
+++ b/.github/workflows/verify-flex-cli-bun.yml
@@ -66,3 +66,13 @@ jobs:
           ${{ matrix.smoke }} --version
           ${{ matrix.smoke }} status
         working-directory: artifacts
+
+      - name: Smoke test import + query (regression for #41)
+        shell: bash
+        working-directory: artifacts
+        run: |
+          mkdir -p sample/instances sample/templates sample/attendance
+          echo '{"startedAt":"2024-01-01T00:00:00Z","durationMs":0}' > sample/crawl-report.json
+          OUTPUT_DIR=sample ${{ matrix.smoke }} import
+          test -f sample/flex-ax.db
+          OUTPUT_DIR=sample ${{ matrix.smoke }} query "SELECT count(*) AS n FROM templates"

--- a/apps/flex-cli/package.json
+++ b/apps/flex-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flex-ax",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "type": "module",
   "description": "flex HR SaaS AX CLI - discover, crawl, and manage flex data",

--- a/apps/flex-cli/package.json
+++ b/apps/flex-cli/package.json
@@ -12,33 +12,31 @@
     "!dist/**/*.map"
   ],
   "scripts": {
-    "start": "tsx src/cli.ts",
-    "crawl": "tsx src/cli.ts crawl",
-    "install-skills": "tsx src/cli.ts install-skills",
+    "start": "bun run src/cli.ts",
+    "crawl": "bun run src/cli.ts crawl",
+    "install-skills": "bun run src/cli.ts install-skills",
     "build": "tsc -p tsconfig.build.json && node scripts/postbuild.cjs",
     "build:exe": "bun build --compile src/cli.ts --outfile bun-dist/flex-ax",
-    "test": "tsx --test src/*.test.ts src/**/*.test.ts",
+    "test": "bun test",
     "lint": "tsc --noEmit",
     "clean": "rimraf output dist"
   },
   "dependencies": {
     "@napi-rs/keyring": "^1.1.7",
-    "better-sqlite3": "^12.8.0",
     "dotenv": "^16.4.7",
     "semver": "^7.7.4",
     "yaml": "^2.6.1",
     "zod": "^3.24.2"
   },
   "engines": {
-    "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+    "bun": ">=1.3.0"
   },
   "devDependencies": {
     "@1password/sdk": "^0.4.0",
-    "@types/better-sqlite3": "^7.6.13",
+    "@types/bun": "^1.1.0",
     "@types/node": "^22.13.5",
     "@types/semver": "^7.7.1",
     "rimraf": "^6.0.1",
-    "tsx": "^4.19.2",
     "typescript": "^5.7.3"
   }
 }

--- a/apps/flex-cli/scripts/postbuild.cjs
+++ b/apps/flex-cli/scripts/postbuild.cjs
@@ -7,6 +7,7 @@ fs.copyFileSync("src/db/schema.sql", "dist/db/schema.sql");
 // Prepend shebang to CLI entry point
 const cli = "dist/cli.js";
 const src = fs.readFileSync(cli, "utf8");
+// Use bun shebang because the CLI imports `bun:sqlite`, which is unavailable on Node.
 if (!src.startsWith("#!")) {
-  fs.writeFileSync(cli, "#!/usr/bin/env node\n" + src);
+  fs.writeFileSync(cli, "#!/usr/bin/env bun\n" + src);
 }

--- a/apps/flex-cli/src/commands/file.ts
+++ b/apps/flex-cli/src/commands/file.ts
@@ -1,4 +1,4 @@
-import Database from "better-sqlite3";
+import { Database } from "bun:sqlite";
 import { createReadStream } from "node:fs";
 import { loadConfig } from "../config/index.js";
 import { resolveFlexDataDir } from "../paths/index.js";
@@ -32,7 +32,7 @@ export async function runFile(): Promise<void> {
   }
   const dbPath = path.resolve(resolved.resolvedPath, "flex-ax.db");
 
-  let db: InstanceType<typeof Database>;
+  let db: Database;
   try {
     db = new Database(dbPath, { readonly: true });
   } catch {

--- a/apps/flex-cli/src/commands/query.ts
+++ b/apps/flex-cli/src/commands/query.ts
@@ -1,4 +1,4 @@
-import Database from "better-sqlite3";
+import { Database } from "bun:sqlite";
 import { loadConfig } from "../config/index.js";
 import { resolveFlexDataDir } from "../paths/index.js";
 import path from "node:path";
@@ -128,7 +128,7 @@ SQL을 실행하고 결과를 JSON으로 출력합니다 (read-only).
   }
   const dbPath = path.resolve(resolved.resolvedPath, "flex-ax.db");
 
-  let db: InstanceType<typeof Database>;
+  let db: Database;
   try {
     db = new Database(dbPath, { readonly: true });
   } catch {

--- a/apps/flex-cli/src/db/import-endpoints.ts
+++ b/apps/flex-cli/src/db/import-endpoints.ts
@@ -1,4 +1,4 @@
-import Database from "better-sqlite3";
+import type { Database } from "bun:sqlite";
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import type { Logger } from "../logger/index.js";
@@ -15,7 +15,7 @@ function readEndpoint(endpointsDir: string, filename: string): any | null {
 }
 
 export function importEndpoints(
-  db: Database.Database,
+  db: Database,
   endpointsDir: string,
   upsertUser: (id: string | undefined, name: string | undefined | null) => void,
   logger: Logger,
@@ -54,7 +54,7 @@ type EnsureCustomer = (customerId: string | null | undefined) => void;
 // Company / Org
 // ============================================================
 function importCompanyOrg(
-  db: Database.Database, dir: string,
+  db: Database, dir: string,
   upsertUser: (id: string | undefined, name: string | undefined | null) => void,
   ensureCustomer: EnsureCustomer,
   logger: Logger, inc: Inc,
@@ -84,9 +84,14 @@ function importCompanyOrg(
     // customers
     const f = readEndpoint(dir, "customer-info.json");
     if (f?.data) {
-      const d = f.data as Record<string, unknown>;
-      const legal = (d.legalInfo ?? {}) as Record<string, unknown>;
-      const addr = (legal.address ?? {}) as Record<string, unknown>;
+      // bun:sqlite Statement#run requires SQLQueryBindings, so we relax the
+      // payload type to `any` rather than threading casts through every field.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const d = f.data as Record<string, any>;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const legal = (d.legalInfo ?? {}) as Record<string, any>;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const addr = (legal.address ?? {}) as Record<string, any>;
       stmts.customer.run(
         d.customerIdHash, legal.name ?? d.customerIdHash,
         legal.establishDate ?? null, d.logoImageFileKey ?? null,
@@ -174,7 +179,7 @@ function importCompanyOrg(
 // Employee / HR
 // ============================================================
 function importEmployeeHR(
-  db: Database.Database, dir: string,
+  db: Database, dir: string,
   upsertUser: (id: string | undefined, name: string | undefined | null) => void,
   ensureCustomer: EnsureCustomer,
   _logger: Logger, inc: Inc,
@@ -370,7 +375,7 @@ function importEmployeeHR(
 // Personnel / Profile
 // ============================================================
 function importPersonnelProfile(
-  db: Database.Database, dir: string,
+  db: Database, dir: string,
   upsertUser: (id: string | undefined, name: string | undefined | null) => void,
   ensureCustomer: EnsureCustomer,
   logger: Logger, inc: Inc,
@@ -533,7 +538,7 @@ function importPersonnelProfile(
 // Work Rules / Time Off / Holidays
 // ============================================================
 function importWorkTimeOff(
-  db: Database.Database, dir: string,
+  db: Database, dir: string,
   upsertUser: (id: string | undefined, name: string | undefined | null) => void,
   ensureCustomer: EnsureCustomer,
   logger: Logger, inc: Inc,
@@ -809,7 +814,7 @@ function importWorkTimeOff(
 // Other (Calendar, Todo, Feedback, Attachments, etc.)
 // ============================================================
 function importOther(
-  db: Database.Database, dir: string,
+  db: Database, dir: string,
   upsertUser: (id: string | undefined, name: string | undefined | null) => void,
   ensureCustomer: EnsureCustomer,
   _logger: Logger, inc: Inc,

--- a/apps/flex-cli/src/db/import.ts
+++ b/apps/flex-cli/src/db/import.ts
@@ -1,12 +1,13 @@
-import Database from "better-sqlite3";
+import { Database, type Statement } from "bun:sqlite";
 import { existsSync, readFileSync } from "node:fs";
-import { readFile, readdir } from "node:fs/promises";
+import { readdir } from "node:fs/promises";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import type { Logger } from "../logger/index.js";
 import { importEndpoints } from "./import-endpoints.js";
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+// Inline the schema as a text import so it survives `bun build --compile`,
+// where reading sibling files at runtime resolves to a virtual `/$bunfs` path
+// that doesn't exist on disk.
+import schemaSql from "./schema.sql" with { type: "text" };
 
 export interface ImportResult {
   templates: number;
@@ -32,14 +33,12 @@ export async function importToSqlite(
   };
 
   // DB 초기화
-  const db = new Database(dbPath);
-  db.pragma("journal_mode = WAL");
-  db.pragma("foreign_keys = OFF"); // 임포트 순서 무관하게 처리, 완료 후 체크
+  const db = new Database(dbPath, { create: true });
+  db.exec("PRAGMA journal_mode = WAL");
+  db.exec("PRAGMA foreign_keys = OFF"); // 임포트 순서 무관하게 처리, 완료 후 체크
 
-  // schema.sql 로드
-  const schemaPath = path.join(__dirname, "schema.sql");
-  const schema = await readFile(schemaPath, "utf-8");
-  db.exec(schema);
+  // schema.sql 적용 (빌드 시점에 텍스트로 인라인됨)
+  db.exec(schemaSql);
 
   // 사용자 수집용
   const users = new Map<string, { name: string; aliases: Set<string> }>();
@@ -238,7 +237,7 @@ export async function importToSqlite(
   }
 
   // FK 무결성 체크
-  const fkErrors = db.pragma("foreign_key_check") as unknown[];
+  const fkErrors = db.query("PRAGMA foreign_key_check").all() as unknown[];
   if (fkErrors.length > 0) {
     logger.warn(`FK 무결성 위반 ${fkErrors.length}건 (참조 누락)`);
   }
@@ -250,7 +249,7 @@ export async function importToSqlite(
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function importInstance(
   data: any,
-  stmts: Record<string, Database.Statement>,
+  stmts: Record<string, Statement>,
   result: ImportResult,
   upsertUser: (id: string | undefined, name: string) => void,
 ): void {

--- a/apps/flex-cli/src/types/sql.d.ts
+++ b/apps/flex-cli/src/types/sql.d.ts
@@ -1,0 +1,4 @@
+declare module "*.sql" {
+  const content: string;
+  export default content;
+}

--- a/apps/flex-cli/tsconfig.json
+++ b/apps/flex-cli/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",
-    "lib": ["ES2022", "DOM"]
+    "lib": ["ES2022", "DOM"],
+    "types": ["bun", "node"]
   },
   "include": ["src/**/*"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       '@napi-rs/keyring':
         specifier: ^1.1.7
         version: 1.2.0
-      better-sqlite3:
-        specifier: ^12.8.0
-        version: 12.8.0
       dotenv:
         specifier: ^16.4.7
         version: 16.6.1
@@ -36,9 +33,9 @@ importers:
       '@1password/sdk':
         specifier: ^0.4.0
         version: 0.4.0
-      '@types/better-sqlite3':
-        specifier: ^7.6.13
-        version: 7.6.13
+      '@types/bun':
+        specifier: ^1.1.0
+        version: 1.3.13
       '@types/node':
         specifier: ^22.13.5
         version: 22.19.15
@@ -48,9 +45,6 @@ importers:
       rimraf:
         specifier: ^6.0.1
         version: 6.1.3
-      tsx:
-        specifier: ^4.19.2
-        version: 4.21.0
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
@@ -350,8 +344,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@types/better-sqlite3@7.6.13':
-    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
+  '@types/bun@1.3.13':
+    resolution: {integrity: sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw==}
 
   '@types/node@22.19.15':
     resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
@@ -370,18 +364,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  better-sqlite3@12.8.0:
-    resolution: {integrity: sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==}
-    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
-
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
-
-  bindings@1.5.0:
-    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
-
-  bl@4.1.0:
-    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
@@ -390,8 +374,8 @@ packages:
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
-  buffer@5.7.1:
-    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+  bun-types@1.3.13:
+    resolution: {integrity: sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA==}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -401,9 +385,6 @@ packages:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
-  chownr@1.1.4:
-    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
-
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -412,18 +393,6 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
-
-  decompress-response@6.0.0:
-    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
-    engines: {node: '>=10'}
-
-  deep-extend@0.6.0:
-    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
-    engines: {node: '>=4.0.0'}
-
-  detect-libc@2.1.2:
-    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
-    engines: {node: '>=8'}
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
@@ -435,9 +404,6 @@ packages:
 
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
-
-  end-of-stream@1.4.5:
-    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -456,18 +422,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  expand-template@2.0.3:
-    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
-    engines: {node: '>=6'}
-
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
-
-  file-uri-to-path@1.0.0:
-    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
-
-  fs-constants@1.0.0:
-    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -495,9 +451,6 @@ packages:
 
   get-tsconfig@4.13.7:
     resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
-
-  github-from-package@0.0.0:
-    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
@@ -539,15 +492,6 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
-  ieee754@1.2.1:
-    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
-
-  inherits@2.0.4:
-    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-
-  ini@1.3.8:
-    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
-
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
@@ -569,33 +513,16 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
-  mimic-response@3.1.0:
-    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
-    engines: {node: '>=10'}
-
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
-
-  minimist@1.2.8:
-    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  mkdirp-classic@0.5.3:
-    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
-
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
-
-  napi-build-utils@2.0.0:
-    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
-
-  node-abi@3.89.0:
-    resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
-    engines: {node: '>=10'}
 
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
@@ -610,9 +537,6 @@ packages:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
 
-  once@1.4.0:
-    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
-
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
@@ -620,26 +544,9 @@ packages:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
 
-  prebuild-install@7.1.3:
-    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
-    engines: {node: '>=10'}
-    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
-    hasBin: true
-
-  pump@3.0.4:
-    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
-
   qs@6.15.0:
     resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
     engines: {node: '>=0.6'}
-
-  rc@1.2.8:
-    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
-    hasBin: true
-
-  readable-stream@3.6.2:
-    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
-    engines: {node: '>= 6'}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
@@ -673,26 +580,6 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
-  simple-concat@1.0.1:
-    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
-
-  simple-get@4.0.1:
-    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
-
-  string_decoder@1.3.0:
-    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
-
-  strip-json-comments@2.0.1:
-    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
-    engines: {node: '>=0.10.0'}
-
-  tar-fs@2.1.4:
-    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
-
-  tar-stream@2.2.0:
-    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
-    engines: {node: '>=6'}
-
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
@@ -700,9 +587,6 @@ packages:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
-
-  tunnel-agent@0.6.0:
-    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
   turbo@2.9.1:
     resolution: {integrity: sha512-TO9du8MwLTAKoXcGezekh9cPJabJUb0+8KxtpMR6kXdRASrmJ8qXf2GkVbCREgzbMQakzfNcux9cZtxheDY4RQ==}
@@ -719,9 +603,6 @@ packages:
   url-template@2.0.8:
     resolution: {integrity: sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==}
 
-  util-deprecate@1.0.2:
-    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
-
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
@@ -731,9 +612,6 @@ packages:
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
-
-  wrappy@1.0.2:
-    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   yaml@2.8.3:
     resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
@@ -898,9 +776,9 @@ snapshots:
   '@turbo/windows-arm64@2.9.1':
     optional: true
 
-  '@types/better-sqlite3@7.6.13':
+  '@types/bun@1.3.13':
     dependencies:
-      '@types/node': 22.19.15
+      bun-types: 1.3.13
 
   '@types/node@22.19.15':
     dependencies:
@@ -914,22 +792,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  better-sqlite3@12.8.0:
-    dependencies:
-      bindings: 1.5.0
-      prebuild-install: 7.1.3
-
   bignumber.js@9.3.1: {}
-
-  bindings@1.5.0:
-    dependencies:
-      file-uri-to-path: 1.0.0
-
-  bl@4.1.0:
-    dependencies:
-      buffer: 5.7.1
-      inherits: 2.0.4
-      readable-stream: 3.6.2
 
   brace-expansion@5.0.5:
     dependencies:
@@ -937,10 +800,9 @@ snapshots:
 
   buffer-equal-constant-time@1.0.1: {}
 
-  buffer@5.7.1:
+  bun-types@1.3.13:
     dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
+      '@types/node': 22.19.15
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -952,19 +814,9 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
 
-  chownr@1.1.4: {}
-
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
-
-  decompress-response@6.0.0:
-    dependencies:
-      mimic-response: 3.1.0
-
-  deep-extend@0.6.0: {}
-
-  detect-libc@2.1.2: {}
 
   dotenv@16.6.1: {}
 
@@ -977,10 +829,6 @@ snapshots:
   ecdsa-sig-formatter@1.0.11:
     dependencies:
       safe-buffer: 5.2.1
-
-  end-of-stream@1.4.5:
-    dependencies:
-      once: 1.4.0
 
   es-define-property@1.0.1: {}
 
@@ -1019,13 +867,7 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.4
       '@esbuild/win32-x64': 0.27.4
 
-  expand-template@2.0.3: {}
-
   extend@3.0.2: {}
-
-  file-uri-to-path@1.0.0: {}
-
-  fs-constants@1.0.0: {}
 
   fsevents@2.3.3:
     optional: true
@@ -1073,8 +915,6 @@ snapshots:
   get-tsconfig@4.13.7:
     dependencies:
       resolve-pkg-maps: 1.0.0
-
-  github-from-package@0.0.0: {}
 
   glob@13.0.6:
     dependencies:
@@ -1139,12 +979,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ieee754@1.2.1: {}
-
-  inherits@2.0.4: {}
-
-  ini@1.3.8: {}
-
   is-stream@2.0.1: {}
 
   json-bigint@1.0.0:
@@ -1166,35 +1000,19 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
-  mimic-response@3.1.0: {}
-
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
 
-  minimist@1.2.8: {}
-
   minipass@7.1.3: {}
 
-  mkdirp-classic@0.5.3: {}
-
   ms@2.1.3: {}
-
-  napi-build-utils@2.0.0: {}
-
-  node-abi@3.89.0:
-    dependencies:
-      semver: 7.7.4
 
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
 
   object-inspect@1.13.4: {}
-
-  once@1.4.0:
-    dependencies:
-      wrappy: 1.0.2
 
   package-json-from-dist@1.0.1: {}
 
@@ -1203,42 +1021,9 @@ snapshots:
       lru-cache: 11.2.7
       minipass: 7.1.3
 
-  prebuild-install@7.1.3:
-    dependencies:
-      detect-libc: 2.1.2
-      expand-template: 2.0.3
-      github-from-package: 0.0.0
-      minimist: 1.2.8
-      mkdirp-classic: 0.5.3
-      napi-build-utils: 2.0.0
-      node-abi: 3.89.0
-      pump: 3.0.4
-      rc: 1.2.8
-      simple-get: 4.0.1
-      tar-fs: 2.1.4
-      tunnel-agent: 0.6.0
-
-  pump@3.0.4:
-    dependencies:
-      end-of-stream: 1.4.5
-      once: 1.4.0
-
   qs@6.15.0:
     dependencies:
       side-channel: 1.1.0
-
-  rc@1.2.8:
-    dependencies:
-      deep-extend: 0.6.0
-      ini: 1.3.8
-      minimist: 1.2.8
-      strip-json-comments: 2.0.1
-
-  readable-stream@3.6.2:
-    dependencies:
-      inherits: 2.0.4
-      string_decoder: 1.3.0
-      util-deprecate: 1.0.2
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -1279,35 +1064,6 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
-  simple-concat@1.0.1: {}
-
-  simple-get@4.0.1:
-    dependencies:
-      decompress-response: 6.0.0
-      once: 1.4.0
-      simple-concat: 1.0.1
-
-  string_decoder@1.3.0:
-    dependencies:
-      safe-buffer: 5.2.1
-
-  strip-json-comments@2.0.1: {}
-
-  tar-fs@2.1.4:
-    dependencies:
-      chownr: 1.1.4
-      mkdirp-classic: 0.5.3
-      pump: 3.0.4
-      tar-stream: 2.2.0
-
-  tar-stream@2.2.0:
-    dependencies:
-      bl: 4.1.0
-      end-of-stream: 1.4.5
-      fs-constants: 1.0.0
-      inherits: 2.0.4
-      readable-stream: 3.6.2
-
   tr46@0.0.3: {}
 
   tsx@4.21.0:
@@ -1316,10 +1072,6 @@ snapshots:
       get-tsconfig: 4.13.7
     optionalDependencies:
       fsevents: 2.3.3
-
-  tunnel-agent@0.6.0:
-    dependencies:
-      safe-buffer: 5.2.1
 
   turbo@2.9.1:
     optionalDependencies:
@@ -1336,8 +1088,6 @@ snapshots:
 
   url-template@2.0.8: {}
 
-  util-deprecate@1.0.2: {}
-
   uuid@9.0.1: {}
 
   webidl-conversions@3.0.1: {}
@@ -1346,8 +1096,6 @@ snapshots:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
-
-  wrappy@1.0.2: {}
 
   yaml@2.8.3: {}
 


### PR DESCRIPTION
## Summary

Fixes #41. `flex-ax import` was crashing on the Windows bundled exe with `Could not find module root given file: \"B:/~BUN/root/flex-ax-windows-x64.exe\"` before it could create `flex-ax.db`.

**Root cause** — the CLI is distributed as a `bun build --compile` single executable, but uses `better-sqlite3`, which is a native N-API addon. `better-sqlite3` uses the `bindings` npm package to locate its compiled `.node` binary by walking up from the source path looking for `package.json`. Inside the compiled Bun exe, source paths resolve to a virtual `B:/~BUN/root/...` location with no `package.json` ancestor, so `new Database()` throws before any DB work happens. `crawl` succeeded only because it doesn't touch SQLite; `import` was the first command to call into the broken native addon.

**Fix** — switch all four SQLite call sites to `bun:sqlite`, which is built into the Bun runtime and needs no native bindings lookup, so it works transparently inside `bun build --compile`.

While verifying the fix locally, hit a follow-on bug that the bindings error was masking: `import.ts` reads `schema.sql` from `__dirname` at runtime, but in the compiled exe the path resolves to a virtual `/$bunfs/root/schema.sql` that doesn't exist. Inline it via `import schemaSql from \"./schema.sql\" with { type: \"text\" }` so the bundler embeds the schema text. Without this, `import` would still fail (just with a different error) once the bindings issue is past.

## Changes

- `db/import.ts`, `db/import-endpoints.ts`, `commands/query.ts`, `commands/file.ts` — `better-sqlite3` → `bun:sqlite`. PRAGMA calls go through `db.exec(...)` / `db.query(...).all()` since `bun:sqlite` doesn't have `db.pragma()`.
- `db/import.ts` — embed `schema.sql` via `with { type: \"text\" }` import.
- `package.json` — drop `better-sqlite3`, `@types/better-sqlite3`, `tsx`; add `@types/bun`. `tsx`-based scripts move to `bun run` / `bun test`. `engines.node` → `engines.bun`.
- `tsconfig.json` — add `\"types\": [\"bun\", \"node\"]` so the `bun:sqlite` module resolves.
- `scripts/postbuild.cjs` — bin shebang `#!/usr/bin/env node` → `#!/usr/bin/env bun` (the produced `dist/cli.js` now imports `bun:sqlite`).
- `.github/workflows/{verify-flex-cli-bun,release-flex-cli}.yml` — add an `import` + `query` smoke test against the compiled exe so this regression class fails CI before it ships. The previous smoke step only ran `--version` and `status`, neither of which touched SQLite.

## Test plan

- [x] `bun test` — 38/38 pass
- [x] `tsc --noEmit` — clean
- [x] `bun build --compile src/cli.ts --outfile /tmp/flex-ax-test`
- [x] `OUTPUT_DIR=/tmp/sample /tmp/flex-ax-test import` creates `flex-ax.db` and applies the full schema
- [x] `OUTPUT_DIR=/tmp/sample /tmp/flex-ax-test query \"SELECT name FROM sqlite_master WHERE type='table'\"` returns the expected table list
- [ ] CI must pass on all 3 OSes — Windows is the one that was actually broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)