### PR TITLE
Expose document.updatedAt as instances.last_updated_at

### DIFF
--- a/apps/flex-cli/src/crawlers/instance.ts
+++ b/apps/flex-cli/src/crawlers/instance.ts
@@ -357,6 +357,7 @@ function mapInstance(detail: DocumentDetailResponse, attachments: AttachmentInfo
     templateName: doc.templateKey,
     drafter: { id: doc.writer.idHash, name: doc.writer.name },
     draftedAt: doc.writtenAt,
+    lastUpdatedAt: doc.updatedAt ?? null,
     status: doc.status,
     approvalLine,
     fields,

--- a/apps/flex-cli/src/db/import.ts
+++ b/apps/flex-cli/src/db/import.ts
@@ -85,8 +85,8 @@ export async function importToSqlite(
       INSERT OR IGNORE INTO templates (id, name) VALUES (?, ?)
     `),
     instance: db.prepare(`
-      INSERT OR REPLACE INTO instances (id, document_number, template_id, drafter_id, drafted_at, status, content_html, raw)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT OR REPLACE INTO instances (id, document_number, template_id, drafter_id, drafted_at, last_updated_at, status, content_html, raw)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
     `),
     fieldValue: db.prepare(`
       INSERT OR REPLACE INTO field_values (instance_id, field_name, field_type, value_text, value_number, value_date, currency)
@@ -268,6 +268,7 @@ function importInstance(
     data.templateId,
     drafter?.id ?? null,
     data.draftedAt,
+    data.lastUpdatedAt ?? doc?.updatedAt ?? null,
     data.status,
     (doc?.content as string) ?? null,
     JSON.stringify(raw ?? null),

--- a/apps/flex-cli/src/db/import.ts
+++ b/apps/flex-cli/src/db/import.ts
@@ -40,6 +40,11 @@ export async function importToSqlite(
   // schema.sql 적용 (빌드 시점에 텍스트로 인라인됨)
   db.exec(schemaSql);
 
+  // 기존 DB 파일에 누락된 컬럼/인덱스 보강. CREATE TABLE IF NOT EXISTS는
+  // 기존 테이블의 컬럼을 변경하지 않으므로, 새로 추가되는 컬럼은 여기서
+  // ALTER TABLE로 보강해 주어야 한다.
+  runMigrations(db);
+
   // 사용자 수집용
   const users = new Map<string, { name: string; aliases: Set<string> }>();
 
@@ -381,6 +386,18 @@ function importInstance(
     );
     result.comments++;
   }
+}
+
+function runMigrations(db: Database): void {
+  const instanceCols = db
+    .query("PRAGMA table_info(instances)")
+    .all() as { name: string }[];
+  if (!instanceCols.some((c) => c.name === "last_updated_at")) {
+    db.exec("ALTER TABLE instances ADD COLUMN last_updated_at TEXT");
+  }
+  db.exec(
+    "CREATE INDEX IF NOT EXISTS idx_instances_last_updated_at ON instances(last_updated_at DESC)",
+  );
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/apps/flex-cli/src/db/schema.sql
+++ b/apps/flex-cli/src/db/schema.sql
@@ -64,7 +64,10 @@ CREATE INDEX IF NOT EXISTS idx_instances_drafter         ON instances(drafter_id
 CREATE INDEX IF NOT EXISTS idx_instances_drafted_at      ON instances(drafted_at);
 CREATE INDEX IF NOT EXISTS idx_instances_status          ON instances(status);
 CREATE INDEX IF NOT EXISTS idx_instances_doc_number      ON instances(document_number);
-CREATE INDEX IF NOT EXISTS idx_instances_last_updated_at ON instances(last_updated_at DESC);
+-- idx_instances_last_updated_at: see runMigrations() in import.ts. The index
+-- depends on a column that was added after the initial schema, so creating it
+-- here would abort `db.exec(schemaSql)` on older DB files where the column
+-- has not yet been ALTERed in.
 
 -- ============================================================
 -- 필드값 (EAV)

--- a/apps/flex-cli/src/db/schema.sql
+++ b/apps/flex-cli/src/db/schema.sql
@@ -53,6 +53,7 @@ CREATE TABLE IF NOT EXISTS instances (
   template_id     TEXT NOT NULL REFERENCES templates(id),
   drafter_id      TEXT REFERENCES users(id),
   drafted_at      TEXT NOT NULL,          -- [PG] → TIMESTAMPTZ
+  last_updated_at TEXT,                   -- [PG] → TIMESTAMPTZ, flex document.updatedAt
   status          TEXT NOT NULL,
   content_html    TEXT,
   raw             TEXT                    -- [PG] → JSONB
@@ -63,6 +64,7 @@ CREATE INDEX IF NOT EXISTS idx_instances_drafter         ON instances(drafter_id
 CREATE INDEX IF NOT EXISTS idx_instances_drafted_at      ON instances(drafted_at);
 CREATE INDEX IF NOT EXISTS idx_instances_status          ON instances(status);
 CREATE INDEX IF NOT EXISTS idx_instances_doc_number      ON instances(document_number);
+CREATE INDEX IF NOT EXISTS idx_instances_last_updated_at ON instances(last_updated_at DESC);
 
 -- ============================================================
 -- 필드값 (EAV)

--- a/apps/flex-cli/src/types/instance.ts
+++ b/apps/flex-cli/src/types/instance.ts
@@ -14,6 +14,7 @@ export interface WorkflowInstance {
   templateName: string;
   drafter: UserInfo;
   draftedAt: string;
+  lastUpdatedAt: string | null;
   status: ApprovalStatus;
   approvalLine: ApprovalStep[];
   fields: FieldValue[];


### PR DESCRIPTION
## Summary
- 결재 문서 매핑 모델(`WorkflowInstance`)과 SQLite `instances` 테이블에 flex `document.updatedAt`을 `lastUpdatedAt` / `last_updated_at`으로 노출.
- `idx_instances_last_updated_at(DESC)` 추가로 최신 업데이트 정렬/필터를 지원.
- 후속 증분 수집 PR(planetarium/reflex#38)에서 customer별 워터마크 갱신 기준으로 사용 예정. 이 PR 단독으로는 동작 변경 없음 (메타데이터 노출만).

## Notes
- 임포터는 신규 JSON의 `data.lastUpdatedAt`을 우선 사용하되, 이 PR 이전에 만들어진 인스턴스 JSON에 대해서는 `_raw.document.updatedAt`으로 백필되도록 폴백을 둠. 기존 SQLite를 재임포트하면 컬럼이 채워진다.
- PG 마이그레이션 시 `last_updated_at`은 `TIMESTAMPTZ`로 (스키마 주석 표기).

## Test plan
- [x] `bunx tsc --noEmit` 통과
- [x] `bun test` 38/38 통과
- [ ] 실제 크롤 1회 → `instances/*.json`에 `lastUpdatedAt` 채워지는지 확인
- [ ] `flex-ax import` 재실행 후 `SELECT id, last_updated_at FROM instances WHERE last_updated_at IS NOT NULL LIMIT 5;` 로 채움 여부 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)