### PR TITLE
Incremental approval-document crawl with per-status watermarks

### DIFF
--- a/apps/flex-cli/src/cli-help.ts
+++ b/apps/flex-cli/src/cli-help.ts
@@ -44,6 +44,8 @@ Env:
                               (CI에서 사용)
   FLEX_BASE_URL               기본 https://flex.team
   FLEX_CUSTOMERS              크롤 대상 법인 customerIdHash (콤마 구분)
+  FLEX_CRAWL_MODE             incremental(기본) | full
+                              full 은 결재 문서 워터마크를 무시하고 전체 재수집
   FLEX_AX_AUTO_UPDATE=false   기동 시 자동 업데이트 비활성화`;
 
 const COMMAND_HELP: Record<string, string> = {
@@ -59,9 +61,17 @@ OS 키링에서 저장된 비밀번호를 삭제합니다.
   status: `Usage: flex-ax status
 
 현재 등록된 로그인 상태를 표시합니다.`,
-  crawl: `Usage: flex-ax crawl
+  crawl: `Usage: flex-ax crawl [--full]
 
-카탈로그 기반으로 데이터를 수집해 output/ 아래에 저장합니다.`,
+카탈로그 기반으로 데이터를 수집해 output/ 아래에 저장합니다.
+
+결재 문서 인스턴스는 기본적으로 증분 수집(incremental)으로 동작합니다.
+customer 단위로 output/<customerIdHash>/watermark.json 을 두고, 다음 실행
+시 flex 검색 요청에 lastUpdatedDateRange (KST 기준)을 적용합니다. 워터마크가
+없는 첫 실행은 자동으로 부트스트랩 풀크롤로 폴백합니다.
+
+Options:
+  --full          워터마크 무시, 결재 문서 전체 재수집 (env: FLEX_CRAWL_MODE=full)`,
   import: `Usage: flex-ax import
 
 크롤링 결과(JSON)를 SQLite로 변환합니다.

--- a/apps/flex-cli/src/cli.ts
+++ b/apps/flex-cli/src/cli.ts
@@ -30,6 +30,7 @@ Env:
   FLEX_PASSWORD
   FLEX_BASE_URL
   FLEX_CUSTOMERS
