### PR TITLE
Report missing docKeys from full-recon crawls

### DIFF
--- a/apps/flex-cli/src/commands/crawl.ts
+++ b/apps/flex-cli/src/commands/crawl.ts
@@ -166,10 +166,15 @@ async function runCrawlForCustomer(
   try {
     templateResult = await crawlTemplates(authCtx, config, catalog, storage, logger);
     const instanceCrawlResult = await crawlInstances(authCtx, config, catalog, storage, logger, mode);
-    instanceResult = instanceCrawlResult;
-    instancesMissing = instanceCrawlResult.missingKeys;
+    // crawlInstances는 in-process 배선용으로 collectedKeys/missingKeys를
+    // 추가로 반환한다. report.instances에는 plain CrawlResult만 들어가야
+    // JSON 직렬화에서 Set이 `{}`로 새거나 missingKeys가 instancesMissing과
+    // 중복 노출되는 일이 없다.
+    const { collectedKeys, missingKeys, ...instancePlain } = instanceCrawlResult;
+    instanceResult = instancePlain;
+    instancesMissing = missingKeys;
     attendanceResult = await crawlAttendanceApprovals(
-      authCtx, config, catalog, storage, logger, instanceCrawlResult.collectedKeys,
+      authCtx, config, catalog, storage, logger, collectedKeys,
     );
     catalogEndpointsResult = await crawlCatalogEndpoints(authCtx, config, catalog, storage, logger);
   } catch (error) {

--- a/apps/flex-cli/src/commands/crawl.ts
+++ b/apps/flex-cli/src/commands/crawl.ts
@@ -160,12 +160,14 @@ async function runCrawlForCustomer(
   let instanceResult: CrawlResult = emptyResult();
   let attendanceResult: CrawlResult = emptyResult();
   let catalogEndpointsResult: CrawlResult = emptyResult();
+  let instancesMissing: string[] = [];
   let fatalError: CrawlError | null = null;
 
   try {
     templateResult = await crawlTemplates(authCtx, config, catalog, storage, logger);
     const instanceCrawlResult = await crawlInstances(authCtx, config, catalog, storage, logger, mode);
     instanceResult = instanceCrawlResult;
+    instancesMissing = instanceCrawlResult.missingKeys;
     attendanceResult = await crawlAttendanceApprovals(
       authCtx, config, catalog, storage, logger, instanceCrawlResult.collectedKeys,
     );
@@ -201,6 +203,7 @@ async function runCrawlForCustomer(
     instances: instanceResult,
     attendance: attendanceResult,
     catalogEndpoints: catalogEndpointsResult,
+    instancesMissing: instancesMissing.length > 0 ? instancesMissing : undefined,
     totalErrors,
   };
 

--- a/apps/flex-cli/src/crawlers/instance.test.ts
+++ b/apps/flex-cli/src/crawlers/instance.test.ts
@@ -62,9 +62,13 @@ function makeLogger(): Logger {
 interface FakeStorage extends StorageWriter {
   _instances: unknown[];
   _watermarks: WatermarkFile;
+  _existingInstanceKeys: Set<string>;
 }
 
-function makeStorage(initial: WatermarkFile = {}): FakeStorage {
+function makeStorage(
+  initial: WatermarkFile = {},
+  existingInstanceKeys: Set<string> = new Set(),
+): FakeStorage {
   let watermarks: WatermarkFile = structuredClone(initial);
   const instances: unknown[] = [];
   const writer: FakeStorage = {
@@ -85,7 +89,9 @@ function makeStorage(initial: WatermarkFile = {}): FakeStorage {
     saveWatermarks: async (file) => {
       watermarks = structuredClone(file);
     },
+    listExistingInstanceKeys: async () => new Set(existingInstanceKeys),
     _instances: instances,
+    _existingInstanceKeys: existingInstanceKeys,
     get _watermarks() {
       return watermarks;
     },
@@ -589,6 +595,111 @@ describe("crawlInstances incremental wiring", () => {
     const stamped = storage._watermarks.approvalDocuments?.lastFullReconAt;
     assert.ok(stamped, "clean zero-doc full crawl must stamp lastFullReconAt");
     assert.ok(Date.parse(stamped!) >= before);
+  });
+
+  it("reports docKeys present on disk but missing from a full recon", async () => {
+    // disk had d-old1 and d-old2; this run sees d-old1 (still alive) and
+    // d-new (newly created). d-old2 disappeared from the flex listing.
+    const search = new Map<string, SearchResp>([
+      [
+        "IN_PROGRESS",
+        { documents: [{ document: { documentKey: "d-old1" } }], total: 1, hasNext: false },
+      ],
+      [
+        "CANCELED|DECLINED|DONE",
+        { documents: [{ document: { documentKey: "d-new" } }], total: 1, hasNext: false },
+      ],
+    ]);
+    const details = new Map<string, DetailResp>([
+      ["d-old1", detailFor("d-old1", "2026-05-01T00:00:00Z", "IN_PROGRESS")],
+      ["d-new", detailFor("d-new", "2026-05-04T00:00:00Z", "DONE")],
+    ]);
+    setupFetch(search, details);
+
+    const storage = makeStorage({}, new Set(["d-old1", "d-old2"]));
+    const result = await crawlInstances(makeAuth(), makeConfig(), null, storage, makeLogger());
+
+    assert.deepEqual(result.missingKeys, ["d-old2"]);
+  });
+
+  it("returns empty missingKeys when the full recon collected every disk key", async () => {
+    const search = new Map<string, SearchResp>([
+      [
+        "IN_PROGRESS",
+        { documents: [{ document: { documentKey: "d-only" } }], total: 1, hasNext: false },
+      ],
+      ["CANCELED|DECLINED|DONE", { documents: [], total: 0, hasNext: false }],
+    ]);
+    const details = new Map<string, DetailResp>([
+      ["d-only", detailFor("d-only", "2026-05-01T00:00:00Z", "IN_PROGRESS")],
+    ]);
+    setupFetch(search, details);
+
+    const storage = makeStorage({}, new Set(["d-only"]));
+    const result = await crawlInstances(makeAuth(), makeConfig(), null, storage, makeLogger());
+
+    assert.deepEqual(result.missingKeys, []);
+  });
+
+  it("does not compute missing diff in incremental mode (avoids false positives)", async () => {
+    // With a watermark in place the run is incremental and only touches
+    // changed docs — disk-vs-collected diff would be hugely noisy.
+    const initial: WatermarkFile = {
+      approvalDocuments: {
+        groups: {
+          "in-progress": {
+            lastUpdatedAt: "2026-04-01T00:00:00Z",
+            overlapDays: 1,
+            lastSuccessfulRunAt: "2026-04-01T00:00:00Z",
+          },
+          done: {
+            lastUpdatedAt: "2026-04-01T00:00:00Z",
+            overlapDays: 2,
+            lastSuccessfulRunAt: "2026-04-01T00:00:00Z",
+          },
+        },
+      },
+    };
+    const search = new Map<string, SearchResp>([
+      ["IN_PROGRESS", { documents: [], total: 0, hasNext: false }],
+      ["CANCELED|DECLINED|DONE", { documents: [], total: 0, hasNext: false }],
+    ]);
+    setupFetch(search, new Map());
+
+    const storage = makeStorage(initial, new Set(["d-historical-1", "d-historical-2"]));
+    const result = await crawlInstances(makeAuth(), makeConfig(), null, storage, makeLogger());
+
+    assert.deepEqual(result.missingKeys, []);
+  });
+
+  it("withholds missing diff when the full recon had any failure (avoids false positives)", async () => {
+    // d-fail couldn't be re-fetched this run, so it landed in
+    // failureCount, not collectedKeys-as-success. Reporting it as
+    // missing would mislead operators.
+    const search = new Map<string, SearchResp>([
+      [
+        "IN_PROGRESS",
+        {
+          documents: [
+            { document: { documentKey: "d-ok" } },
+            { document: { documentKey: "d-fail" } },
+          ],
+          total: 2,
+          hasNext: false,
+        },
+      ],
+      ["CANCELED|DECLINED|DONE", { documents: [], total: 0, hasNext: false }],
+    ]);
+    const details = new Map<string, DetailResp>([
+      ["d-ok", detailFor("d-ok", "2026-05-01T00:00:00Z", "IN_PROGRESS")],
+    ]);
+    setupFetch(search, details, new Set(["d-fail"]));
+
+    const storage = makeStorage({}, new Set(["d-ok", "d-fail", "d-historical"]));
+    const result = await crawlInstances(makeAuth(), makeConfig(), null, storage, makeLogger());
+
+    assert.equal(result.failureCount, 1);
+    assert.deepEqual(result.missingKeys, []);
   });
 
   it("does not stamp lastFullReconAt when a bootstrap full crawl had any failure", async () => {

--- a/apps/flex-cli/src/crawlers/instance.test.ts
+++ b/apps/flex-cli/src/crawlers/instance.test.ts
@@ -702,6 +702,39 @@ describe("crawlInstances incremental wiring", () => {
     assert.deepEqual(result.missingKeys, []);
   });
 
+  it("withholds lastFullReconAt and missingKeys when the list stage throws", async () => {
+    // crawlSearchGroup throws after retries (search API is permanently
+    // failing). result.errors records an `instance-list` entry but
+    // failureCount stays at 0 because no doc-level work happened — the
+    // listStageOk flag must still block the full-recon outcomes.
+    globalThis.fetch = (async (input: unknown) => {
+      const url = String(input);
+      if (url.includes("/user-boxes/search")) {
+        return new Response("server error", { status: 500 });
+      }
+      return new Response("not found", { status: 404 });
+    }) as typeof fetch;
+
+    const storage = makeStorage({}, new Set(["d-historical"]));
+    const result = await crawlInstances(makeAuth(), makeConfig(), null, storage, makeLogger());
+
+    assert.ok(
+      result.errors.some((e) => e.target === "instance-list"),
+      "list-stage error must be recorded",
+    );
+    assert.equal(result.failureCount, 0, "no doc-level failures occurred");
+    assert.equal(
+      storage._watermarks.approvalDocuments?.lastFullReconAt,
+      undefined,
+      "list-stage throw must not stamp lastFullReconAt",
+    );
+    assert.deepEqual(
+      result.missingKeys,
+      [],
+      "list-stage throw must withhold the missing diff (collectedKeys is partial)",
+    );
+  });
+
   it("does not stamp lastFullReconAt when a bootstrap full crawl had any failure", async () => {
     const search = new Map<string, SearchResp>([
       [

--- a/apps/flex-cli/src/crawlers/instance.ts
+++ b/apps/flex-cli/src/crawlers/instance.ts
@@ -39,10 +39,15 @@ export async function crawlInstances(
   storage: StorageWriter,
   logger: Logger,
   mode: CrawlMode = "incremental",
-): Promise<CrawlResult & { collectedKeys: Set<string> }> {
+): Promise<
+  CrawlResult & { collectedKeys: Set<string>; missingKeys: string[] }
+> {
   const startTime = Date.now();
   const result = emptyCrawlResult();
   const collectedKeys = new Set<string>();
+  // full recon이 아닐 땐 의미가 없으므로 비워둔다 (incremental은 변경된
+  // 문서만 재방문하니 disk-vs-collected diff는 거짓양성 폭증).
+  let missingKeys: string[] = [];
 
   logger.info("인스턴스(결재 문서) 수집 시작", { mode });
 
@@ -73,6 +78,30 @@ export async function crawlInstances(
   }
   // to 날짜는 그룹 진입 전에 한 번 캡처해서 페이지/그룹 간 일관되게 사용.
   const todayKst = toKstDate(new Date());
+
+  // full reconciliation diff: effectiveFull일 때만 시작 시점의 디스크 상
+  // docKey 집합을 캡처해두고, 종료 후 collectedKeys와 차집합을 missing
+  // 후보로 보고서에 노출. 자동 tombstone은 별도 트랙.
+  let existingBeforeRun: Set<string> | null = null;
+  if (effectiveFull) {
+    try {
+      existingBeforeRun = await storage.listExistingInstanceKeys();
+      logger.info("full recon — 기존 docKey 스냅샷 캡처", {
+        count: existingBeforeRun.size,
+      });
+    } catch (err) {
+      // 스냅샷 실패는 missing diff만 비우고 크롤은 계속 진행 (비치명적).
+      logger.error("기존 docKey 스냅샷 실패 — missing diff 생략", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      result.errors.push({
+        target: "instance-recon",
+        phase: "list-existing",
+        message: err instanceof Error ? err.message : String(err),
+        timestamp: nowISO(),
+      });
+    }
+  }
 
   try {
     for (const group of searchGroups) {
@@ -151,6 +180,26 @@ export async function crawlInstances(
     domainState.lastFullReconAt = nowISO();
   }
 
+  // Full recon diff — 디스크에 있었지만 이번 실행 목록에서 사라진 docKey들.
+  // 권한 회수, 삭제, flex 측 list 누락 등의 신호. 자동 tombstone은 후속.
+  // 단, 같은 그룹에 실패가 한 건이라도 있으면 그 docKey들이 단순히 detail
+  // 단계에서 못 가져와서 collectedKeys에 빠진 것일 수 있으니 missing 판정을
+  // 보류한다 (false positive 방지).
+  if (existingBeforeRun && result.failureCount === 0) {
+    const missing: string[] = [];
+    for (const key of existingBeforeRun) {
+      if (!collectedKeys.has(key)) missing.push(key);
+    }
+    missing.sort();
+    missingKeys = missing;
+    if (missing.length > 0) {
+      logger.warn("full recon: 목록에서 사라진 docKey 후보", {
+        count: missing.length,
+        sample: missing.slice(0, 10),
+      });
+    }
+  }
+
   watermarks[APPROVAL_DOCUMENTS_DOMAIN] = domainState;
   try {
     await storage.saveWatermarks(watermarks);
@@ -169,7 +218,7 @@ export async function crawlInstances(
 
   result.durationMs = Date.now() - startTime;
   logger.info(`\n인스턴스 수집 완료: 성공 ${result.successCount}, 실패 ${result.failureCount}`);
-  return { ...result, collectedKeys };
+  return { ...result, collectedKeys, missingKeys };
 }
 
 interface SearchGroup {

--- a/apps/flex-cli/src/crawlers/instance.ts
+++ b/apps/flex-cli/src/crawlers/instance.ts
@@ -103,6 +103,11 @@ export async function crawlInstances(
     }
   }
 
+  // list-stage(검색 단계)가 try 끝까지 도달했는지 추적. crawlSearchGroup이
+  // 재시도 후에도 throw하면 catch에서 false로 전환. failureCount는 doc 단위
+  // 실패만 세므로 list 자체가 깨진 케이스를 별도로 표시해둬야 한다.
+  let listStageOk = true;
+
   try {
     for (const group of searchGroups) {
       const existing = domainState.groups[group.label];
@@ -160,6 +165,7 @@ export async function crawlInstances(
       });
     }
   } catch (error) {
+    listStageOk = false;
     logger.error("인스턴스 목록 수집 중 치명적 오류", {
       error: error instanceof Error ? error.message : String(error),
     });
@@ -171,21 +177,22 @@ export async function crawlInstances(
     });
   }
 
-  // 사실상 풀크롤로 돌았고 인스턴스 단계에 단 1건의 실패도 없었을 때만
-  // lastFullReconAt 갱신. 실패가 섞이면 "전체 recon 완료" 의미가 흐려지므로,
-  // 후속 cadence-기반 자동 풀크롤 트리거가 사고로 다음 실행을 건너뛰지 않도록
-  // 보수적으로 잠근다. 정당한 0건(워크스페이스에 문서 없음, 권한 없음 등)도
-  // 클린한 recon이므로 stamp 대상이다 — successCount는 게이트하지 않는다.
-  if (effectiveFull && result.failureCount === 0) {
+  // 사실상 풀크롤로 돌았고 list 단계가 끝까지 살아남았으며 인스턴스 단계에
+  // 단 1건의 실패도 없었을 때만 lastFullReconAt 갱신. 실패/list-throw가 섞이면
+  // "전체 recon 완료" 의미가 흐려지므로, 후속 cadence-기반 자동 풀크롤
+  // 트리거가 사고로 다음 실행을 건너뛰지 않도록 보수적으로 잠근다. 정당한
+  // 0건(워크스페이스에 문서 없음, 권한 없음 등)도 클린한 recon이므로 stamp
+  // 대상이다 — successCount는 게이트하지 않는다.
+  if (effectiveFull && listStageOk && result.failureCount === 0) {
     domainState.lastFullReconAt = nowISO();
   }
 
   // Full recon diff — 디스크에 있었지만 이번 실행 목록에서 사라진 docKey들.
   // 권한 회수, 삭제, flex 측 list 누락 등의 신호. 자동 tombstone은 후속.
-  // 단, 같은 그룹에 실패가 한 건이라도 있으면 그 docKey들이 단순히 detail
-  // 단계에서 못 가져와서 collectedKeys에 빠진 것일 수 있으니 missing 판정을
-  // 보류한다 (false positive 방지).
-  if (existingBeforeRun && result.failureCount === 0) {
+  // 단, 같은 그룹에 실패가 한 건이라도 있거나 list 단계가 throw로 조기
+  // 종료됐다면 collectedKeys가 부분 결과라 missing 판정을 보류한다
+  // (false positive 방지).
+  if (existingBeforeRun && listStageOk && result.failureCount === 0) {
     const missing: string[] = [];
     for (const key of existingBeforeRun) {
       if (!collectedKeys.has(key)) missing.push(key);

--- a/apps/flex-cli/src/storage/index.test.ts
+++ b/apps/flex-cli/src/storage/index.test.ts
@@ -205,6 +205,19 @@ describe("createStorageWriter listExistingInstanceKeys", () => {
     const keys = await writer.listExistingInstanceKeys();
     assert.deepEqual([...keys].sort(), ["doc-1", "doc-2"]);
   });
+
+  it("does not misclassify a directory whose name ends in .json as a docKey", async () => {
+    const dir = await tmpStorageDir();
+    const instancesDir = path.join(dir, "instances");
+    await mkdir(instancesDir);
+    await writeFile(path.join(instancesDir, "real-doc.json"), "{}", "utf-8");
+    // A dir whose name ends in .json — readdir returns the bare name
+    // and the previous implementation would have called this a docKey.
+    await mkdir(path.join(instancesDir, "looks-like-doc.json"));
+    const writer = createStorageWriter(dir, path.join(dir, "catalog.json"));
+    const keys = await writer.listExistingInstanceKeys();
+    assert.deepEqual([...keys], ["real-doc"]);
+  });
 });
 
 describe("createStorageWriter loadWatermarks", () => {

--- a/apps/flex-cli/src/storage/index.test.ts
+++ b/apps/flex-cli/src/storage/index.test.ts
@@ -186,6 +186,27 @@ describe("normalizeWatermarkFile", () => {
   });
 });
 
+describe("createStorageWriter listExistingInstanceKeys", () => {
+  it("returns an empty set when the instances directory does not exist", async () => {
+    const dir = await tmpStorageDir();
+    const writer = createStorageWriter(dir, path.join(dir, "catalog.json"));
+    const keys = await writer.listExistingInstanceKeys();
+    assert.equal(keys.size, 0);
+  });
+
+  it("returns docKeys derived from .json filenames, ignoring other entries", async () => {
+    const dir = await tmpStorageDir();
+    const instancesDir = path.join(dir, "instances");
+    await mkdir(instancesDir);
+    await writeFile(path.join(instancesDir, "doc-1.json"), "{}", "utf-8");
+    await writeFile(path.join(instancesDir, "doc-2.json"), "{}", "utf-8");
+    await writeFile(path.join(instancesDir, "README.md"), "ignore me", "utf-8");
+    const writer = createStorageWriter(dir, path.join(dir, "catalog.json"));
+    const keys = await writer.listExistingInstanceKeys();
+    assert.deepEqual([...keys].sort(), ["doc-1", "doc-2"]);
+  });
+});
+
 describe("createStorageWriter loadWatermarks", () => {
   it("returns {} when watermark.json is missing (ENOENT)", async () => {
     const dir = await tmpStorageDir();

--- a/apps/flex-cli/src/storage/index.ts
+++ b/apps/flex-cli/src/storage/index.ts
@@ -235,15 +235,19 @@ export function createStorageWriter(outputDir: string, catalogPath: string): Sto
 
     async listExistingInstanceKeys() {
       const dir = path.join(outputDir, "instances");
-      let entries: string[];
+      let entries: import("node:fs").Dirent[];
       try {
-        entries = await readdir(dir);
+        entries = await readdir(dir, { withFileTypes: true });
       } catch (err) {
         if ((err as NodeJS.ErrnoException).code === "ENOENT") return new Set<string>();
         throw err;
       }
       const keys = new Set<string>();
-      for (const name of entries) {
+      for (const entry of entries) {
+        // 디렉토리 / 비-json 엔트리 제외. `foo.json/`처럼 디렉토리가 .json
+        // 확장자를 가져도 docKey로 오인되지 않도록.
+        if (!entry.isFile()) continue;
+        const name = entry.name;
         if (!name.endsWith(".json")) continue;
         keys.add(name.slice(0, -".json".length));
       }

--- a/apps/flex-cli/src/storage/index.ts
+++ b/apps/flex-cli/src/storage/index.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { CrawlError } from "../types/common.js";
 import type { AttendanceApproval } from "../types/attendance.js";
@@ -48,6 +48,12 @@ export interface CrawlReport {
   instances: CrawlResult;
   attendance: CrawlResult;
   catalogEndpoints?: CrawlResult;
+  /**
+   * Full reconciliation diff. 풀크롤(또는 부트스트랩)에서 디스크에는 있었지만
+   * 이번 실행 검색 목록에서 사라진 docKey들. 권한 회수/문서 삭제/flex list
+   * 누락 등의 신호. 자동 tombstone은 별도 트랙. incremental 실행에선 비워둔다.
+   */
+  instancesMissing?: string[];
   totalErrors: CrawlError[];
 }
 
@@ -61,6 +67,11 @@ export interface StorageWriter {
   saveCatalog(catalog: ApiCatalog): Promise<void>;
   loadWatermarks(): Promise<WatermarkFile>;
   saveWatermarks(file: WatermarkFile): Promise<void>;
+  /**
+   * `${outputDir}/instances/` 안에 이미 저장된 docKey 집합을 반환한다.
+   * 디렉토리가 없으면 빈 set. full reconciliation diff 계산에 쓰인다.
+   */
+  listExistingInstanceKeys(): Promise<Set<string>>;
 }
 
 async function ensureDir(dir: string): Promise<void> {
@@ -220,6 +231,23 @@ export function createStorageWriter(outputDir: string, catalogPath: string): Sto
 
     async saveWatermarks(file) {
       await writeJson(path.join(outputDir, "watermark.json"), file);
+    },
+
+    async listExistingInstanceKeys() {
+      const dir = path.join(outputDir, "instances");
+      let entries: string[];
+      try {
+        entries = await readdir(dir);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === "ENOENT") return new Set<string>();
+        throw err;
+      }
+      const keys = new Set<string>();
+      for (const name of entries) {
+        if (!name.endsWith(".json")) continue;
+        keys.add(name.slice(0, -".json".length));
+      }
+      return keys;
     },
   };
 }


### PR DESCRIPTION
## Summary
- Full reconciliation diff. 풀크롤(`--full`/`FLEX_CRAWL_MODE=full`/부트스트랩) 시 시작 시점 디스크 docKey 스냅샷과 이번 실행 `collectedKeys`의 차집합을 계산해 `crawl-report.json#instancesMissing`에 노출.
- 이게 issue #38 acceptance criteria의 마지막 항목 (full reconciliation 전략 별도 정의)을 닫는다.
- 자동 tombstone은 의도적으로 미포함 — 운영자 신호 단계까지만. raw 보존이 우선.

## Guards (false positive 방지)
- `effectiveFull` 모드에서만 동작. incremental은 변경된 문서만 재방문하니 disk-vs-collected diff는 의미 없음.
- 인스턴스 단계에 실패가 1건이라도 있으면 missing 판정 보류 — detail fetch 일시 오류로 collect에서 빠진 doc을 missing으로 오판하지 않게.
- 스냅샷 자체 실패(`listExistingInstanceKeys`가 throw)는 비치명적: 구조화된 에러를 `result.errors`에 push하고 크롤은 계속.

## Storage
- `StorageWriter.listExistingInstanceKeys()` 신규. `${outputDir}/instances/*.json` 파일명에서 `.json` 떼서 set 반환. 디렉토리 없으면 빈 set.

## Issue acceptance criteria status (planetarium/reflex#38)
- [x] customer별 결재 문서 워터마크 저장 (PR #52)
- [x] 검색 요청에 `filter.lastUpdatedDateRange` 적용 (#52)
- [x] `LAST_UPDATED_AT DESC` 정렬 유지 (기존)
- [x] 상세 응답의 `document.updatedAt` 최댓값으로 워터마크 갱신 (#52)
- [x] overlap 재수집 idempotent upsert (#52)
- [x] `instances.last_updated_at` indexed (PR #51)
- [x] **full reconciliation 전략을 별도로 정의 (이 PR)** ← 마지막 항목

## Test plan
- [x] `bunx tsc --noEmit` 클린
- [x] `bun test` 77/77 (신규 6 추가)
- [ ] 실제 워크스페이스에서 풀크롤 1회 → `crawl-report.json#instancesMissing` 비어있는지 확인 (정상 케이스). 일부러 디스크에 가짜 `instances/zzz-missing.json` 만들고 풀크롤 → instancesMissing에 `zzz-missing`이 잡히는지

## Follow-ups (별 트랙)
- 첨부파일 fileKey 기반 skip
- cadence 자동 풀크롤 승격 (필요 시)

🤖 Generated with [Claude Code](https://claude.com/claude-code)