### PR TITLE
fix(ci): evaluate release name template

### DIFF
--- a/.github/workflows/release-flex-cli.yml
+++ b/.github/workflows/release-flex-cli.yml
@@ -103,9 +103,14 @@ jobs:
           mkdir -p dist
           find release-assets -type f -exec cp {} dist/ \;
 
+      - name: Extract version from tag
+        id: version
+        shell: bash
+        run: echo "version=${GITHUB_REF_NAME#flex-cli@}" >> "$GITHUB_OUTPUT"
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
-          name: "flex-cli ${GITHUB_REF_NAME#flex-cli@}"
+          name: "flex-cli ${{ steps.version.outputs.version }}"
           files: dist/*
           generate_release_notes: true


### PR DESCRIPTION
## Summary
`softprops/action-gh-release@v2` 의 `with.name` 필드는 GitHub Actions 표현식 `\${{ ... }}` 만 평가하고 셸 파라미터 확장은 안 해서, 0.7.0 ~ 0.8.0 릴리스 이름이 `flex-cli \${GITHUB_REF_NAME#flex-cli@}` 리터럴 그대로 박혀 있었습니다. release 잡에서 버전을 step output 으로 뽑아 `\${{ steps.version.outputs.version }}` 으로 주입하도록 수정.

다음 릴리스부터 `flex-cli 0.8.1` 형태로 표시됩니다.

기존 릴리스(0.7.0 ~ 0.8.0)는 별도로 \`gh release edit\` 로 이름을 고치겠습니다.

## Test plan
- [ ] 다음 태그(예: 0.8.1) 가 푸시되면 release 페이지 이름이 "flex-cli 0.8.1" 로 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)