### PR TITLE
[codex] Add GUI credential dialogs

### DIFF
--- a/.github/workflows/verify-flex-cli-bun.yml
+++ b/.github/workflows/verify-flex-cli-bun.yml
@@ -76,3 +76,8 @@ jobs:
           OUTPUT_DIR=sample ${{ matrix.smoke }} import
           test -f sample/flex-ax.db
           OUTPUT_DIR=sample ${{ matrix.smoke }} query "SELECT count(*) AS n FROM templates"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.outfile }}
+          path: artifacts/${{ matrix.outfile }}

--- a/apps/flex-cli/package.json
+++ b/apps/flex-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flex-ax",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "private": true,
   "type": "module",
   "description": "flex HR SaaS AX CLI - discover, crawl, and manage flex data",

--- a/apps/flex-cli/src/cli-help.ts
+++ b/apps/flex-cli/src/cli-help.ts
@@ -3,7 +3,9 @@ const TOP_LEVEL_COMMANDS = `Commands:
                   비밀번호는 OS 키링; 검증 후 저장)
                   비대화식: FLEX_EMAIL/FLEX_PASSWORD env 또는
                   --password-stdin 으로 stdin 파이프 입력 가능
+                  --gui 로 플랫폼 기본 대화상자 사용 가능
   logout          OS 키링에서 비밀번호 삭제 (글로벌 config의 이메일은 보존)
+                  --gui 로 삭제 확인 대화상자 사용 가능
   status          현재 등록 상태 표시 (비밀번호 값은 마스킹)
   crawl           카탈로그 기반 크롤링 → output/ 저장
   import          크롤링 결과(JSON) → SQLite DB 변환
@@ -33,6 +35,7 @@ Options:
   --version, -v       버전 출력
   --help, -h          도움말 출력
   --password-stdin    (login 전용) 비밀번호를 stdin 파이프로 주입
+  --gui               (login/logout 전용) 플랫폼 기본 대화상자 사용
 
 Env:
   FLEX_EMAIL                  선택 — 지정 시 글로벌 config보다 우선
@@ -44,13 +47,15 @@ Env:
   FLEX_AX_AUTO_UPDATE=false   기동 시 자동 업데이트 비활성화`;
 
 const COMMAND_HELP: Record<string, string> = {
-  login: `Usage: flex-ax login [--password-stdin]
+  login: `Usage: flex-ax login [--gui] [--password-stdin]
 
 이메일/비밀번호를 등록합니다.
+--gui 를 사용하면 브라우저 대신 플랫폼 기본 대화상자로 입력합니다.
 --password-stdin 을 사용하면 stdin 파이프로 비밀번호를 주입할 수 있습니다.`,
-  logout: `Usage: flex-ax logout
+  logout: `Usage: flex-ax logout [--gui]
 
-OS 키링에서 저장된 비밀번호를 삭제합니다.`,
+OS 키링에서 저장된 비밀번호를 삭제합니다.
+--gui 를 사용하면 삭제 확인 대화상자를 표시합니다.`,
   status: `Usage: flex-ax status
 
 현재 등록된 로그인 상태를 표시합니다.`,

--- a/apps/flex-cli/src/cli.ts
+++ b/apps/flex-cli/src/cli.ts
@@ -77,9 +77,9 @@ addPassthroughCommand(program, "login", "이메일/비밀번호 등록", async (
   await runLogin(args);
 });
 
-addPassthroughCommand(program, "logout", "OS 키링에서 비밀번호 삭제", async () => {
+addPassthroughCommand(program, "logout", "OS 키링에서 비밀번호 삭제", async (args) => {
   const { runLogout } = await import("./commands/logout.js");
-  await runLogout();
+  await runLogout(args);
 });
 
 addPassthroughCommand(program, "status", "현재 등록 상태 표시", async () => {

--- a/apps/flex-cli/src/commands/login.ts
+++ b/apps/flex-cli/src/commands/login.ts
@@ -2,7 +2,8 @@ import { loadConfig } from "../config/index.js";
 import { saveGlobalConfig, getGlobalConfigPath } from "../config/global-config.js";
 import { createLogger } from "../logger/index.js";
 import { performLogin } from "../auth/index.js";
-import { promptLine, promptPassword, saveToKeyring } from "../auth/credentials.js";
+import { promptLine, promptPassword, readFromKeyring, saveToKeyring } from "../auth/credentials.js";
+import { confirmGuiOverwrite, GuiUnavailableError, promptGuiCredentials } from "../gui/dialogs.js";
 
 /**
  * 이메일 + 비밀번호를 받아 실제 5단계 로그인까지 통과하면
@@ -18,6 +19,7 @@ import { promptLine, promptPassword, saveToKeyring } from "../auth/credentials.j
 export async function runLogin(argv: string[] = process.argv.slice(3)): Promise<void> {
   const logger = createLogger("LOGIN");
   const passwordFromStdin = argv.includes("--password-stdin");
+  const useGui = argv.includes("--gui");
 
   let config;
   try {
@@ -30,6 +32,15 @@ export async function runLogin(argv: string[] = process.argv.slice(3)): Promise<
   }
 
   const isTTY = process.stdin.isTTY === true;
+
+  if (useGui) {
+    if (passwordFromStdin) {
+      logger.error("--gui와 --password-stdin은 함께 사용할 수 없습니다.");
+      process.exit(1);
+    }
+    await runGuiLogin(config.flexEmail, config.flexBaseUrl, logger);
+    return;
+  }
 
   if (passwordFromStdin && isTTY) {
     logger.error("--password-stdin은 stdin이 파이프로 주입될 때 사용하세요. 대화형 셸이라면 옵션을 빼거나 echo/here-doc으로 파이프하세요.");
@@ -93,6 +104,51 @@ export async function runLogin(argv: string[] = process.argv.slice(3)): Promise<
   }
   saveToKeyring(email, password, logger);
   console.log(`[FLEX-AX:LOGIN] 완료 — 이후 crawl/check-apis 실행 시 자동으로 사용됩니다.`);
+}
+
+async function runGuiLogin(defaultEmail: string, baseUrl: string, logger: ReturnType<typeof createLogger>): Promise<void> {
+  let credentials;
+  try {
+    credentials = await promptGuiCredentials(defaultEmail);
+  } catch (error) {
+    if (error instanceof GuiUnavailableError) {
+      logger.error(error.message);
+      process.exit(1);
+    }
+    throw error;
+  }
+
+  const existing = readFromKeyring(credentials.email);
+  if (existing !== null) {
+    let shouldOverwrite = false;
+    try {
+      shouldOverwrite = await confirmGuiOverwrite(credentials.email);
+    } catch (error) {
+      if (error instanceof GuiUnavailableError) {
+        logger.error(error.message);
+        process.exit(1);
+      }
+      throw error;
+    }
+    if (!shouldOverwrite) {
+      console.log("[FLEX-AX:LOGIN] 취소됨 — 기존 키링 항목을 유지했습니다.");
+      return;
+    }
+  }
+
+  try {
+    await performLogin(baseUrl, credentials.email, credentials.password, logger);
+  } catch (error) {
+    logger.error("로그인 검증 실패 — 키링/글로벌 config에 저장하지 않았습니다", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    process.exit(1);
+  }
+
+  saveGlobalConfig({ email: credentials.email });
+  console.log(`[FLEX-AX:LOGIN] 이메일 저장: ${getGlobalConfigPath()}`);
+  saveToKeyring(credentials.email, credentials.password, logger);
+  console.log("[FLEX-AX:LOGIN] 완료 — 이후 crawl/check-apis 실행 시 자동으로 사용됩니다.");
 }
 
 async function readAllStdin(): Promise<string> {

--- a/apps/flex-cli/src/commands/logout.ts
+++ b/apps/flex-cli/src/commands/logout.ts
@@ -1,9 +1,11 @@
 import { loadConfig } from "../config/index.js";
 import { createLogger } from "../logger/index.js";
 import { deleteFromKeyring } from "../auth/credentials.js";
+import { confirmGuiLogout, GuiUnavailableError } from "../gui/dialogs.js";
 
-export async function runLogout(): Promise<void> {
+export async function runLogout(argv: string[] = process.argv.slice(3)): Promise<void> {
   const logger = createLogger("LOGOUT");
+  const useGui = argv.includes("--gui");
 
   let config;
   try {
@@ -18,6 +20,23 @@ export async function runLogout(): Promise<void> {
   if (!config.flexEmail) {
     console.log("[FLEX-AX:LOGOUT] 등록된 이메일이 없습니다 — 삭제할 항목이 없습니다.");
     return;
+  }
+
+  if (useGui) {
+    let confirmed = false;
+    try {
+      confirmed = await confirmGuiLogout(config.flexEmail);
+    } catch (error) {
+      if (error instanceof GuiUnavailableError) {
+        logger.error(error.message);
+        process.exit(1);
+      }
+      throw error;
+    }
+    if (!confirmed) {
+      console.log("[FLEX-AX:LOGOUT] 취소됨 — 키링 항목을 유지했습니다.");
+      return;
+    }
   }
 
   const removed = deleteFromKeyring(config.flexEmail);

--- a/apps/flex-cli/src/gui/dialogs.ts
+++ b/apps/flex-cli/src/gui/dialogs.ts
@@ -1,0 +1,345 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export class GuiUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "GuiUnavailableError";
+  }
+}
+
+class GuiCommandMissingError extends GuiUnavailableError {}
+
+export interface GuiCredentials {
+  email: string;
+  password: string;
+}
+
+export async function promptGuiCredentials(defaultEmail: string): Promise<GuiCredentials> {
+  const email = (await promptText({
+    title: "flex-ax login",
+    label: "Email",
+    defaultValue: defaultEmail,
+  })).trim();
+  if (!email) {
+    throw new GuiUnavailableError("이메일 입력이 비어있습니다.");
+  }
+
+  const password = await promptPassword(email);
+  if (!password) {
+    throw new GuiUnavailableError("비밀번호 입력이 비어있습니다.");
+  }
+
+  return { email, password };
+}
+
+export async function confirmGuiOverwrite(email: string): Promise<boolean> {
+  return confirmDialog(
+    "flex-ax login",
+    `An OS keyring credential already exists for ${email}. Replace it?`,
+    "Replace",
+    "Cancel",
+  );
+}
+
+export async function confirmGuiLogout(email: string): Promise<boolean> {
+  return confirmDialog(
+    "flex-ax logout",
+    `Remove the OS keyring credential for ${email}?`,
+    "Remove",
+    "Cancel",
+  );
+}
+
+async function promptText(options: {
+  title: string;
+  label: string;
+  defaultValue: string;
+}): Promise<string> {
+  switch (process.platform) {
+    case "darwin":
+      return runAppleScriptText(options);
+    case "win32":
+      return runPowerShellText(options);
+    default:
+      return runLinuxText(options);
+  }
+}
+
+async function promptPassword(email: string): Promise<string> {
+  switch (process.platform) {
+    case "darwin":
+      return runAppleScriptPassword(email);
+    case "win32":
+      return runPowerShellPassword(email);
+    default:
+      return runLinuxPassword(email);
+  }
+}
+
+async function confirmDialog(
+  title: string,
+  message: string,
+  okLabel: string,
+  cancelLabel: string,
+): Promise<boolean> {
+  switch (process.platform) {
+    case "darwin":
+      return runAppleScriptConfirm(title, message, okLabel, cancelLabel);
+    case "win32":
+      return runPowerShellConfirm(title, message, okLabel);
+    default:
+      return runLinuxConfirm(title, message, okLabel, cancelLabel);
+  }
+}
+
+async function runAppleScriptText(options: {
+  title: string;
+  label: string;
+  defaultValue: string;
+}): Promise<string> {
+  const script = `
+on run argv
+  set dialogTitle to item 1 of argv
+  set dialogLabel to item 2 of argv
+  set defaultValue to item 3 of argv
+  display dialog dialogLabel default answer defaultValue with title dialogTitle buttons {"Cancel", "OK"} default button "OK" cancel button "Cancel"
+  return text returned of result
+end run`;
+  return runCommand("osascript", ["-e", script, options.title, options.label, options.defaultValue]);
+}
+
+async function runAppleScriptPassword(email: string): Promise<string> {
+  const script = `
+on run argv
+  set emailAddress to item 1 of argv
+  display dialog "Password for " & emailAddress default answer "" with hidden answer with title "flex-ax login" buttons {"Cancel", "OK"} default button "OK" cancel button "Cancel"
+  return text returned of result
+end run`;
+  return runCommand("osascript", ["-e", script, email]);
+}
+
+async function runAppleScriptConfirm(
+  title: string,
+  message: string,
+  okLabel: string,
+  cancelLabel: string,
+): Promise<boolean> {
+  const script = `
+on run argv
+  set dialogTitle to item 1 of argv
+  set dialogMessage to item 2 of argv
+  set okLabel to item 3 of argv
+  set cancelLabel to item 4 of argv
+  display dialog dialogMessage with title dialogTitle buttons {cancelLabel, okLabel} default button okLabel cancel button cancelLabel
+  return button returned of result
+end run`;
+  const output = await runCommand("osascript", ["-e", script, title, message, okLabel, cancelLabel]);
+  return output === okLabel;
+}
+
+async function runPowerShellText(options: {
+  title: string;
+  label: string;
+  defaultValue: string;
+}): Promise<string> {
+  const script = `
+Add-Type -AssemblyName System.Windows.Forms
+Add-Type -AssemblyName System.Drawing
+$form = New-Object System.Windows.Forms.Form
+$form.Text = $args[0]
+$form.StartPosition = "CenterScreen"
+$form.ClientSize = New-Object System.Drawing.Size(420, 130)
+$label = New-Object System.Windows.Forms.Label
+$label.Text = $args[1]
+$label.AutoSize = $true
+$label.Location = New-Object System.Drawing.Point(12, 16)
+$box = New-Object System.Windows.Forms.TextBox
+$box.Text = $args[2]
+$box.Width = 390
+$box.Location = New-Object System.Drawing.Point(12, 44)
+$ok = New-Object System.Windows.Forms.Button
+$ok.Text = "OK"
+$ok.DialogResult = [System.Windows.Forms.DialogResult]::OK
+$ok.Location = New-Object System.Drawing.Point(246, 86)
+$cancel = New-Object System.Windows.Forms.Button
+$cancel.Text = "Cancel"
+$cancel.DialogResult = [System.Windows.Forms.DialogResult]::Cancel
+$cancel.Location = New-Object System.Drawing.Point(327, 86)
+$form.Controls.AddRange(@($label, $box, $ok, $cancel))
+$form.AcceptButton = $ok
+$form.CancelButton = $cancel
+if ($form.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) { [Console]::Out.Write($box.Text) } else { exit 1 }`;
+  return runCommand("powershell.exe", [
+    "-NoProfile",
+    "-NonInteractive",
+    "-ExecutionPolicy",
+    "Bypass",
+    "-Command",
+    script,
+    options.title,
+    options.label,
+    options.defaultValue,
+  ]);
+}
+
+async function runPowerShellPassword(email: string): Promise<string> {
+  const script = `
+Add-Type -AssemblyName System.Windows.Forms
+Add-Type -AssemblyName System.Drawing
+$form = New-Object System.Windows.Forms.Form
+$form.Text = "flex-ax login"
+$form.StartPosition = "CenterScreen"
+$form.ClientSize = New-Object System.Drawing.Size(420, 130)
+$label = New-Object System.Windows.Forms.Label
+$label.Text = "Password for " + $args[0]
+$label.AutoSize = $true
+$label.Location = New-Object System.Drawing.Point(12, 16)
+$box = New-Object System.Windows.Forms.TextBox
+$box.Width = 390
+$box.UseSystemPasswordChar = $true
+$box.Location = New-Object System.Drawing.Point(12, 44)
+$ok = New-Object System.Windows.Forms.Button
+$ok.Text = "OK"
+$ok.DialogResult = [System.Windows.Forms.DialogResult]::OK
+$ok.Location = New-Object System.Drawing.Point(246, 86)
+$cancel = New-Object System.Windows.Forms.Button
+$cancel.Text = "Cancel"
+$cancel.DialogResult = [System.Windows.Forms.DialogResult]::Cancel
+$cancel.Location = New-Object System.Drawing.Point(327, 86)
+$form.Controls.AddRange(@($label, $box, $ok, $cancel))
+$form.AcceptButton = $ok
+$form.CancelButton = $cancel
+if ($form.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) { [Console]::Out.Write($box.Text) } else { exit 1 }`;
+  return runCommand("powershell.exe", [
+    "-NoProfile",
+    "-NonInteractive",
+    "-ExecutionPolicy",
+    "Bypass",
+    "-Command",
+    script,
+    email,
+  ]);
+}
+
+async function runPowerShellConfirm(title: string, message: string, okLabel: string): Promise<boolean> {
+  const script = `
+Add-Type -AssemblyName System.Windows.Forms
+$result = [System.Windows.Forms.MessageBox]::Show($args[1], $args[0], [System.Windows.Forms.MessageBoxButtons]::OKCancel, [System.Windows.Forms.MessageBoxIcon]::Question)
+if ($result -eq [System.Windows.Forms.DialogResult]::OK) { [Console]::Out.Write($args[2]) } else { exit 1 }`;
+  const output = await runCommand("powershell.exe", [
+    "-NoProfile",
+    "-NonInteractive",
+    "-ExecutionPolicy",
+    "Bypass",
+    "-Command",
+    script,
+    title,
+    message,
+    okLabel,
+  ]);
+  return output === okLabel;
+}
+
+async function runLinuxText(options: {
+  title: string;
+  label: string;
+  defaultValue: string;
+}): Promise<string> {
+  try {
+    return await runCommand("zenity", [
+      "--entry",
+      "--title",
+      options.title,
+      "--text",
+      options.label,
+      "--entry-text",
+      options.defaultValue,
+    ]);
+  } catch (error) {
+    if (!isCommandMissing(error)) throw error;
+    return runCommand("kdialog", [
+      "--title",
+      options.title,
+      "--inputbox",
+      options.label,
+      options.defaultValue,
+    ]);
+  }
+}
+
+async function runLinuxPassword(email: string): Promise<string> {
+  try {
+    return await runCommand("zenity", [
+      "--password",
+      "--title",
+      "flex-ax login",
+      "--text",
+      `Password for ${email}`,
+    ]);
+  } catch (error) {
+    if (!isCommandMissing(error)) throw error;
+    return runCommand("kdialog", ["--title", "flex-ax login", "--password", `Password for ${email}`]);
+  }
+}
+
+async function runLinuxConfirm(
+  title: string,
+  message: string,
+  okLabel: string,
+  cancelLabel: string,
+): Promise<boolean> {
+  try {
+    await runCommand("zenity", [
+      "--question",
+      "--title",
+      title,
+      "--text",
+      message,
+      "--ok-label",
+      okLabel,
+      "--cancel-label",
+      cancelLabel,
+    ]);
+    return true;
+  } catch (error) {
+    if (!isCommandMissing(error)) throw error;
+    await runCommand("kdialog", ["--title", title, "--yesno", message, "--yes-label", okLabel, "--no-label", cancelLabel]);
+    return true;
+  }
+}
+
+async function runCommand(command: string, args: string[]): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync(command, args, {
+      windowsHide: true,
+      timeout: 0,
+      maxBuffer: 1024 * 64,
+    });
+    return stdout.replace(/\r?\n$/, "");
+  } catch (error) {
+    if (isCommandMissing(error)) {
+      throw new GuiCommandMissingError(guiInstallHint());
+    }
+    throw new GuiUnavailableError("GUI 입력이 취소되었거나 실행할 수 없습니다.");
+  }
+}
+
+function isCommandMissing(error: unknown): boolean {
+  return (
+    error instanceof GuiCommandMissingError ||
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    ((error as { code?: unknown }).code === "ENOENT" || (error as { code?: unknown }).code === 127)
+  );
+}
+
+function guiInstallHint(): string {
+  if (process.platform === "linux") {
+    return "GUI 입력 도구를 찾을 수 없습니다. zenity 또는 kdialog를 설치하거나 `flex-ax login`을 사용하세요.";
+  }
+  return "GUI 입력 도구를 실행할 수 없습니다. `flex-ax login`을 사용하세요.";
+}

--- a/apps/flex-cli/src/gui/dialogs.ts
+++ b/apps/flex-cli/src/gui/dialogs.ts
@@ -314,7 +314,7 @@ async function runLinuxConfirm(
 async function runCommand(command: string, args: string[]): Promise<string> {
   try {
     const { stdout } = await execFileAsync(command, args, {
-      windowsHide: true,
+      windowsHide: false,
       timeout: 0,
       maxBuffer: 1024 * 64,
     });

--- a/apps/flex-cli/src/gui/dialogs.ts
+++ b/apps/flex-cli/src/gui/dialogs.ts
@@ -145,19 +145,21 @@ async function runPowerShellText(options: {
   label: string;
   defaultValue: string;
 }): Promise<string> {
-  const script = `
+  const payload = encodePowerShellPayload(options);
+  const script = `& {
+$payload = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String("${payload}")) | ConvertFrom-Json
 Add-Type -AssemblyName System.Windows.Forms
 Add-Type -AssemblyName System.Drawing
 $form = New-Object System.Windows.Forms.Form
-$form.Text = $args[0]
+$form.Text = $payload.title
 $form.StartPosition = "CenterScreen"
 $form.ClientSize = New-Object System.Drawing.Size(420, 130)
 $label = New-Object System.Windows.Forms.Label
-$label.Text = $args[1]
+$label.Text = $payload.label
 $label.AutoSize = $true
 $label.Location = New-Object System.Drawing.Point(12, 16)
 $box = New-Object System.Windows.Forms.TextBox
-$box.Text = $args[2]
+$box.Text = $payload.defaultValue
 $box.Width = 390
 $box.Location = New-Object System.Drawing.Point(12, 44)
 $ok = New-Object System.Windows.Forms.Button
@@ -171,7 +173,8 @@ $cancel.Location = New-Object System.Drawing.Point(327, 86)
 $form.Controls.AddRange(@($label, $box, $ok, $cancel))
 $form.AcceptButton = $ok
 $form.CancelButton = $cancel
-if ($form.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) { [Console]::Out.Write($box.Text) } else { exit 1 }`;
+if ($form.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) { [Console]::Out.Write($box.Text) } else { exit 1 }
+}`;
   return runCommand("powershell.exe", [
     "-NoProfile",
     "-NonInteractive",
@@ -179,14 +182,13 @@ if ($form.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) { [Console]:
     "Bypass",
     "-Command",
     script,
-    options.title,
-    options.label,
-    options.defaultValue,
   ]);
 }
 
 async function runPowerShellPassword(email: string): Promise<string> {
-  const script = `
+  const payload = encodePowerShellPayload({ email });
+  const script = `& {
+$payload = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String("${payload}")) | ConvertFrom-Json
 Add-Type -AssemblyName System.Windows.Forms
 Add-Type -AssemblyName System.Drawing
 $form = New-Object System.Windows.Forms.Form
@@ -194,7 +196,7 @@ $form.Text = "flex-ax login"
 $form.StartPosition = "CenterScreen"
 $form.ClientSize = New-Object System.Drawing.Size(420, 130)
 $label = New-Object System.Windows.Forms.Label
-$label.Text = "Password for " + $args[0]
+$label.Text = "Password for " + $payload.email
 $label.AutoSize = $true
 $label.Location = New-Object System.Drawing.Point(12, 16)
 $box = New-Object System.Windows.Forms.TextBox
@@ -212,7 +214,8 @@ $cancel.Location = New-Object System.Drawing.Point(327, 86)
 $form.Controls.AddRange(@($label, $box, $ok, $cancel))
 $form.AcceptButton = $ok
 $form.CancelButton = $cancel
-if ($form.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) { [Console]::Out.Write($box.Text) } else { exit 1 }`;
+if ($form.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) { [Console]::Out.Write($box.Text) } else { exit 1 }
+}`;
   return runCommand("powershell.exe", [
     "-NoProfile",
     "-NonInteractive",
@@ -220,15 +223,17 @@ if ($form.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) { [Console]:
     "Bypass",
     "-Command",
     script,
-    email,
   ]);
 }
 
 async function runPowerShellConfirm(title: string, message: string, okLabel: string): Promise<boolean> {
-  const script = `
+  const payload = encodePowerShellPayload({ title, message, okLabel });
+  const script = `& {
+$payload = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String("${payload}")) | ConvertFrom-Json
 Add-Type -AssemblyName System.Windows.Forms
-$result = [System.Windows.Forms.MessageBox]::Show($args[1], $args[0], [System.Windows.Forms.MessageBoxButtons]::OKCancel, [System.Windows.Forms.MessageBoxIcon]::Question)
-if ($result -eq [System.Windows.Forms.DialogResult]::OK) { [Console]::Out.Write($args[2]) } else { exit 1 }`;
+$result = [System.Windows.Forms.MessageBox]::Show($payload.message, $payload.title, [System.Windows.Forms.MessageBoxButtons]::OKCancel, [System.Windows.Forms.MessageBoxIcon]::Question)
+if ($result -eq [System.Windows.Forms.DialogResult]::OK) { [Console]::Out.Write($payload.okLabel) } else { exit 1 }
+}`;
   const output = await runCommand("powershell.exe", [
     "-NoProfile",
     "-NonInteractive",
@@ -236,11 +241,12 @@ if ($result -eq [System.Windows.Forms.DialogResult]::OK) { [Console]::Out.Write(
     "Bypass",
     "-Command",
     script,
-    title,
-    message,
-    okLabel,
   ]);
   return output === okLabel;
+}
+
+function encodePowerShellPayload(value: unknown): string {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
 }
 
 async function runLinuxText(options: {


### PR DESCRIPTION
## Summary

Adds a lightweight GUI credential flow for flex-ax login/logout without introducing a browser tab or desktop app framework.

- Adds `flex-ax login --gui` for platform-native email/password dialogs
- Adds `flex-ax logout --gui` for a native confirmation dialog before deleting the keyring entry
- Reuses existing login verification, global config persistence, and OS keyring save/delete paths
- Documents the new `--gui` option in command help

## Platform behavior

- macOS uses AppleScript dialogs via `osascript`
- Windows uses PowerShell WinForms dialogs
- Linux uses `zenity`, falling back to `kdialog` when available

Secrets are accepted through masked password controls and are not printed to logs, stdout, or command-line arguments.

Closes #46.

## Validation

- `pnpm --filter flex-ax lint`
- `pnpm --filter flex-ax build`
- `cd apps/flex-cli && bun test src/cli-help.test.ts src/auto-update.test.ts`
- Manual macOS dialog smoke test with `node apps/flex-cli/dist/cli.js login --gui`

Note: full `pnpm --filter flex-ax test` still fails in the existing `src/commands/query.test.ts` `parseQueryArgs` expectations, unrelated to this change.