+  FLEX_CRAWL_MODE=incremental|full   (default: incremental — 워터마크 없으면 부트스트랩 풀크롤)
   FLEX_AX_AUTO_UPDATE=false
 `,
 );
@@ -87,9 +88,9 @@ addPassthroughCommand(program, "status", "현재 등록 상태 표시", async ()
   await runStatus();
 });
 
-addPassthroughCommand(program, "crawl", "카탈로그 기반 크롤링", async () => {
+addPassthroughCommand(program, "crawl", "카탈로그 기반 크롤링", async (args) => {
   const { runCrawl } = await import("./commands/crawl.js");
-  await runCrawl();
+  await runCrawl(args);
 });
 
 addPassthroughCommand(program, "import", "크롤링 결과를 SQLite로 변환", async () => {

--- a/apps/flex-cli/src/commands/crawl.ts
+++ b/apps/flex-cli/src/commands/crawl.ts
@@ -19,7 +19,7 @@ import { crawlCatalogEndpoints } from "../crawlers/catalog-endpoints.js";
 import type { CrawlError } from "../types/common.js";
 import type { CrawlResult } from "../crawlers/shared.js";
 
-export async function runCrawl(args: string[] = []): Promise<void> {
+export async function runCrawl(args: string[] = process.argv.slice(3)): Promise<void> {
   const logger = createLogger("CRAWL");
 
   let config: Config;

--- a/apps/flex-cli/src/commands/crawl.ts
+++ b/apps/flex-cli/src/commands/crawl.ts
@@ -13,13 +13,13 @@ import {
 import { createStorageWriter, type CrawlReport, type StorageWriter } from "../storage/index.js";
 import type { ApiCatalog } from "../types/catalog.js";
 import { crawlTemplates } from "../crawlers/template.js";
-import { crawlInstances } from "../crawlers/instance.js";
+import { crawlInstances, type CrawlMode } from "../crawlers/instance.js";
 import { crawlAttendanceApprovals } from "../crawlers/attendance.js";
 import { crawlCatalogEndpoints } from "../crawlers/catalog-endpoints.js";
 import type { CrawlError } from "../types/common.js";
 import type { CrawlResult } from "../crawlers/shared.js";
 
-export async function runCrawl(): Promise<void> {
+export async function runCrawl(args: string[] = []): Promise<void> {
   const logger = createLogger("CRAWL");
 
   let config: Config;
@@ -30,6 +30,12 @@ export async function runCrawl(): Promise<void> {
       error: error instanceof Error ? error.message : String(error),
     });
     process.exit(1);
+  }
+
+  // CLI flag가 env/config 보다 우선. `--full`이 있으면 강제로 풀크롤.
+  const mode: CrawlMode = args.includes("--full") ? "full" : config.flexCrawlMode;
+  if (mode !== config.flexCrawlMode) {
+    logger.info("크롤 모드 override", { from: config.flexCrawlMode, to: mode });
   }
 
   // 카탈로그 로드 (없으면 하드코딩 폴백)
@@ -122,7 +128,7 @@ export async function runCrawl(): Promise<void> {
         continue;
       }
 
-      const errors = await runCrawlForCustomer(authCtx, config, catalog, corp, logger);
+      const errors = await runCrawlForCustomer(authCtx, config, catalog, corp, logger, mode);
       allErrors.push(...errors);
     }
   } finally {
@@ -143,6 +149,7 @@ async function runCrawlForCustomer(
   catalog: ApiCatalog | null,
   corp: Corporation,
   logger: Logger,
+  mode: CrawlMode,
 ): Promise<CrawlError[]> {
   const customerOutputDir = path.join(config.outputDir, corp.customerIdHash);
   const storage: StorageWriter = createStorageWriter(customerOutputDir, config.catalogPath);
@@ -157,7 +164,7 @@ async function runCrawlForCustomer(
 
   try {
     templateResult = await crawlTemplates(authCtx, config, catalog, storage, logger);
-    const instanceCrawlResult = await crawlInstances(authCtx, config, catalog, storage, logger);
+    const instanceCrawlResult = await crawlInstances(authCtx, config, catalog, storage, logger, mode);
     instanceResult = instanceCrawlResult;
     attendanceResult = await crawlAttendanceApprovals(
       authCtx, config, catalog, storage, logger, instanceCrawlResult.collectedKeys,

--- a/apps/flex-cli/src/config/index.ts
+++ b/apps/flex-cli/src/config/index.ts
@@ -68,6 +68,13 @@ const configSchema = z.object({
         .map((s) => s.trim())
         .filter((s) => s.length > 0),
     ),
+  /**
+   * 결재 문서 인스턴스 크롤 모드.
+   * - "incremental"(기본): 워터마크가 있으면 `lastUpdatedDateRange`를 적용해 증분 수집.
+   *   워터마크가 없으면 자동으로 부트스트랩 풀크롤로 폴백.
+   * - "full": 워터마크 무시, 날짜 필터 없이 전체 재수집. CLI `--full`로도 강제할 수 있다.
+   */
+  flexCrawlMode: z.enum(["incremental", "full"]).default("incremental"),
 });
 
 export type Config = z.infer<typeof configSchema>;
@@ -89,5 +96,6 @@ export function loadConfig(): Config {
     crawlSensitive: process.env.FLEX_CRAWL_SENSITIVE || undefined,
     skipEndpoints: process.env.FLEX_SKIP_ENDPOINTS || undefined,
     customers: process.env.FLEX_CUSTOMERS || undefined,
+    flexCrawlMode: process.env.FLEX_CRAWL_MODE || undefined,
   });
 }

--- a/apps/flex-cli/src/crawlers/instance.test.ts
+++ b/apps/flex-cli/src/crawlers/instance.test.ts
@@ -1,0 +1,393 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import type { AuthContext } from "../auth/index.js";
+import type { Config } from "../config/index.js";
+import type { Logger } from "../logger/index.js";
+import type {
+  CrawlReport,
+  StorageWriter,
+  WatermarkFile,
+} from "../storage/index.js";
+import { crawlInstances } from "./instance.js";
+import { toKstDate } from "./shared.js";
+
+interface CapturedFetch {
+  url: string;
+  method: string;
+  body: unknown;
+}
+
+const ORIGINAL_FETCH = globalThis.fetch;
+
+function makeAuth(): AuthContext {
+  return {
+    baseUrl: "https://flex.test",
+    deviceId: "device-1",
+    workspaceToken: "ws-token",
+    refreshToken: "rt-token",
+    customerToken: "ct-token",
+  };
+}
+
+function makeConfig(): Config {
+  return {
+    flexEmail: "",
+    flexPassword: "",
+    flexBaseUrl: "https://flex.test",
+    outputDir: "./output",
+    catalogPath: "./output/api-catalog.json",
+    requestDelayMs: 0,
+    maxRetries: 0,
+    concurrency: 2,
+    attachmentConcurrency: 1,
+    searchPageSize: 100,
+    downloadAttachments: false,
+    crawlSensitive: false,
+    skipEndpoints: [],
+    customers: [],
+    flexCrawlMode: "incremental",
+  };
+}
+
+function makeLogger(): Logger {
+  return {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    progress: () => {},
+  };
+}
+
+interface FakeStorage extends StorageWriter {
+  _instances: unknown[];
+  _watermarks: WatermarkFile;
+}
+
+function makeStorage(initial: WatermarkFile = {}): FakeStorage {
+  let watermarks: WatermarkFile = structuredClone(initial);
+  const instances: unknown[] = [];
+  const writer: FakeStorage = {
+    saveTemplate: async () => {},
+    saveInstance: async (i) => {
+      instances.push(i);
+    },
+    saveAttendanceApproval: async () => {},
+    saveAttachment: async () => "",
+    saveEndpointData: async () => {},
+    saveReport: async (_r: CrawlReport) => {},
+    saveCatalog: async () => {},
+    loadWatermarks: async () => structuredClone(watermarks),
+    saveWatermarks: async (file) => {
+      watermarks = structuredClone(file);
+    },
+    _instances: instances,
+    get _watermarks() {
+      return watermarks;
+    },
+  } as FakeStorage;
+  return writer;
+}
+
+interface SearchResp {
+  documents: Array<{
+    document: { documentKey: string; lastUpdatedAt?: string };
+  }>;
+  total: number;
+  hasNext: boolean;
+  continuationToken?: string;
+}
+
+interface DetailResp {
+  document: {
+    documentKey: string;
+    code: string;
+    templateKey: string;
+    status: string;
+    title: string;
+    writer: { idHash: string; name: string };
+    writtenAt: string;
+    inputs: unknown[];
+    updatedAt: string;
+  };
+  approvalProcess?: { status: string; lines: unknown[] };
+}
+
+function detailFor(docKey: string, updatedAt: string, status = "DONE"): DetailResp {
+  return {
+    document: {
+      documentKey: docKey,
+      code: docKey,
+      templateKey: "tmpl-1",
+      status,
+      title: "doc",
+      writer: { idHash: "u1", name: "tester" },
+      writtenAt: "2026-01-01T00:00:00Z",
+      inputs: [],
+      updatedAt,
+    },
+    approvalProcess: { status: "DONE", lines: [] },
+  };
+}
+
+function setupFetch(
+  searchResponses: Map<string, SearchResp>,
+  details: Map<string, DetailResp>,
+  failDetailFor: Set<string> = new Set(),
+): { calls: CapturedFetch[] } {
+  const calls: CapturedFetch[] = [];
+  globalThis.fetch = (async (input: unknown, init?: { method?: string; body?: string }) => {
+    const url = String(input);
+    const method = init?.method ?? "GET";
+    const body = init?.body ? JSON.parse(init.body) : null;
+    calls.push({ url, method, body });
+
+    if (url.includes("/user-boxes/search")) {
+      const statuses: string[] = body?.filter?.statuses ?? [];
+      const key = statuses.sort().join("|");
+      const resp = searchResponses.get(key);
+      if (!resp) {
+        return new Response(JSON.stringify({ documents: [], total: 0, hasNext: false }), {
+          status: 200,
+        });
+      }
+      return new Response(JSON.stringify(resp), { status: 200 });
+    }
+
+    // Detail GET: /api/v3/approval-document/approval-documents/<docKey>
+    const docKey = url.split("/").pop()!;
+    if (failDetailFor.has(docKey)) {
+      return new Response("boom", { status: 500 });
+    }
+    const detail = details.get(docKey);
+    if (!detail) {
+      return new Response("not found", { status: 404 });
+    }
+    return new Response(JSON.stringify(detail), { status: 200 });
+  }) as typeof fetch;
+  return { calls };
+}
+
+describe("crawlInstances incremental wiring", () => {
+  beforeEach(() => {
+    globalThis.fetch = ORIGINAL_FETCH;
+  });
+  afterEach(() => {
+    globalThis.fetch = ORIGINAL_FETCH;
+  });
+
+  it("bootstraps without lastUpdatedDateRange when no watermark exists, then writes one", async () => {
+    const search = new Map<string, SearchResp>([
+      [
+        "IN_PROGRESS",
+        { documents: [{ document: { documentKey: "d1" } }], total: 1, hasNext: false },
+      ],
+      [
+        "CANCELED|DECLINED|DONE",
+        { documents: [{ document: { documentKey: "d2" } }], total: 1, hasNext: false },
+      ],
+    ]);
+    const details = new Map<string, DetailResp>([
+      ["d1", detailFor("d1", "2026-04-29T12:00:00Z", "IN_PROGRESS")],
+      ["d2", detailFor("d2", "2026-04-30T03:00:00Z", "DONE")],
+    ]);
+    const { calls } = setupFetch(search, details);
+
+    const storage = makeStorage();
+    const result = await crawlInstances(makeAuth(), makeConfig(), null, storage, makeLogger());
+
+    assert.equal(result.successCount, 2);
+    const searchCalls = calls.filter((c) => c.url.includes("/user-boxes/search"));
+    for (const c of searchCalls) {
+      const filter = (c.body as { filter: Record<string, unknown> }).filter;
+      assert.ok(
+        !("lastUpdatedDateRange" in filter),
+        "bootstrap must not send lastUpdatedDateRange",
+      );
+    }
+
+    const wm = storage._watermarks.approvalDocuments!;
+    assert.equal(wm.groups["in-progress"].lastUpdatedAt, "2026-04-29T12:00:00Z");
+    assert.equal(wm.groups["done"].lastUpdatedAt, "2026-04-30T03:00:00Z");
+    assert.ok(wm.lastFullReconAt, "bootstrap counts as a full recon");
+  });
+
+  it("injects lastUpdatedDateRange (KST) when watermarks exist and mode=incremental", async () => {
+    const initial: WatermarkFile = {
+      approvalDocuments: {
+        groups: {
+          "in-progress": {
+            lastUpdatedAt: "2026-04-29T12:17:44Z",
+            overlapDays: 1,
+            lastSuccessfulRunAt: "2026-04-30T00:00:00Z",
+          },
+          done: {
+            lastUpdatedAt: "2026-04-25T03:00:00Z",
+            overlapDays: 2,
+            lastSuccessfulRunAt: "2026-04-30T00:00:00Z",
+          },
+        },
+      },
+    };
+    const search = new Map<string, SearchResp>([
+      ["IN_PROGRESS", { documents: [], total: 0, hasNext: false }],
+      ["CANCELED|DECLINED|DONE", { documents: [], total: 0, hasNext: false }],
+    ]);
+    const { calls } = setupFetch(search, new Map());
+
+    await crawlInstances(makeAuth(), makeConfig(), null, makeStorage(initial), makeLogger());
+
+    const today = toKstDate(new Date());
+    const inProgressCall = calls.find(
+      (c) =>
+        c.url.includes("/user-boxes/search") &&
+        Array.isArray((c.body as { filter: { statuses: string[] } }).filter.statuses) &&
+        (c.body as { filter: { statuses: string[] } }).filter.statuses[0] === "IN_PROGRESS",
+    );
+    assert.ok(inProgressCall);
+    const ipFilter = (inProgressCall.body as { filter: Record<string, unknown> }).filter;
+    assert.deepEqual(ipFilter.lastUpdatedDateRange, {
+      from: "2026-04-28", // KST(2026-04-29 21:17 KST) - 1d = 2026-04-28
+      to: today,
+    });
+
+    const doneCall = calls.find(
+      (c) =>
+        c.url.includes("/user-boxes/search") &&
+        (c.body as { filter: { statuses: string[] } }).filter.statuses.includes("DONE"),
+    );
+    assert.ok(doneCall);
+    const doneFilter = (doneCall.body as { filter: Record<string, unknown> }).filter;
+    assert.deepEqual(doneFilter.lastUpdatedDateRange, {
+      from: "2026-04-23", // KST(2026-04-25 12:00 KST) - 2d = 2026-04-23
+      to: today,
+    });
+  });
+
+  it("mode=full ignores existing watermarks and skips lastUpdatedDateRange", async () => {
+    const initial: WatermarkFile = {
+      approvalDocuments: {
+        groups: {
+          "in-progress": {
+            lastUpdatedAt: "2026-04-29T12:00:00Z",
+            overlapDays: 1,
+            lastSuccessfulRunAt: "2026-04-30T00:00:00Z",
+          },
+        },
+      },
+    };
+    const search = new Map<string, SearchResp>([
+      ["IN_PROGRESS", { documents: [], total: 0, hasNext: false }],
+      ["CANCELED|DECLINED|DONE", { documents: [], total: 0, hasNext: false }],
+    ]);
+    const { calls } = setupFetch(search, new Map());
+
+    await crawlInstances(
+      makeAuth(),
+      makeConfig(),
+      null,
+      makeStorage(initial),
+      makeLogger(),
+      "full",
+    );
+
+    const searchCalls = calls.filter((c) => c.url.includes("/user-boxes/search"));
+    for (const c of searchCalls) {
+      const filter = (c.body as { filter: Record<string, unknown> }).filter;
+      assert.ok(
+        !("lastUpdatedDateRange" in filter),
+        "full mode must not send lastUpdatedDateRange",
+      );
+    }
+  });
+
+  it("does not advance a group's watermark when that group has any failure", async () => {
+    const initial: WatermarkFile = {
+      approvalDocuments: {
+        groups: {
+          "in-progress": {
+            lastUpdatedAt: "2026-04-29T00:00:00Z",
+            overlapDays: 1,
+            lastSuccessfulRunAt: "2026-04-29T00:00:00Z",
+          },
+          done: {
+            lastUpdatedAt: "2026-04-29T00:00:00Z",
+            overlapDays: 2,
+            lastSuccessfulRunAt: "2026-04-29T00:00:00Z",
+          },
+        },
+      },
+    };
+    const search = new Map<string, SearchResp>([
+      [
+        "IN_PROGRESS",
+        {
+          documents: [
+            { document: { documentKey: "ip-ok" } },
+            { document: { documentKey: "ip-fail" } },
+          ],
+          total: 2,
+          hasNext: false,
+        },
+      ],
+      [
+        "CANCELED|DECLINED|DONE",
+        { documents: [{ document: { documentKey: "done-ok" } }], total: 1, hasNext: false },
+      ],
+    ]);
+    const details = new Map<string, DetailResp>([
+      ["ip-ok", detailFor("ip-ok", "2026-05-03T01:00:00Z", "IN_PROGRESS")],
+      ["done-ok", detailFor("done-ok", "2026-05-04T05:00:00Z", "DONE")],
+    ]);
+    const { calls: _calls } = setupFetch(search, details, new Set(["ip-fail"]));
+
+    const storage = makeStorage(initial);
+    const result = await crawlInstances(makeAuth(), makeConfig(), null, storage, makeLogger());
+
+    assert.equal(result.failureCount, 1);
+    assert.equal(result.successCount, 2);
+
+    // in-progress had 1 failure → watermark must be unchanged
+    assert.equal(
+      storage._watermarks.approvalDocuments!.groups["in-progress"].lastUpdatedAt,
+      "2026-04-29T00:00:00Z",
+    );
+    // done was clean → watermark advances to the observed max
+    assert.equal(
+      storage._watermarks.approvalDocuments!.groups["done"].lastUpdatedAt,
+      "2026-05-04T05:00:00Z",
+    );
+  });
+
+  it("never regresses a watermark when observed max is older than stored", async () => {
+    const initial: WatermarkFile = {
+      approvalDocuments: {
+        groups: {
+          "in-progress": {
+            lastUpdatedAt: "2099-01-01T00:00:00Z",
+            overlapDays: 1,
+            lastSuccessfulRunAt: "2099-01-01T00:00:00Z",
+          },
+        },
+      },
+    };
+    const search = new Map<string, SearchResp>([
+      [
+        "IN_PROGRESS",
+        { documents: [{ document: { documentKey: "old-doc" } }], total: 1, hasNext: false },
+      ],
+      ["CANCELED|DECLINED|DONE", { documents: [], total: 0, hasNext: false }],
+    ]);
+    const details = new Map<string, DetailResp>([
+      ["old-doc", detailFor("old-doc", "2026-04-01T00:00:00Z", "IN_PROGRESS")],
+    ]);
+    setupFetch(search, details);
+
+    const storage = makeStorage(initial);
+    await crawlInstances(makeAuth(), makeConfig(), null, storage, makeLogger());
+
+    assert.equal(
+      storage._watermarks.approvalDocuments!.groups["in-progress"].lastUpdatedAt,
+      "2099-01-01T00:00:00Z",
+    );
+  });
+});

--- a/apps/flex-cli/src/crawlers/instance.test.ts
+++ b/apps/flex-cli/src/crawlers/instance.test.ts
@@ -239,9 +239,15 @@ describe("crawlInstances incremental wiring", () => {
     ]);
     const { calls } = setupFetch(search, new Map());
 
+    // Capture today both before and after the crawl so that an
+    // (extremely rare) KST-midnight crossing during the test doesn't
+    // make the comparison flaky — `to` must equal whichever value the
+    // crawl observed when it built todayKst.
+    const todayBefore = toKstDate(new Date());
     await crawlInstances(makeAuth(), makeConfig(), null, makeStorage(initial), makeLogger());
+    const todayAfter = toKstDate(new Date());
+    const acceptableTodays = new Set([todayBefore, todayAfter]);
 
-    const today = toKstDate(new Date());
     const inProgressCall = calls.find(
       (c) =>
         c.url.includes("/user-boxes/search") &&
@@ -249,11 +255,12 @@ describe("crawlInstances incremental wiring", () => {
         (c.body as { filter: { statuses: string[] } }).filter.statuses[0] === "IN_PROGRESS",
     );
     assert.ok(inProgressCall);
-    const ipFilter = (inProgressCall.body as { filter: Record<string, unknown> }).filter;
-    assert.deepEqual(ipFilter.lastUpdatedDateRange, {
-      from: "2026-04-28", // KST(2026-04-29 21:17 KST) - 1d = 2026-04-28
-      to: today,
-    });
+    const ipRange = (
+      (inProgressCall.body as { filter: { lastUpdatedDateRange: { from: string; to: string } } })
+        .filter.lastUpdatedDateRange
+    );
+    assert.equal(ipRange.from, "2026-04-28"); // KST(2026-04-29 21:17 KST) - 1d
+    assert.ok(acceptableTodays.has(ipRange.to), `to=${ipRange.to} must be a today-KST value`);
 
     const doneCall = calls.find(
       (c) =>
@@ -261,11 +268,12 @@ describe("crawlInstances incremental wiring", () => {
         (c.body as { filter: { statuses: string[] } }).filter.statuses.includes("DONE"),
     );
     assert.ok(doneCall);
-    const doneFilter = (doneCall.body as { filter: Record<string, unknown> }).filter;
-    assert.deepEqual(doneFilter.lastUpdatedDateRange, {
-      from: "2026-04-23", // KST(2026-04-25 12:00 KST) - 2d = 2026-04-23
-      to: today,
-    });
+    const doneRange = (
+      (doneCall.body as { filter: { lastUpdatedDateRange: { from: string; to: string } } })
+        .filter.lastUpdatedDateRange
+    );
+    assert.equal(doneRange.from, "2026-04-23"); // KST(2026-04-25 12:00 KST) - 2d
+    assert.ok(acceptableTodays.has(doneRange.to), `to=${doneRange.to} must be a today-KST value`);
   });
 
   it("mode=full ignores existing watermarks and skips lastUpdatedDateRange", async () => {
@@ -474,6 +482,26 @@ describe("crawlInstances incremental wiring", () => {
       storage._watermarks.approvalDocuments!.groups["in-progress"].lastUpdatedAt,
       "2026-05-05T01:00:00Z",
     );
+  });
+
+  it("records a structured error when saveWatermarks fails", async () => {
+    const search = new Map<string, SearchResp>([
+      ["IN_PROGRESS", { documents: [], total: 0, hasNext: false }],
+      ["CANCELED|DECLINED|DONE", { documents: [], total: 0, hasNext: false }],
+    ]);
+    setupFetch(search, new Map());
+
+    const storage = makeStorage();
+    storage.saveWatermarks = async () => {
+      throw new Error("disk full");
+    };
+
+    const result = await crawlInstances(makeAuth(), makeConfig(), null, storage, makeLogger());
+
+    const saveErr = result.errors.find((e) => e.phase === "save-watermark");
+    assert.ok(saveErr, "save-watermark failure must surface in result.errors");
+    assert.equal(saveErr.target, "instance-watermark");
+    assert.match(saveErr.message, /disk full/);
   });
 
   it("uses epoch-ms comparison so trailing-Z and millisecond forms order correctly", async () => {

--- a/apps/flex-cli/src/crawlers/instance.test.ts
+++ b/apps/flex-cli/src/crawlers/instance.test.ts
@@ -3,10 +3,11 @@ import assert from "node:assert/strict";
 import type { AuthContext } from "../auth/index.js";
 import type { Config } from "../config/index.js";
 import type { Logger } from "../logger/index.js";
-import type {
-  CrawlReport,
-  StorageWriter,
-  WatermarkFile,
+import {
+  normalizeWatermarkFile,
+  type CrawlReport,
+  type StorageWriter,
+  type WatermarkFile,
 } from "../storage/index.js";
 import { crawlInstances } from "./instance.js";
 import { toKstDate } from "./shared.js";
@@ -76,7 +77,11 @@ function makeStorage(initial: WatermarkFile = {}): FakeStorage {
     saveEndpointData: async () => {},
     saveReport: async (_r: CrawlReport) => {},
     saveCatalog: async () => {},
-    loadWatermarks: async () => structuredClone(watermarks),
+    // Mirror the production storage by routing reads through the
+    // normalizer. Tests that seed pathological initial state (invalid
+    // lastUpdatedAt, future timestamps, etc.) thus exercise the same
+    // self-heal path the real disk path does.
+    loadWatermarks: async () => normalizeWatermarkFile(structuredClone(watermarks)),
     saveWatermarks: async (file) => {
       watermarks = structuredClone(file);
     },
@@ -415,6 +420,62 @@ describe("crawlInstances incremental wiring", () => {
     );
   });
 
+  it("self-heals a future-dated watermark by treating that group as bootstrap", async () => {
+    // Hand-edit / clock-skew: stored watermark is in the future. Without
+    // self-heal, computeDateRange would emit `from > to` and the search
+    // would return nothing forever.
+    const initial = {
+      approvalDocuments: {
+        groups: {
+          "in-progress": {
+            lastUpdatedAt: "2099-01-01T00:00:00Z",
+            overlapDays: 1,
+            lastSuccessfulRunAt: "2099-01-01T00:00:00Z",
+          },
+          done: {
+            lastUpdatedAt: "2026-04-25T00:00:00Z",
+            overlapDays: 2,
+            lastSuccessfulRunAt: "2026-04-25T00:00:00Z",
+          },
+        },
+      },
+    } as WatermarkFile;
+
+    const search = new Map<string, SearchResp>([
+      [
+        "IN_PROGRESS",
+        { documents: [{ document: { documentKey: "ip-ok" } }], total: 1, hasNext: false },
+      ],
+      ["CANCELED|DECLINED|DONE", { documents: [], total: 0, hasNext: false }],
+    ]);
+    const details = new Map<string, DetailResp>([
+      ["ip-ok", detailFor("ip-ok", "2026-05-05T01:00:00Z", "IN_PROGRESS")],
+    ]);
+    const { calls } = setupFetch(search, details);
+
+    const storage = makeStorage(initial);
+    await crawlInstances(makeAuth(), makeConfig(), null, storage, makeLogger());
+
+    // in-progress had a bad watermark → group dropped at normalize → no
+    // lastUpdatedDateRange in the in-progress search.
+    const inProgressCall = calls.find(
+      (c) =>
+        c.url.includes("/user-boxes/search") &&
+        (c.body as { filter: { statuses: string[] } }).filter.statuses[0] === "IN_PROGRESS",
+    );
+    assert.ok(inProgressCall);
+    const filter = (inProgressCall.body as { filter: Record<string, unknown> }).filter;
+    assert.ok(
+      !("lastUpdatedDateRange" in filter),
+      "future watermark must self-heal by omitting the date range",
+    );
+    // Watermark replaced by the freshly observed value.
+    assert.equal(
+      storage._watermarks.approvalDocuments!.groups["in-progress"].lastUpdatedAt,
+      "2026-05-05T01:00:00Z",
+    );
+  });
+
   it("uses epoch-ms comparison so trailing-Z and millisecond forms order correctly", async () => {
     // Stored watermark "...44Z" is *earlier* in time than a candidate
     // "...44.500Z", but a naive lexicographic comparison would place the
@@ -524,13 +585,16 @@ describe("crawlInstances incremental wiring", () => {
   });
 
   it("never regresses a watermark when observed max is older than stored", async () => {
+    // The stored watermark must be a plausible (non-future) timestamp,
+    // since the normalizer now drops future watermarks. Pick a recent
+    // date and observe an even-older one.
     const initial: WatermarkFile = {
       approvalDocuments: {
         groups: {
           "in-progress": {
-            lastUpdatedAt: "2099-01-01T00:00:00Z",
+            lastUpdatedAt: "2026-05-01T00:00:00Z",
             overlapDays: 1,
-            lastSuccessfulRunAt: "2099-01-01T00:00:00Z",
+            lastSuccessfulRunAt: "2026-05-01T00:00:00Z",
           },
         },
       },
@@ -552,7 +616,7 @@ describe("crawlInstances incremental wiring", () => {
 
     assert.equal(
       storage._watermarks.approvalDocuments!.groups["in-progress"].lastUpdatedAt,
-      "2099-01-01T00:00:00Z",
+      "2026-05-01T00:00:00Z",
     );
   });
 });

--- a/apps/flex-cli/src/crawlers/instance.test.ts
+++ b/apps/flex-cli/src/crawlers/instance.test.ts
@@ -481,6 +481,27 @@ describe("crawlInstances incremental wiring", () => {
     assert.ok(stamped >= before, "lastSuccessfulRunAt must be from this run, not the prior one");
   });
 
+  it("does not stamp lastFullReconAt when a bootstrap full crawl had any failure", async () => {
+    const search = new Map<string, SearchResp>([
+      [
+        "IN_PROGRESS",
+        { documents: [{ document: { documentKey: "fail-doc" } }], total: 1, hasNext: false },
+      ],
+      ["CANCELED|DECLINED|DONE", { documents: [], total: 0, hasNext: false }],
+    ]);
+    setupFetch(search, new Map(), new Set(["fail-doc"]));
+
+    const storage = makeStorage();
+    const result = await crawlInstances(makeAuth(), makeConfig(), null, storage, makeLogger());
+
+    assert.equal(result.failureCount, 1);
+    assert.equal(
+      storage._watermarks.approvalDocuments?.lastFullReconAt,
+      undefined,
+      "lastFullReconAt must not be stamped when the recon had failures",
+    );
+  });
+
   it("never regresses a watermark when observed max is older than stored", async () => {
     const initial: WatermarkFile = {
       approvalDocuments: {

--- a/apps/flex-cli/src/crawlers/instance.test.ts
+++ b/apps/flex-cli/src/crawlers/instance.test.ts
@@ -452,6 +452,35 @@ describe("crawlInstances incremental wiring", () => {
     );
   });
 
+  it("stamps lastSuccessfulRunAt on a clean zero-doc run while preserving lastUpdatedAt", async () => {
+    const initial: WatermarkFile = {
+      approvalDocuments: {
+        groups: {
+          "in-progress": {
+            lastUpdatedAt: "2026-04-29T12:00:00Z",
+            overlapDays: 1,
+            lastSuccessfulRunAt: "2026-04-30T00:00:00Z",
+          },
+        },
+      },
+    };
+    const search = new Map<string, SearchResp>([
+      ["IN_PROGRESS", { documents: [], total: 0, hasNext: false }],
+      ["CANCELED|DECLINED|DONE", { documents: [], total: 0, hasNext: false }],
+    ]);
+    setupFetch(search, new Map());
+
+    const storage = makeStorage(initial);
+    const before = Date.now();
+    await crawlInstances(makeAuth(), makeConfig(), null, storage, makeLogger());
+
+    const wm = storage._watermarks.approvalDocuments!.groups["in-progress"];
+    assert.equal(wm.lastUpdatedAt, "2026-04-29T12:00:00Z", "lastUpdatedAt must be preserved");
+    assert.ok(wm.lastSuccessfulRunAt, "lastSuccessfulRunAt must be set");
+    const stamped = Date.parse(wm.lastSuccessfulRunAt!);
+    assert.ok(stamped >= before, "lastSuccessfulRunAt must be from this run, not the prior one");
+  });
+
   it("never regresses a watermark when observed max is older than stored", async () => {
     const initial: WatermarkFile = {
       approvalDocuments: {

--- a/apps/flex-cli/src/crawlers/instance.test.ts
+++ b/apps/flex-cli/src/crawlers/instance.test.ts
@@ -358,6 +358,100 @@ describe("crawlInstances incremental wiring", () => {
     );
   });
 
+  it("treats an invalid watermark.lastUpdatedAt as bootstrap for that group", async () => {
+    // Simulates a corrupted/hand-edited watermark file that survived
+    // normalization (e.g., string field present but unparseable). The
+    // group must omit lastUpdatedDateRange so the run self-heals into a
+    // full crawl rather than aborting on RangeError.
+    const initial = {
+      approvalDocuments: {
+        groups: {
+          "in-progress": {
+            lastUpdatedAt: "garbage",
+            overlapDays: 1,
+            lastSuccessfulRunAt: "2026-04-30T00:00:00Z",
+          },
+          done: {
+            lastUpdatedAt: "2026-04-25T00:00:00Z",
+            overlapDays: 2,
+            lastSuccessfulRunAt: "2026-04-30T00:00:00Z",
+          },
+        },
+      },
+    } as unknown as WatermarkFile;
+
+    const search = new Map<string, SearchResp>([
+      [
+        "IN_PROGRESS",
+        { documents: [{ document: { documentKey: "ip-ok" } }], total: 1, hasNext: false },
+      ],
+      ["CANCELED|DECLINED|DONE", { documents: [], total: 0, hasNext: false }],
+    ]);
+    const details = new Map<string, DetailResp>([
+      ["ip-ok", detailFor("ip-ok", "2026-05-05T01:00:00Z", "IN_PROGRESS")],
+    ]);
+    const { calls } = setupFetch(search, details);
+
+    const storage = makeStorage(initial);
+    const result = await crawlInstances(makeAuth(), makeConfig(), null, storage, makeLogger());
+
+    assert.equal(result.failureCount, 0);
+    const inProgressCall = calls.find(
+      (c) =>
+        c.url.includes("/user-boxes/search") &&
+        (c.body as { filter: { statuses: string[] } }).filter.statuses[0] === "IN_PROGRESS",
+    );
+    assert.ok(inProgressCall);
+    const filter = (inProgressCall.body as { filter: Record<string, unknown> }).filter;
+    assert.ok(
+      !("lastUpdatedDateRange" in filter),
+      "invalid watermark must self-heal by omitting the date range",
+    );
+    // After a clean run, the corrupted watermark is replaced with the
+    // observed max — the file repairs itself.
+    assert.equal(
+      storage._watermarks.approvalDocuments!.groups["in-progress"].lastUpdatedAt,
+      "2026-05-05T01:00:00Z",
+    );
+  });
+
+  it("uses epoch-ms comparison so trailing-Z and millisecond forms order correctly", async () => {
+    // Stored watermark "...44Z" is *earlier* in time than a candidate
+    // "...44.500Z", but a naive lexicographic comparison would place the
+    // candidate first and refuse to advance. epoch-ms comparison fixes it.
+    const initial: WatermarkFile = {
+      approvalDocuments: {
+        groups: {
+          "in-progress": {
+            lastUpdatedAt: "2026-04-29T12:17:44Z",
+            overlapDays: 1,
+            lastSuccessfulRunAt: "2026-04-29T12:17:44Z",
+          },
+        },
+      },
+    };
+    const search = new Map<string, SearchResp>([
+      [
+        "IN_PROGRESS",
+        { documents: [{ document: { documentKey: "ms-doc" } }], total: 1, hasNext: false },
+      ],
+      ["CANCELED|DECLINED|DONE", { documents: [], total: 0, hasNext: false }],
+    ]);
+    const details = new Map<string, DetailResp>([
+      ["ms-doc", detailFor("ms-doc", "2026-04-29T12:17:44.500Z", "IN_PROGRESS")],
+    ]);
+    setupFetch(search, details);
+
+    const storage = makeStorage(initial);
+    await crawlInstances(makeAuth(), makeConfig(), null, storage, makeLogger());
+
+    assert.equal(
+      storage._watermarks.approvalDocuments!.groups["in-progress"].lastUpdatedAt,
+      "2026-04-29T12:17:44.500Z",
+      "candidate is later in time and must replace the watermark",
+    );
+  });
+
   it("never regresses a watermark when observed max is older than stored", async () => {
     const initial: WatermarkFile = {
       approvalDocuments: {

--- a/apps/flex-cli/src/crawlers/instance.test.ts
+++ b/apps/flex-cli/src/crawlers/instance.test.ts
@@ -481,6 +481,27 @@ describe("crawlInstances incremental wiring", () => {
     assert.ok(stamped >= before, "lastSuccessfulRunAt must be from this run, not the prior one");
   });
 
+  it("stamps lastFullReconAt on a clean zero-doc bootstrap full crawl", async () => {
+    // Customer has no approval documents (or no access). The crawl
+    // should still record a recon marker — otherwise cadence-based
+    // auto-promotion can never advance away from this state.
+    const search = new Map<string, SearchResp>([
+      ["IN_PROGRESS", { documents: [], total: 0, hasNext: false }],
+      ["CANCELED|DECLINED|DONE", { documents: [], total: 0, hasNext: false }],
+    ]);
+    setupFetch(search, new Map());
+
+    const storage = makeStorage();
+    const before = Date.now();
+    const result = await crawlInstances(makeAuth(), makeConfig(), null, storage, makeLogger());
+
+    assert.equal(result.successCount, 0);
+    assert.equal(result.failureCount, 0);
+    const stamped = storage._watermarks.approvalDocuments?.lastFullReconAt;
+    assert.ok(stamped, "clean zero-doc full crawl must stamp lastFullReconAt");
+    assert.ok(Date.parse(stamped!) >= before);
+  });
+
   it("does not stamp lastFullReconAt when a bootstrap full crawl had any failure", async () => {
     const search = new Map<string, SearchResp>([
       [

--- a/apps/flex-cli/src/crawlers/instance.ts
+++ b/apps/flex-cli/src/crawlers/instance.ts
@@ -145,8 +145,9 @@ export async function crawlInstances(
   // 사실상 풀크롤로 돌았고 인스턴스 단계에 단 1건의 실패도 없었을 때만
   // lastFullReconAt 갱신. 실패가 섞이면 "전체 recon 완료" 의미가 흐려지므로,
   // 후속 cadence-기반 자동 풀크롤 트리거가 사고로 다음 실행을 건너뛰지 않도록
-  // 보수적으로 잠근다.
-  if (effectiveFull && result.failureCount === 0 && result.successCount > 0) {
+  // 보수적으로 잠근다. 정당한 0건(워크스페이스에 문서 없음, 권한 없음 등)도
+  // 클린한 recon이므로 stamp 대상이다 — successCount는 게이트하지 않는다.
+  if (effectiveFull && result.failureCount === 0) {
     domainState.lastFullReconAt = nowISO();
   }
 

--- a/apps/flex-cli/src/crawlers/instance.ts
+++ b/apps/flex-cli/src/crawlers/instance.ts
@@ -155,8 +155,15 @@ export async function crawlInstances(
   try {
     await storage.saveWatermarks(watermarks);
   } catch (saveError) {
-    logger.error("워터마크 저장 실패 — 다음 실행에서 동일 범위 재수집 가능", {
-      error: saveError instanceof Error ? saveError.message : String(saveError),
+    const message = saveError instanceof Error ? saveError.message : String(saveError);
+    logger.error("워터마크 저장 실패 — 다음 실행에서 동일 범위 재수집 가능", { error: message });
+    // 보고서/exit code만 보는 환경에서도 운영자가 알아챌 수 있도록 구조화된
+    // 에러로 남긴다 (크롤은 비치명적으로 계속 진행).
+    result.errors.push({
+      target: "instance-watermark",
+      phase: "save-watermark",
+      message,
+      timestamp: nowISO(),
     });
   }
 

--- a/apps/flex-cli/src/crawlers/instance.ts
+++ b/apps/flex-cli/src/crawlers/instance.ts
@@ -142,8 +142,11 @@ export async function crawlInstances(
     });
   }
 
-  // 사실상 풀크롤로 돌았고 한 건이라도 처리했다면 lastFullReconAt 갱신.
-  if (effectiveFull && result.successCount > 0) {
+  // 사실상 풀크롤로 돌았고 인스턴스 단계에 단 1건의 실패도 없었을 때만
+  // lastFullReconAt 갱신. 실패가 섞이면 "전체 recon 완료" 의미가 흐려지므로,
+  // 후속 cadence-기반 자동 풀크롤 트리거가 사고로 다음 실행을 건너뛰지 않도록
+  // 보수적으로 잠근다.
+  if (effectiveFull && result.failureCount === 0 && result.successCount > 0) {
     domainState.lastFullReconAt = nowISO();
   }
 

--- a/apps/flex-cli/src/crawlers/instance.ts
+++ b/apps/flex-cli/src/crawlers/instance.ts
@@ -102,22 +102,24 @@ export async function crawlInstances(
 
       // 그룹 단위로 워터마크 갱신 정책:
       //   - 그룹 내 실패가 단 1건이라도 있으면 갱신 보류 (다음 실행에서 재시도)
-      //   - 후퇴 금지 — 새 max가 기존보다 작으면 기존 유지
-      //   - 0건 처리됐어도 후퇴/삭제 금지
-      if (groupFailure === 0 && observedMaxUpdatedAt) {
+      //   - 후퇴 금지 — 새 max가 기존보다 작으면 기존 lastUpdatedAt 유지
+      //   - 0건 처리됐어도 그룹 자체가 클린하게 끝났으면 lastSuccessfulRunAt은 갱신
+      if (groupFailure === 0) {
         const prev = existing?.lastUpdatedAt ?? null;
-        if (isLaterIso(observedMaxUpdatedAt, prev)) {
+        if (observedMaxUpdatedAt && isLaterIso(observedMaxUpdatedAt, prev)) {
           domainState.groups[group.label] = {
             lastUpdatedAt: observedMaxUpdatedAt,
             overlapDays: existing?.overlapDays ?? group.defaultOverlapDays,
             lastSuccessfulRunAt: nowISO(),
           };
         } else if (existing) {
+          // 0건이거나 후퇴 케이스 — lastUpdatedAt은 보존, 성공 마감 시각만 갱신
           domainState.groups[group.label] = {
             ...existing,
             lastSuccessfulRunAt: nowISO(),
           };
         }
+        // existing도 없고 observed도 없으면 commit할 게 없음 (no-op)
       }
 
       logger.info("인스턴스 그룹 종료", {

--- a/apps/flex-cli/src/crawlers/instance.ts
+++ b/apps/flex-cli/src/crawlers/instance.ts
@@ -13,6 +13,7 @@ import {
   type CrawlResult,
   emptyCrawlResult,
   nowISO,
+  isLaterIso,
   toKstDate,
   withRetry,
   flexFetch,
@@ -105,7 +106,7 @@ export async function crawlInstances(
       //   - 0건 처리됐어도 후퇴/삭제 금지
       if (groupFailure === 0 && observedMaxUpdatedAt) {
         const prev = existing?.lastUpdatedAt ?? null;
-        if (!prev || observedMaxUpdatedAt > prev) {
+        if (isLaterIso(observedMaxUpdatedAt, prev)) {
           domainState.groups[group.label] = {
             lastUpdatedAt: observedMaxUpdatedAt,
             overlapDays: existing?.overlapDays ?? group.defaultOverlapDays,
@@ -170,8 +171,12 @@ function computeDateRange(
   todayKst: string,
 ): DateRange | undefined {
   if (!watermark?.lastUpdatedAt) return undefined;
+  const watermarkMs = Date.parse(watermark.lastUpdatedAt);
+  // 워터마크 파일 손상/수동 편집으로 invalid timestamp가 들어오면 그 그룹은
+  // 이번 실행을 풀크롤처럼 처리(undefined 반환)해서 자가복구되도록 한다.
+  if (!Number.isFinite(watermarkMs)) return undefined;
   const overlapDays = watermark.overlapDays ?? defaultOverlapDays;
-  const fromMs = new Date(watermark.lastUpdatedAt).getTime() - overlapDays * MS_PER_DAY;
+  const fromMs = watermarkMs - overlapDays * MS_PER_DAY;
   return { from: toKstDate(new Date(fromMs)), to: todayKst };
 }
 
@@ -276,7 +281,7 @@ async function crawlSearchGroup(
         const instance = mapInstance(detail, attachments);
         await storage.saveInstance(instance);
         const observed = detail.document.updatedAt ?? null;
-        if (observed && (!groupMaxUpdatedAt || observed > groupMaxUpdatedAt)) {
+        if (isLaterIso(observed, groupMaxUpdatedAt)) {
           groupMaxUpdatedAt = observed;
         }
         collectedKeys.add(docKey);

--- a/apps/flex-cli/src/crawlers/instance.ts
+++ b/apps/flex-cli/src/crawlers/instance.ts
@@ -1,7 +1,11 @@
 import { type AuthContext, apiHeaders } from "../auth/index.js";
 import type { Config } from "../config/index.js";
 import type { Logger } from "../logger/index.js";
-import type { StorageWriter } from "../storage/index.js";
+import type {
+  StorageWriter,
+  WatermarkDomainState,
+  WatermarkGroupState,
+} from "../storage/index.js";
 import type { ApiCatalog } from "../types/catalog.js";
 import type { WorkflowInstance } from "../types/instance.js";
 import type { ApprovalStep, AttachmentInfo, FieldValue } from "../types/common.js";
@@ -9,6 +13,7 @@ import {
   type CrawlResult,
   emptyCrawlResult,
   nowISO,
+  toKstDate,
   withRetry,
   flexFetch,
   flexPost,
@@ -16,18 +21,29 @@ import {
   pooledMap,
 } from "./shared.js";
 
+export type CrawlMode = "incremental" | "full";
+
+const APPROVAL_DOCUMENTS_DOMAIN = "approvalDocuments";
+const MS_PER_DAY = 86_400_000;
+
+interface DateRange {
+  from: string;
+  to: string;
+}
+
 export async function crawlInstances(
   authCtx: AuthContext,
   config: Config,
   catalog: ApiCatalog | null,
   storage: StorageWriter,
   logger: Logger,
+  mode: CrawlMode = "incremental",
 ): Promise<CrawlResult & { collectedKeys: Set<string> }> {
   const startTime = Date.now();
   const result = emptyCrawlResult();
   const collectedKeys = new Set<string>();
 
-  logger.info("인스턴스(결재 문서) 수집 시작");
+  logger.info("인스턴스(결재 문서) 수집 시작", { mode });
 
   const searchUrl = resolveUrl(
     config.flexBaseUrl, catalog, "instance-search",
@@ -38,14 +54,36 @@ export async function crawlInstances(
     "/api/v3/approval-document/approval-documents",
   );
 
-  try {
-    const searchGroups: SearchGroup[] = [
-      { label: "in-progress", statuses: ["IN_PROGRESS"] },
-      { label: "done", statuses: ["DONE", "DECLINED", "CANCELED"] },
-    ];
+  const searchGroups: SearchGroup[] = [
+    { label: "in-progress", statuses: ["IN_PROGRESS"], defaultOverlapDays: 1 },
+    { label: "done", statuses: ["DONE", "DECLINED", "CANCELED"], defaultOverlapDays: 2 },
+  ];
 
+  const watermarks = await storage.loadWatermarks();
+  const domainState: WatermarkDomainState =
+    watermarks[APPROVAL_DOCUMENTS_DOMAIN] ?? { groups: {} };
+  // 모든 그룹에 워터마크가 모두 비어 있다면 부트스트랩 — 사실상 풀크롤로 동작.
+  const noWatermarks = searchGroups.every(
+    (g) => !domainState.groups[g.label]?.lastUpdatedAt,
+  );
+  const effectiveFull = mode === "full" || noWatermarks;
+  if (mode === "incremental" && noWatermarks) {
+    logger.info("워터마크 없음 — bootstrap 풀크롤로 진행");
+  }
+  // to 날짜는 그룹 진입 전에 한 번 캡처해서 페이지/그룹 간 일관되게 사용.
+  const todayKst = toKstDate(new Date());
+
+  try {
     for (const group of searchGroups) {
-      await crawlSearchGroup(
+      const existing = domainState.groups[group.label];
+      const dateRange = effectiveFull
+        ? undefined
+        : computeDateRange(existing, group.defaultOverlapDays, todayKst);
+
+      const groupSuccessBefore = result.successCount;
+      const groupFailureBefore = result.failureCount;
+
+      const observedMaxUpdatedAt = await crawlSearchGroup(
         authCtx,
         config,
         storage,
@@ -55,7 +93,39 @@ export async function crawlInstances(
         searchUrl,
         detailBase,
         group,
+        dateRange,
       );
+
+      const groupSuccess = result.successCount - groupSuccessBefore;
+      const groupFailure = result.failureCount - groupFailureBefore;
+
+      // 그룹 단위로 워터마크 갱신 정책:
+      //   - 그룹 내 실패가 단 1건이라도 있으면 갱신 보류 (다음 실행에서 재시도)
+      //   - 후퇴 금지 — 새 max가 기존보다 작으면 기존 유지
+      //   - 0건 처리됐어도 후퇴/삭제 금지
+      if (groupFailure === 0 && observedMaxUpdatedAt) {
+        const prev = existing?.lastUpdatedAt ?? null;
+        if (!prev || observedMaxUpdatedAt > prev) {
+          domainState.groups[group.label] = {
+            lastUpdatedAt: observedMaxUpdatedAt,
+            overlapDays: existing?.overlapDays ?? group.defaultOverlapDays,
+            lastSuccessfulRunAt: nowISO(),
+          };
+        } else if (existing) {
+          domainState.groups[group.label] = {
+            ...existing,
+            lastSuccessfulRunAt: nowISO(),
+          };
+        }
+      }
+
+      logger.info("인스턴스 그룹 종료", {
+        group: group.label,
+        groupSuccess,
+        groupFailure,
+        observedMaxUpdatedAt,
+        committedWatermark: domainState.groups[group.label]?.lastUpdatedAt ?? null,
+      });
     }
   } catch (error) {
     logger.error("인스턴스 목록 수집 중 치명적 오류", {
@@ -69,6 +139,20 @@ export async function crawlInstances(
     });
   }
 
+  // 사실상 풀크롤로 돌았고 한 건이라도 처리했다면 lastFullReconAt 갱신.
+  if (effectiveFull && result.successCount > 0) {
+    domainState.lastFullReconAt = nowISO();
+  }
+
+  watermarks[APPROVAL_DOCUMENTS_DOMAIN] = domainState;
+  try {
+    await storage.saveWatermarks(watermarks);
+  } catch (saveError) {
+    logger.error("워터마크 저장 실패 — 다음 실행에서 동일 범위 재수집 가능", {
+      error: saveError instanceof Error ? saveError.message : String(saveError),
+    });
+  }
+
   result.durationMs = Date.now() - startTime;
   logger.info(`\n인스턴스 수집 완료: 성공 ${result.successCount}, 실패 ${result.failureCount}`);
   return { ...result, collectedKeys };
@@ -77,6 +161,18 @@ export async function crawlInstances(
 interface SearchGroup {
   label: string;
   statuses: string[];
+  defaultOverlapDays: number;
+}
+
+function computeDateRange(
+  watermark: WatermarkGroupState | undefined,
+  defaultOverlapDays: number,
+  todayKst: string,
+): DateRange | undefined {
+  if (!watermark?.lastUpdatedAt) return undefined;
+  const overlapDays = watermark.overlapDays ?? defaultOverlapDays;
+  const fromMs = new Date(watermark.lastUpdatedAt).getTime() - overlapDays * MS_PER_DAY;
+  return { from: toKstDate(new Date(fromMs)), to: todayKst };
 }
 
 async function crawlSearchGroup(
@@ -89,15 +185,20 @@ async function crawlSearchGroup(
   searchUrl: string,
   detailBase: string,
   group: SearchGroup,
-): Promise<void> {
+  dateRange: DateRange | undefined,
+): Promise<string | null> {
   logger.info("인스턴스 검색 그룹 시작", {
     group: group.label,
     statuses: group.statuses,
+    lastUpdatedDateRange: dateRange ?? null,
   });
 
   let continuationToken: string | undefined;
   let hasMore = true;
   let isFirstPage = true;
+  // 이번 그룹에서 성공적으로 상세까지 가져온 문서들의 document.updatedAt
+  // 최댓값. 워커가 동시에 갱신하므로 단순 비교/대입(JS 단일 스레드 보장).
+  let groupMaxUpdatedAt: string | null = null;
 
   while (hasMore) {
     const searchBody = {
@@ -108,6 +209,7 @@ async function crawlSearchGroup(
         approverTargets: [],
         referrerTargets: [],
         starred: false,
+        ...(dateRange ? { lastUpdatedDateRange: dateRange } : {}),
       },
       search: { keyword: "", type: "ALL" },
     };
@@ -173,6 +275,10 @@ async function crawlSearchGroup(
 
         const instance = mapInstance(detail, attachments);
         await storage.saveInstance(instance);
+        const observed = detail.document.updatedAt ?? null;
+        if (observed && (!groupMaxUpdatedAt || observed > groupMaxUpdatedAt)) {
+          groupMaxUpdatedAt = observed;
+        }
         collectedKeys.add(docKey);
         result.successCount++;
       } catch (error) {
@@ -225,6 +331,8 @@ async function crawlSearchGroup(
 
     continuationToken = nextContinuationToken;
   }
+
+  return groupMaxUpdatedAt;
 }
 
 // --- flex API 응답 타입 ---

--- a/apps/flex-cli/src/crawlers/shared.test.ts
+++ b/apps/flex-cli/src/crawlers/shared.test.ts
@@ -1,0 +1,22 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { toKstDate } from "./shared.js";
+
+describe("toKstDate", () => {
+  it("returns YYYY-MM-DD in Asia/Seoul", () => {
+    assert.equal(toKstDate("2026-04-29T12:17:44Z"), "2026-04-29");
+  });
+
+  it("crosses the date boundary on UTC midnight (KST = UTC+9)", () => {
+    // UTC 16:00 of day N → KST 01:00 of day N+1
+    assert.equal(toKstDate("2026-04-29T16:00:00Z"), "2026-04-30");
+    // UTC 14:59 of day N → still KST 23:59 of day N
+    assert.equal(toKstDate("2026-04-29T14:59:00Z"), "2026-04-29");
+  });
+
+  it("accepts Date and number inputs", () => {
+    const ms = Date.parse("2026-04-29T12:17:44Z");
+    assert.equal(toKstDate(new Date(ms)), "2026-04-29");
+    assert.equal(toKstDate(ms), "2026-04-29");
+  });
+});

--- a/apps/flex-cli/src/crawlers/shared.test.ts
+++ b/apps/flex-cli/src/crawlers/shared.test.ts
@@ -1,6 +1,32 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { toKstDate } from "./shared.js";
+import { isLaterIso, toKstDate } from "./shared.js";
+
+describe("isLaterIso", () => {
+  it("compares by epoch ms, not lexicographically", () => {
+    // ms-bearing string is lexicographically smaller than the trailing-Z
+    // form even though it's later in time. Compare:
+    //   "2026-04-29T12:17:44.500Z"  <  "2026-04-29T12:17:44Z"  (lex)
+    //   500ms later                  >  baseline               (time)
+    assert.equal(isLaterIso("2026-04-29T12:17:44.500Z", "2026-04-29T12:17:44Z"), true);
+    assert.equal(isLaterIso("2026-04-29T12:17:44Z", "2026-04-29T12:17:44.500Z"), false);
+  });
+
+  it("treats null/undefined baseline as -infinity", () => {
+    assert.equal(isLaterIso("2026-01-01T00:00:00Z", null), true);
+    assert.equal(isLaterIso("2026-01-01T00:00:00Z", undefined), true);
+  });
+
+  it("never promotes an invalid candidate over any baseline", () => {
+    assert.equal(isLaterIso("not-a-date", null), false);
+    assert.equal(isLaterIso("", "2026-01-01T00:00:00Z"), false);
+    assert.equal(isLaterIso(null, null), false);
+  });
+
+  it("treats invalid baseline as -infinity (any valid candidate wins)", () => {
+    assert.equal(isLaterIso("2026-01-01T00:00:00Z", "garbage"), true);
+  });
+});
 
 describe("toKstDate", () => {
   it("returns YYYY-MM-DD in Asia/Seoul", () => {

--- a/apps/flex-cli/src/crawlers/shared.ts
+++ b/apps/flex-cli/src/crawlers/shared.ts
@@ -134,6 +134,28 @@ export function nowISO(): string {
 }
 
 /**
+ * candidate가 baseline보다 시간상 더 늦은지 epoch ms로 비교한다. ISO 8601
+ * 사전식 비교는 `...00Z` vs `...00.500Z` 같이 밀리초 포함/미포함이 섞이면
+ * 시간 순서를 보장하지 않으므로 max 선택용으로 쓰면 안 된다.
+ *
+ * 잘못된 포맷:
+ *   - candidate가 invalid 또는 빈 문자열 → false (절대 baseline을 대체하지 않음)
+ *   - baseline이 invalid 또는 null → candidate가 valid이기만 하면 true
+ */
+export function isLaterIso(
+  candidate: string | null | undefined,
+  baseline: string | null | undefined,
+): boolean {
+  if (!candidate) return false;
+  const a = Date.parse(candidate);
+  if (!Number.isFinite(a)) return false;
+  if (!baseline) return true;
+  const b = Date.parse(baseline);
+  if (!Number.isFinite(b)) return true;
+  return a > b;
+}
+
+/**
  * KST(Asia/Seoul) 기준 YYYY-MM-DD 문자열로 변환한다.
  *
  * flex.team의 `lastUpdatedDateRange` 필터는 timestamp가 아니라 date 단위로

--- a/apps/flex-cli/src/crawlers/shared.ts
+++ b/apps/flex-cli/src/crawlers/shared.ts
@@ -133,6 +133,19 @@ export function nowISO(): string {
   return new Date().toISOString();
 }
 
+/**
+ * KST(Asia/Seoul) 기준 YYYY-MM-DD 문자열로 변환한다.
+ *
+ * flex.team의 `lastUpdatedDateRange` 필터는 timestamp가 아니라 date 단위로
+ * 동작하며 워크스페이스 timezone 기준으로 해석되는 것으로 보인다(2026-05-04
+ * 캡처). 한국 워크스페이스 운영을 가정해 KST로 정규화한다. `sv-SE` 로케일은
+ * `YYYY-MM-DD` 형식을 그대로 반환하므로 패딩 처리가 불필요하다.
+ */
+export function toKstDate(d: Date | string | number): string {
+  const date = typeof d === "object" ? d : new Date(d);
+  return new Intl.DateTimeFormat("sv-SE", { timeZone: "Asia/Seoul" }).format(date);
+}
+
 /** CrawlResult 초기값 생성 */
 export function emptyCrawlResult(): CrawlResult {
   return {

--- a/apps/flex-cli/src/storage/index.test.ts
+++ b/apps/flex-cli/src/storage/index.test.ts
@@ -129,6 +129,27 @@ describe("normalizeWatermarkFile", () => {
     assert.ok(groups.ok);
   });
 
+  it("drops a group whose lastUpdatedAt is in the future relative to `now`", () => {
+    // hand-edited or clock-skewed payload: stored timestamp is later
+    // than the supplied `now`. computeDateRange would otherwise emit
+    // from > to and wedge incremental crawls.
+    const now = Date.parse("2026-05-06T00:00:00Z");
+    const result = normalizeWatermarkFile(
+      {
+        approvalDocuments: {
+          groups: {
+            future: { lastUpdatedAt: "2099-01-01T00:00:00Z" },
+            past: { lastUpdatedAt: "2026-04-29T12:00:00Z" },
+          },
+        },
+      },
+      now,
+    );
+    const groups = result.approvalDocuments!.groups;
+    assert.equal(groups.future, undefined);
+    assert.ok(groups.past);
+  });
+
   it("preserves a well-formed file unchanged in shape", () => {
     const raw: WatermarkFile = {
       approvalDocuments: {

--- a/apps/flex-cli/src/storage/index.test.ts
+++ b/apps/flex-cli/src/storage/index.test.ts
@@ -49,6 +49,40 @@ describe("normalizeWatermarkFile", () => {
     assert.equal(wm.lastFullReconAt, "2026-04-20T00:00:00Z");
   });
 
+  it("keeps a group when only lastUpdatedAt is present (informational fields are optional)", () => {
+    const result = normalizeWatermarkFile({
+      approvalDocuments: {
+        groups: {
+          "in-progress": { lastUpdatedAt: "2026-04-29T12:00:00Z" },
+        },
+      },
+    });
+    const g = result.approvalDocuments!.groups["in-progress"];
+    assert.equal(g.lastUpdatedAt, "2026-04-29T12:00:00Z");
+    assert.equal(g.overlapDays, undefined);
+    assert.equal(g.lastSuccessfulRunAt, undefined);
+  });
+
+  it("omits out-of-range overlapDays but keeps the group", () => {
+    const result = normalizeWatermarkFile({
+      approvalDocuments: {
+        groups: {
+          neg: { lastUpdatedAt: "2026-04-29T12:00:00Z", overlapDays: -1 },
+          tooBig: { lastUpdatedAt: "2026-04-29T12:00:00Z", overlapDays: 100000 },
+          fractional: { lastUpdatedAt: "2026-04-29T12:00:00Z", overlapDays: 1.5 },
+          nan: { lastUpdatedAt: "2026-04-29T12:00:00Z", overlapDays: Number.NaN },
+          ok: { lastUpdatedAt: "2026-04-29T12:00:00Z", overlapDays: 2 },
+        },
+      },
+    });
+    const groups = result.approvalDocuments!.groups;
+    for (const label of ["neg", "tooBig", "fractional", "nan"]) {
+      assert.ok(groups[label], `group ${label} must survive`);
+      assert.equal(groups[label].overlapDays, undefined);
+    }
+    assert.equal(groups.ok.overlapDays, 2);
+  });
+
   it("preserves a well-formed file unchanged in shape", () => {
     const raw: WatermarkFile = {
       approvalDocuments: {

--- a/apps/flex-cli/src/storage/index.test.ts
+++ b/apps/flex-cli/src/storage/index.test.ts
@@ -1,6 +1,17 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { normalizeWatermarkFile, type WatermarkFile } from "./index.js";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { tmpdir } from "node:os";
+import {
+  createStorageWriter,
+  normalizeWatermarkFile,
+  type WatermarkFile,
+} from "./index.js";
+
+async function tmpStorageDir(): Promise<string> {
+  return await mkdtemp(path.join(tmpdir(), "flex-ax-storage-"));
+}
 
 describe("normalizeWatermarkFile", () => {
   it("returns {} for non-object roots (array, null, primitive)", () => {
@@ -83,6 +94,22 @@ describe("normalizeWatermarkFile", () => {
     assert.equal(groups.ok.overlapDays, 2);
   });
 
+  it("drops a group whose lastUpdatedAt is empty or whitespace-only", () => {
+    const result = normalizeWatermarkFile({
+      approvalDocuments: {
+        groups: {
+          empty: { lastUpdatedAt: "" },
+          ws: { lastUpdatedAt: "   \t  " },
+          ok: { lastUpdatedAt: "2026-04-29T12:00:00Z" },
+        },
+      },
+    });
+    const groups = result.approvalDocuments!.groups;
+    assert.equal(groups.empty, undefined);
+    assert.equal(groups.ws, undefined);
+    assert.ok(groups.ok);
+  });
+
   it("preserves a well-formed file unchanged in shape", () => {
     const raw: WatermarkFile = {
       approvalDocuments: {
@@ -98,5 +125,33 @@ describe("normalizeWatermarkFile", () => {
     };
     const result = normalizeWatermarkFile(raw);
     assert.deepEqual(result, raw);
+  });
+});
+
+describe("createStorageWriter loadWatermarks", () => {
+  it("returns {} when watermark.json is missing (ENOENT)", async () => {
+    const dir = await tmpStorageDir();
+    const writer = createStorageWriter(dir, path.join(dir, "catalog.json"));
+    assert.deepEqual(await writer.loadWatermarks(), {});
+  });
+
+  it("returns {} when watermark.json contains unparseable JSON", async () => {
+    const dir = await tmpStorageDir();
+    await writeFile(path.join(dir, "watermark.json"), "{ this is not json", "utf-8");
+    const writer = createStorageWriter(dir, path.join(dir, "catalog.json"));
+    assert.deepEqual(await writer.loadWatermarks(), {});
+  });
+
+  it("surfaces unexpected I/O errors instead of falling back to bootstrap", async () => {
+    // Triggering a non-ENOENT read error reliably across platforms: make
+    // watermark.json a directory. readFile then fails with EISDIR.
+    const dir = await tmpStorageDir();
+    await mkdir(path.join(dir, "watermark.json"));
+    const writer = createStorageWriter(dir, path.join(dir, "catalog.json"));
+    await assert.rejects(
+      () => writer.loadWatermarks(),
+      (err: NodeJS.ErrnoException) =>
+        err.code === "EISDIR" || err.code === "EACCES" || err.code === "EPERM",
+    );
   });
 });

--- a/apps/flex-cli/src/storage/index.test.ts
+++ b/apps/flex-cli/src/storage/index.test.ts
@@ -1,0 +1,68 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { normalizeWatermarkFile, type WatermarkFile } from "./index.js";
+
+describe("normalizeWatermarkFile", () => {
+  it("returns {} for non-object roots (array, null, primitive)", () => {
+    assert.deepEqual(normalizeWatermarkFile([]), {});
+    assert.deepEqual(normalizeWatermarkFile(null), {});
+    assert.deepEqual(normalizeWatermarkFile("garbage"), {});
+    assert.deepEqual(normalizeWatermarkFile(42), {});
+  });
+
+  it("drops domains whose state is not a plain object", () => {
+    const result = normalizeWatermarkFile({
+      approvalDocuments: [1, 2, 3],
+      timeOff: null,
+    });
+    assert.deepEqual(result, {});
+  });
+
+  it("substitutes empty groups when groups is missing or non-object", () => {
+    const result = normalizeWatermarkFile({
+      approvalDocuments: { groups: "not-an-object" },
+      other: { groups: [1, 2] },
+    });
+    assert.deepEqual(result.approvalDocuments, { groups: {}, lastFullReconAt: undefined });
+    assert.deepEqual(result.other, { groups: {}, lastFullReconAt: undefined });
+  });
+
+  it("drops malformed group entries while keeping well-formed siblings", () => {
+    const raw = {
+      approvalDocuments: {
+        groups: {
+          "in-progress": {
+            lastUpdatedAt: "2026-04-29T12:00:00Z",
+            overlapDays: 1,
+            lastSuccessfulRunAt: "2026-04-30T00:00:00Z",
+          },
+          done: { lastUpdatedAt: 123 }, // wrong type → drop
+          junk: null,
+        },
+        lastFullReconAt: "2026-04-20T00:00:00Z",
+      },
+    };
+    const result = normalizeWatermarkFile(raw);
+    const wm = result.approvalDocuments!;
+    assert.equal(Object.keys(wm.groups).length, 1);
+    assert.ok(wm.groups["in-progress"]);
+    assert.equal(wm.lastFullReconAt, "2026-04-20T00:00:00Z");
+  });
+
+  it("preserves a well-formed file unchanged in shape", () => {
+    const raw: WatermarkFile = {
+      approvalDocuments: {
+        groups: {
+          "in-progress": {
+            lastUpdatedAt: "2026-04-29T12:00:00Z",
+            overlapDays: 1,
+            lastSuccessfulRunAt: "2026-04-30T00:00:00Z",
+          },
+        },
+        lastFullReconAt: "2026-04-20T00:00:00Z",
+      },
+    };
+    const result = normalizeWatermarkFile(raw);
+    assert.deepEqual(result, raw);
+  });
+});

--- a/apps/flex-cli/src/storage/index.test.ts
+++ b/apps/flex-cli/src/storage/index.test.ts
@@ -110,6 +110,25 @@ describe("normalizeWatermarkFile", () => {
     assert.ok(groups.ok);
   });
 
+  it("ignores __proto__ / constructor / prototype keys without polluting Object.prototype", () => {
+    // JSON.parse turns "__proto__" into an own property, so an
+    // attacker-controlled watermark.json could otherwise mutate the
+    // base object prototype as soon as we index into it.
+    const malicious = JSON.parse(
+      '{"__proto__":{"polluted":true},"approvalDocuments":{"groups":{"__proto__":{"lastUpdatedAt":"2026-04-29T12:00:00Z","polluted":true},"constructor":{"lastUpdatedAt":"2026-04-29T12:00:00Z"},"prototype":{"lastUpdatedAt":"2026-04-29T12:00:00Z"},"ok":{"lastUpdatedAt":"2026-04-29T12:00:00Z"}}}}',
+    );
+    const result = normalizeWatermarkFile(malicious);
+
+    // Object.prototype must still be clean.
+    assert.equal(({} as Record<string, unknown>).polluted, undefined);
+
+    // Dangerous keys are dropped at both the domain and the group level;
+    // safe siblings survive.
+    const groups = result.approvalDocuments!.groups;
+    assert.equal(Object.keys(groups).length, 1);
+    assert.ok(groups.ok);
+  });
+
   it("preserves a well-formed file unchanged in shape", () => {
     const raw: WatermarkFile = {
       approvalDocuments: {

--- a/apps/flex-cli/src/storage/index.test.ts
+++ b/apps/flex-cli/src/storage/index.test.ts
@@ -150,6 +150,24 @@ describe("normalizeWatermarkFile", () => {
     assert.ok(groups.past);
   });
 
+  it("does not drop a watermark when the local clock skews a few minutes (same KST date)", () => {
+    // Watermark timestamp is "after" `now` in epoch ms but falls on the
+    // same KST calendar day. Treating that as a future-drop would make
+    // every NTP-skewed run fall back to bootstrap.
+    const now = Date.parse("2026-05-06T12:00:00Z");
+    const result = normalizeWatermarkFile(
+      {
+        approvalDocuments: {
+          groups: {
+            skewed: { lastUpdatedAt: "2026-05-06T12:02:00Z" },
+          },
+        },
+      },
+      now,
+    );
+    assert.ok(result.approvalDocuments!.groups.skewed);
+  });
+
   it("preserves a well-formed file unchanged in shape", () => {
     const raw: WatermarkFile = {
       approvalDocuments: {

--- a/apps/flex-cli/src/storage/index.ts
+++ b/apps/flex-cli/src/storage/index.ts
@@ -84,8 +84,15 @@ function isSafeKey(key: string): boolean {
  * 손상되거나 사람이 손댄 watermark.json을 안전한 shape으로 정규화한다.
  * 의도적으로 관대하다(스키마 위반은 조용히 누락) — 워터마크는 손실되어도
  * 부트스트랩 풀크롤로 자가복구되므로 크롤 전체를 중단시키는 것보다 낫다.
+ *
+ * `now`는 미래 시각 워터마크 감지용으로만 쓰이며 호출자가 명시적으로 주입할
+ * 수 있다 (테스트 결정론). 미래 워터마크는 손편집/클록스큐 신호로 보고
+ * 그 그룹을 drop해, 다음 실행이 풀크롤로 자가복구되게 한다.
  */
-export function normalizeWatermarkFile(parsed: unknown): WatermarkFile {
+export function normalizeWatermarkFile(
+  parsed: unknown,
+  now: number = Date.now(),
+): WatermarkFile {
   if (!isPlainObject(parsed)) return {};
   const out: WatermarkFile = {};
   for (const [domain, rawState] of Object.entries(parsed)) {
@@ -104,6 +111,13 @@ export function normalizeWatermarkFile(parsed: unknown): WatermarkFile {
         if (typeof lastUpdatedAt !== "string" || lastUpdatedAt.trim().length === 0) {
           continue;
         }
+        // 미래 timestamp는 손상 신호. 그대로 두면 computeDateRange가 from>to인
+        // 잘못된 범위를 만들어 검색이 빈 결과/에러를 반환할 수 있고, 후퇴 금지
+        // 정책 때문에 자가복구도 막힌다. 여기서 그룹째 drop해 다음 실행을
+        // 풀크롤로 자가복구하게 한다. 파싱 불가 값(NaN)은 통과시키고
+        // computeDateRange의 finite 가드가 처리한다.
+        const ms = Date.parse(lastUpdatedAt);
+        if (Number.isFinite(ms) && ms > now) continue;
         const group: WatermarkGroupState = { lastUpdatedAt };
         const overlapDays = rawGroup.overlapDays;
         if (

--- a/apps/flex-cli/src/storage/index.ts
+++ b/apps/flex-cli/src/storage/index.ts
@@ -72,6 +72,15 @@ function isPlainObject(v: unknown): v is Record<string, unknown> {
 }
 
 /**
+ * `JSON.parse`는 `__proto__`/`constructor`/`prototype` 같은 특수 키를 own
+ * property로 만들 수 있다. 검증 없이 일반 `{}`에 대입하면 프로토타입이
+ * 오염되거나 객체 동작이 비정상화될 수 있으므로 이 키들은 거른다.
+ */
+function isSafeKey(key: string): boolean {
+  return key !== "__proto__" && key !== "constructor" && key !== "prototype";
+}
+
+/**
  * 손상되거나 사람이 손댄 watermark.json을 안전한 shape으로 정규화한다.
  * 의도적으로 관대하다(스키마 위반은 조용히 누락) — 워터마크는 손실되어도
  * 부트스트랩 풀크롤로 자가복구되므로 크롤 전체를 중단시키는 것보다 낫다.
@@ -80,11 +89,13 @@ export function normalizeWatermarkFile(parsed: unknown): WatermarkFile {
   if (!isPlainObject(parsed)) return {};
   const out: WatermarkFile = {};
   for (const [domain, rawState] of Object.entries(parsed)) {
+    if (!isSafeKey(domain)) continue;
     if (!isPlainObject(rawState)) continue;
     const groupsCandidate = (rawState as Record<string, unknown>).groups;
     const groups: Record<string, WatermarkGroupState> = {};
     if (isPlainObject(groupsCandidate)) {
       for (const [label, rawGroup] of Object.entries(groupsCandidate)) {
+        if (!isSafeKey(label)) continue;
         if (!isPlainObject(rawGroup)) continue;
         const lastUpdatedAt = rawGroup.lastUpdatedAt;
         // lastUpdatedAt만이 워터마크의 본질. 나머지는 누락/이상값이면 omit해서

--- a/apps/flex-cli/src/storage/index.ts
+++ b/apps/flex-cli/src/storage/index.ts
@@ -58,6 +58,47 @@ async function ensureDir(dir: string): Promise<void> {
   await mkdir(dir, { recursive: true });
 }
 
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/**
+ * 손상되거나 사람이 손댄 watermark.json을 안전한 shape으로 정규화한다.
+ * 의도적으로 관대하다(스키마 위반은 조용히 누락) — 워터마크는 손실되어도
+ * 부트스트랩 풀크롤로 자가복구되므로 크롤 전체를 중단시키는 것보다 낫다.
+ */
+export function normalizeWatermarkFile(parsed: unknown): WatermarkFile {
+  if (!isPlainObject(parsed)) return {};
+  const out: WatermarkFile = {};
+  for (const [domain, rawState] of Object.entries(parsed)) {
+    if (!isPlainObject(rawState)) continue;
+    const groupsCandidate = (rawState as Record<string, unknown>).groups;
+    const groups: Record<string, WatermarkGroupState> = {};
+    if (isPlainObject(groupsCandidate)) {
+      for (const [label, rawGroup] of Object.entries(groupsCandidate)) {
+        if (!isPlainObject(rawGroup)) continue;
+        const lastUpdatedAt = rawGroup.lastUpdatedAt;
+        const overlapDays = rawGroup.overlapDays;
+        const lastSuccessfulRunAt = rawGroup.lastSuccessfulRunAt;
+        if (
+          typeof lastUpdatedAt !== "string" ||
+          typeof overlapDays !== "number" ||
+          typeof lastSuccessfulRunAt !== "string"
+        ) {
+          continue;
+        }
+        groups[label] = { lastUpdatedAt, overlapDays, lastSuccessfulRunAt };
+      }
+    }
+    const lastFullReconAt = (rawState as Record<string, unknown>).lastFullReconAt;
+    out[domain] = {
+      groups,
+      lastFullReconAt: typeof lastFullReconAt === "string" ? lastFullReconAt : undefined,
+    };
+  }
+  return out;
+}
+
 async function writeJson(filePath: string, data: unknown): Promise<void> {
   await ensureDir(path.dirname(filePath));
   await writeFile(filePath, JSON.stringify(data, null, 2), "utf-8");
@@ -110,10 +151,7 @@ export function createStorageWriter(outputDir: string, catalogPath: string): Sto
       try {
         const content = await readFile(watermarkPath, "utf-8");
         const parsed = JSON.parse(content) as unknown;
-        if (parsed && typeof parsed === "object") {
-          return parsed as WatermarkFile;
-        }
-        return {};
+        return normalizeWatermarkFile(parsed);
       } catch {
         // 파일 없거나 깨진 경우 — 부트스트랩으로 처리
         return {};

--- a/apps/flex-cli/src/storage/index.ts
+++ b/apps/flex-cli/src/storage/index.ts
@@ -16,11 +16,20 @@ import type { CrawlResult } from "../crawlers/shared.js";
  */
 export interface WatermarkGroupState {
   lastUpdatedAt: string;
-  /** 다음 실행 시 검색 from 날짜를 워터마크보다 N일 앞당긴다. flex의 date-단위 필터 잘림 보정용 */
-  overlapDays: number;
-  /** 마지막으로 이 그룹이 성공적으로 수집된 시각 (정보용) */
-  lastSuccessfulRunAt: string;
+  /**
+   * 다음 실행 시 검색 from 날짜를 워터마크보다 N일 앞당긴다. flex의 date-단위 필터 잘림 보정용.
+   * Optional — 누락 시 호출자가 group 단위 default를 사용한다.
+   */
+  overlapDays?: number;
+  /**
+   * 마지막으로 이 그룹이 성공적으로 수집된 시각 (정보용). Optional — 사용자가
+   * watermark.json을 손으로 편집할 때 이 필드를 빠뜨려도 워터마크 자체는 살린다.
+   */
+  lastSuccessfulRunAt?: string;
 }
+
+/** overlapDays로 받아들일 수 있는 정수 상한. 그 이상은 손상으로 간주해 default fallback. */
+const MAX_OVERLAP_DAYS = 365;
 
 export interface WatermarkDomainState {
   groups: Record<string, WatermarkGroupState>;
@@ -78,16 +87,24 @@ export function normalizeWatermarkFile(parsed: unknown): WatermarkFile {
       for (const [label, rawGroup] of Object.entries(groupsCandidate)) {
         if (!isPlainObject(rawGroup)) continue;
         const lastUpdatedAt = rawGroup.lastUpdatedAt;
+        // lastUpdatedAt만이 워터마크의 본질. 나머지는 누락/이상값이면 omit해서
+        // 호출자가 default로 폴백하게 한다 (=그룹 자체를 잃지 않는다).
+        if (typeof lastUpdatedAt !== "string") continue;
+        const group: WatermarkGroupState = { lastUpdatedAt };
         const overlapDays = rawGroup.overlapDays;
-        const lastSuccessfulRunAt = rawGroup.lastSuccessfulRunAt;
         if (
-          typeof lastUpdatedAt !== "string" ||
-          typeof overlapDays !== "number" ||
-          typeof lastSuccessfulRunAt !== "string"
+          typeof overlapDays === "number" &&
+          Number.isInteger(overlapDays) &&
+          overlapDays >= 0 &&
+          overlapDays <= MAX_OVERLAP_DAYS
         ) {
-          continue;
+          group.overlapDays = overlapDays;
         }
-        groups[label] = { lastUpdatedAt, overlapDays, lastSuccessfulRunAt };
+        const lastSuccessfulRunAt = rawGroup.lastSuccessfulRunAt;
+        if (typeof lastSuccessfulRunAt === "string") {
+          group.lastSuccessfulRunAt = lastSuccessfulRunAt;
+        }
+        groups[label] = group;
       }
     }
     const lastFullReconAt = (rawState as Record<string, unknown>).lastFullReconAt;

--- a/apps/flex-cli/src/storage/index.ts
+++ b/apps/flex-cli/src/storage/index.ts
@@ -89,7 +89,10 @@ export function normalizeWatermarkFile(parsed: unknown): WatermarkFile {
         const lastUpdatedAt = rawGroup.lastUpdatedAt;
         // lastUpdatedAt만이 워터마크의 본질. 나머지는 누락/이상값이면 omit해서
         // 호출자가 default로 폴백하게 한다 (=그룹 자체를 잃지 않는다).
-        if (typeof lastUpdatedAt !== "string") continue;
+        // 빈 문자열/공백은 영구적으로 unusable하므로 그룹째 드롭한다.
+        if (typeof lastUpdatedAt !== "string" || lastUpdatedAt.trim().length === 0) {
+          continue;
+        }
         const group: WatermarkGroupState = { lastUpdatedAt };
         const overlapDays = rawGroup.overlapDays;
         if (
@@ -165,14 +168,25 @@ export function createStorageWriter(outputDir: string, catalogPath: string): Sto
 
     async loadWatermarks() {
       const watermarkPath = path.join(outputDir, "watermark.json");
+      let content: string;
       try {
-        const content = await readFile(watermarkPath, "utf-8");
-        const parsed = JSON.parse(content) as unknown;
-        return normalizeWatermarkFile(parsed);
+        content = await readFile(watermarkPath, "utf-8");
+      } catch (err) {
+        // 파일 없음(ENOENT) — 정상적인 부트스트랩 시나리오. silent fallback.
+        if ((err as NodeJS.ErrnoException).code === "ENOENT") return {};
+        // 권한/디스크/디렉토리 충돌 등 기타 I/O 에러는 surface해서 호출자가
+        // 인지하게 한다. 침묵 부트스트랩은 이전에 잘 채워둔 워터마크를
+        // 모르고 덮어쓰는 위험이 있다.
+        throw err;
+      }
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(content);
       } catch {
-        // 파일 없거나 깨진 경우 — 부트스트랩으로 처리
+        // 손상된 JSON은 부트스트랩으로 폴백. 다음 정상 실행에서 새로 채워진다.
         return {};
       }
+      return normalizeWatermarkFile(parsed);
     },
 
     async saveWatermarks(file) {

--- a/apps/flex-cli/src/storage/index.ts
+++ b/apps/flex-cli/src/storage/index.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { CrawlError } from "../types/common.js";
 import type { AttendanceApproval } from "../types/attendance.js";
@@ -6,6 +6,30 @@ import type { WorkflowInstance } from "../types/instance.js";
 import type { WorkflowTemplate } from "../types/template.js";
 import type { ApiCatalog } from "../types/catalog.js";
 import type { CrawlResult } from "../crawlers/shared.js";
+
+/**
+ * customer 단위 증분 수집 워터마크. 도메인(예: `approvalDocuments`)별로
+ * 그룹별 마지막 관측 `updatedAt` UTC ISO 문자열을 저장한다.
+ *
+ * 그룹별로 따로 두는 이유는 IN_PROGRESS와 DONE 그룹이 변동 패턴과 권장
+ * overlap이 다르기 때문이다. `lastFullReconAt`은 도메인 공통이다.
+ */
+export interface WatermarkGroupState {
+  lastUpdatedAt: string;
+  /** 다음 실행 시 검색 from 날짜를 워터마크보다 N일 앞당긴다. flex의 date-단위 필터 잘림 보정용 */
+  overlapDays: number;
+  /** 마지막으로 이 그룹이 성공적으로 수집된 시각 (정보용) */
+  lastSuccessfulRunAt: string;
+}
+
+export interface WatermarkDomainState {
+  groups: Record<string, WatermarkGroupState>;
+  lastFullReconAt?: string;
+}
+
+export interface WatermarkFile {
+  [domain: string]: WatermarkDomainState | undefined;
+}
 
 export interface CrawlReport {
   startedAt: string;
@@ -26,6 +50,8 @@ export interface StorageWriter {
   saveEndpointData(endpointId: string, data: unknown): Promise<void>;
   saveReport(report: CrawlReport): Promise<void>;
   saveCatalog(catalog: ApiCatalog): Promise<void>;
+  loadWatermarks(): Promise<WatermarkFile>;
+  saveWatermarks(file: WatermarkFile): Promise<void>;
 }
 
 async function ensureDir(dir: string): Promise<void> {
@@ -77,6 +103,25 @@ export function createStorageWriter(outputDir: string, catalogPath: string): Sto
 
     async saveCatalog(catalog) {
       await writeJson(catalogPath, catalog);
+    },
+
+    async loadWatermarks() {
+      const watermarkPath = path.join(outputDir, "watermark.json");
+      try {
+        const content = await readFile(watermarkPath, "utf-8");
+        const parsed = JSON.parse(content) as unknown;
+        if (parsed && typeof parsed === "object") {
+          return parsed as WatermarkFile;
+        }
+        return {};
+      } catch {
+        // 파일 없거나 깨진 경우 — 부트스트랩으로 처리
+        return {};
+      }
+    },
+
+    async saveWatermarks(file) {
+      await writeJson(path.join(outputDir, "watermark.json"), file);
     },
   };
 }

--- a/apps/flex-cli/src/storage/index.ts
+++ b/apps/flex-cli/src/storage/index.ts
@@ -5,7 +5,7 @@ import type { AttendanceApproval } from "../types/attendance.js";
 import type { WorkflowInstance } from "../types/instance.js";
 import type { WorkflowTemplate } from "../types/template.js";
 import type { ApiCatalog } from "../types/catalog.js";
-import type { CrawlResult } from "../crawlers/shared.js";
+import { type CrawlResult, toKstDate } from "../crawlers/shared.js";
 
 /**
  * customer 단위 증분 수집 워터마크. 도메인(예: `approvalDocuments`)별로
@@ -94,6 +94,7 @@ export function normalizeWatermarkFile(
   now: number = Date.now(),
 ): WatermarkFile {
   if (!isPlainObject(parsed)) return {};
+  const todayKst = toKstDate(now);
   const out: WatermarkFile = {};
   for (const [domain, rawState] of Object.entries(parsed)) {
     if (!isSafeKey(domain)) continue;
@@ -113,11 +114,14 @@ export function normalizeWatermarkFile(
         }
         // 미래 timestamp는 손상 신호. 그대로 두면 computeDateRange가 from>to인
         // 잘못된 범위를 만들어 검색이 빈 결과/에러를 반환할 수 있고, 후퇴 금지
-        // 정책 때문에 자가복구도 막힌다. 여기서 그룹째 drop해 다음 실행을
-        // 풀크롤로 자가복구하게 한다. 파싱 불가 값(NaN)은 통과시키고
-        // computeDateRange의 finite 가드가 처리한다.
+        // 정책 때문에 자가복구도 막힌다. 그러나 비교 기준을 epoch ms로 두면
+        // 운영 환경의 NTP skew(수초~수분) 만으로도 정상 워터마크가 미래 판정을
+        // 받아 매 실행 부트스트랩으로 폴백할 수 있어, 여기선 KST date 기준으로
+        // 비교한다 — 같은 날이면 통과, 그 다음날 이후로 명확히 미래일 때만
+        // 그룹째 drop해 다음 실행을 풀크롤로 자가복구하게 한다. 파싱 불가
+        // 값(NaN)은 통과시키고 computeDateRange의 finite 가드가 처리한다.
         const ms = Date.parse(lastUpdatedAt);
-        if (Number.isFinite(ms) && ms > now) continue;
+        if (Number.isFinite(ms) && toKstDate(ms) > todayKst) continue;
         const group: WatermarkGroupState = { lastUpdatedAt };
         const overlapDays = rawGroup.overlapDays;
         if (


### PR DESCRIPTION
## Summary
- 결재 문서 크롤러를 customer + status 그룹 단위 **증분 수집**으로 전환. 각 customer의 `output/<customerIdHash>/watermark.json`에 그룹별 `lastUpdatedAt`(서버 UTC ISO 그대로) + `overlapDays` 보관.
- 워터마크가 있으면 검색 payload에 `filter.lastUpdatedDateRange = { from: KST(watermark - overlapDays), to: KST(today) }` 주입. KST 가정. status 그룹별 overlap 다르게 (in-progress=1d, done=2d).
- 워터마크가 없으면 **bootstrap 풀크롤**로 자동 폴백, `lastFullReconAt` 스탬프.
- `flex-ax crawl --full` 또는 `FLEX_CRAWL_MODE=full`로 워터마크 무시 강제 풀크롤.

## Watermark commit policy
- 그룹 단위로만 갱신. 그룹 내 실패 1건이라도 있으면 그 그룹 워터마크 보류 (다음 실행에서 재시도).
- 후퇴 금지 — 관측 max가 기존보다 작거나 같으면 기존 유지.
- 0건 처리됐어도 워터마크 후퇴/삭제 없음.
- overlap으로 인한 재수집은 기존 JSON 덮어쓰기 + DB upsert가 흡수 (idempotent).

## CLI / env
- `flex-ax crawl --full` flag 추가.
- `FLEX_CRAWL_MODE=incremental|full` env 추가 (기본 incremental). `--full`이 있으면 env/config보다 우선.

## Issue acceptance criteria (planetarium/reflex#38)
- [x] customer별 결재 문서 워터마크 저장
- [x] 검색 요청에 `filter.lastUpdatedDateRange` 적용
- [x] `LAST_UPDATED_AT DESC` 정렬 유지 (기존 그대로)
- [x] 상세 응답의 `document.updatedAt` 최댓값으로 워터마크 갱신
- [x] overlap 재수집 idempotent upsert
- [x] `instances.last_updated_at` indexed (이전 PR #51에서 처리)
- [ ] full reconciliation 전략 — 후속 PR에서 missing docKey diff/tombstone 처리

## Test plan
- [x] `bun test` 46/46 (신규 8 추가) — KST boundary, bootstrap, incremental injection, full override, failure blocking, no regression
- [x] `bunx tsc --noEmit` 클린
- [ ] 실제 워크스페이스에서 1) bootstrap → 2) 증분 → 3) `--full` 순으로 1회씩 돌려 watermark.json 갱신과 search payload 캡처

🤖 Generated with [Claude Code](https://claude.com/claude-code)