### PR TITLE
[codex] Update flex-cli actions for Node 24

### DIFF
--- a/.github/workflows/release-flex-cli.yml
+++ b/.github/workflows/release-flex-cli.yml
@@ -40,7 +40,7 @@ jobs:
           node-version: "22"
           cache: pnpm
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: ".bun-version"
 

--- a/.github/workflows/release-flex-cli.yml
+++ b/.github/workflows/release-flex-cli.yml
@@ -29,13 +29,13 @@ jobs:
             smoke: ./flex-ax-windows-x64.exe
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+      - uses: pnpm/action-setup@a0ea98b2dc7d387a59324835f7421c1d5f8357b4 # v6.0.5
         with:
           version: 9.15.4
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "22"
           cache: pnpm
@@ -83,7 +83,7 @@ jobs:
           test -f sample/flex-ax.db
           OUTPUT_DIR=sample ${{ matrix.smoke }} query "SELECT count(*) AS n FROM templates"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.outfile }}
           path: artifacts/${{ matrix.outfile }}
@@ -93,7 +93,7 @@ jobs:
     needs: build
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: release-assets
 
@@ -109,7 +109,7 @@ jobs:
         run: echo "version=${GITHUB_REF_NAME#flex-cli@}" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           name: "flex-cli ${{ steps.version.outputs.version }}"
           files: dist/*

--- a/.github/workflows/verify-flex-cli-bun.yml
+++ b/.github/workflows/verify-flex-cli-bun.yml
@@ -39,13 +39,13 @@ jobs:
             smoke: ./flex-ax-windows-x64.exe
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+      - uses: pnpm/action-setup@a0ea98b2dc7d387a59324835f7421c1d5f8357b4 # v6.0.5
         with:
           version: 9.15.4
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "22"
           cache: pnpm
@@ -77,7 +77,7 @@ jobs:
           test -f sample/flex-ax.db
           OUTPUT_DIR=sample ${{ matrix.smoke }} query "SELECT count(*) AS n FROM templates"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.outfile }}
           path: artifacts/${{ matrix.outfile }}

--- a/.github/workflows/verify-flex-cli-bun.yml
+++ b/.github/workflows/verify-flex-cli-bun.yml
@@ -50,7 +50,7 @@ jobs:
           node-version: "22"
           cache: pnpm
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: ".bun-version"
 


### PR DESCRIPTION
## Summary
- update flex-cli release and verification workflow actions to Node 24-compatible releases
- keep third-party actions pinned to the release commit SHAs
- address Node.js 20 actions deprecation warnings from #38

Closes #38

## Validation
- ruby YAML parse check for both updated workflow files
- verified removed Node 20-era action references in the flex-cli workflows
- confirmed updated action.yml runtimes use node24