### PR TITLE
[codex] fix query argv test expectations

### DIFF
--- a/apps/flex-cli/src/commands/query.test.ts
+++ b/apps/flex-cli/src/commands/query.test.ts
@@ -3,8 +3,8 @@ import assert from "node:assert/strict";
 import { parseQueryArgs, applyVars, QueryArgError } from "./query.js";
 
 describe("parseQueryArgs", () => {
-  // argv[0] = node, argv[1] = script, argv[2] = "query", argv[3..] = args
-  const base = ["node", "flex-ax", "query"];
+  // parseQueryArgs() receives the command args passed to runQuery(args).
+  const base: string[] = [];
 
   it("parses inline SQL", () => {
     const result = parseQueryArgs([...base, "SELECT * FROM users"]);


### PR DESCRIPTION
## Summary
- align `parseQueryArgs` tests with the actual `runQuery(args)` calling contract
- remove the `node flex-ax query` argv prefix from test inputs
- update the test comment to describe the real command-args shape

## Why
`parseQueryArgs()` is called from Commander with command-only args, but the tests were passing a full `process.argv`-style prefix. That made the tests fail even though the command wiring already matched the intended CLI behavior.

## Impact
This keeps the implementation unchanged and fixes the failing query command tests by asserting against the real runtime contract.

## Validation
- `cd apps/flex-cli && bun test src/commands/query.test.ts`
- `pnpm --filter flex-ax test`

Refs #48
