### PR TITLE
Comment-aware reconciliation: IN_PROGRESS sweep, closed-window sweep, signature hash

### DIFF
--- a/apps/flex-cli/src/cli-help.ts
+++ b/apps/flex-cli/src/cli-help.ts
@@ -46,6 +46,8 @@ Env:
   FLEX_CUSTOMERS              크롤 대상 법인 customerIdHash (콤마 구분)
   FLEX_CRAWL_MODE             incremental(기본) | full
                               full 은 결재 문서 워터마크를 무시하고 전체 재수집
+  FLEX_CLOSED_SWEEP_DAYS=30   종결(DONE/DECLINED/CANCELED) 후 N일 이내 문서를
+                              매 cycle 추가로 detail 재조회 (댓글 흡수). 0이면 비활성
   FLEX_AX_AUTO_UPDATE=false   기동 시 자동 업데이트 비활성화`;
 
 const COMMAND_HELP: Record<string, string> = {
@@ -69,6 +71,12 @@ OS 키링에서 저장된 비밀번호를 삭제합니다.
 customer 단위로 output/<customerIdHash>/watermark.json 을 두고, 다음 실행
 시 flex 검색 요청에 lastUpdatedDateRange (KST 기준)을 적용합니다. 워터마크가
 없는 첫 실행은 자동으로 부트스트랩 풀크롤로 폴백합니다.
+
+진행 중(IN_PROGRESS) 문서는 워터마크와 무관하게 매 cycle 전체 sweep합니다 —
+flex의 document.updatedAt이 댓글 mutation으로는 갱신되지 않기 때문에
+워터마크 검색만으론 댓글 변화를 흡수할 수 없습니다. 종결(DONE/DECLINED/
+CANCELED) 문서 중 종결된 지 N일 이내인 것도 같은 이유로 매 cycle 추가
+재조회합니다 (FLEX_CLOSED_SWEEP_DAYS, 기본 30, 0이면 비활성).
 
 Options:
   --full          워터마크 무시, 결재 문서 전체 재수집 (env: FLEX_CRAWL_MODE=full)`,

--- a/apps/flex-cli/src/commands/crawl.ts
+++ b/apps/flex-cli/src/commands/crawl.ts
@@ -166,11 +166,18 @@ async function runCrawlForCustomer(
   try {
     templateResult = await crawlTemplates(authCtx, config, catalog, storage, logger);
     const instanceCrawlResult = await crawlInstances(authCtx, config, catalog, storage, logger, mode);
-    // crawlInstances는 in-process 배선용으로 collectedKeys/missingKeys를
-    // 추가로 반환한다. report.instances에는 plain CrawlResult만 들어가야
-    // JSON 직렬화에서 Set이 `{}`로 새거나 missingKeys가 instancesMissing과
-    // 중복 노출되는 일이 없다.
-    const { collectedKeys, missingKeys, ...instancePlain } = instanceCrawlResult;
+    // crawlInstances는 in-process 배선용으로 collectedKeys / missingKeys /
+    // closedSweepCount를 추가로 반환한다. report.instances에는 plain CrawlResult
+    // 만 들어가야 JSON 직렬화에서 Set이 `{}`로 새거나 추가 필드가 노출되는 일이
+    // 없다. closedSweepCount는 instance.ts 안에서 logger.info로 이미 보고되므로
+    // 여기서는 destructure로 떼어내기만 한다.
+    const {
+      collectedKeys,
+      missingKeys,
+      closedSweepCount: _closedSweepCount,
+      ...instancePlain
+    } = instanceCrawlResult;
+    void _closedSweepCount;
     instanceResult = instancePlain;
     instancesMissing = missingKeys;
     attendanceResult = await crawlAttendanceApprovals(

--- a/apps/flex-cli/src/config/index.ts
+++ b/apps/flex-cli/src/config/index.ts
@@ -75,6 +75,13 @@ const configSchema = z.object({
    * - "full": 워터마크 무시, 날짜 필터 없이 전체 재수집. CLI `--full`로도 강제할 수 있다.
    */
   flexCrawlMode: z.enum(["incremental", "full"]).default("incremental"),
+  /**
+   * 종결(DONE/DECLINED/CANCELED) 문서 중 종결된 지 N일 이내인 것들을 매 cycle
+   * 추가로 detail 재조회한다. 댓글 mutation은 `document.updatedAt`을 갱신하지
+   * 않으므로(planetarium/reflex#38) 워터마크 검색만으론 종결 후 댓글을 흡수할
+   * 수 없다. 0이면 비활성. 기본 30일.
+   */
+  closedSweepDays: z.coerce.number().int().min(0).default(30),
 });
 
 export type Config = z.infer<typeof configSchema>;
@@ -97,5 +104,6 @@ export function loadConfig(): Config {
     skipEndpoints: process.env.FLEX_SKIP_ENDPOINTS || undefined,
     customers: process.env.FLEX_CUSTOMERS || undefined,
     flexCrawlMode: process.env.FLEX_CRAWL_MODE || undefined,
+    closedSweepDays: process.env.FLEX_CLOSED_SWEEP_DAYS || undefined,
   });
 }

--- a/apps/flex-cli/src/crawlers/instance.test.ts
+++ b/apps/flex-cli/src/crawlers/instance.test.ts
@@ -925,6 +925,79 @@ describe("crawlInstances incremental wiring", () => {
     assert.equal(att.mimeType, "application/pdf", "mimeType must be carried over from prior");
   });
 
+  it("matches attachments by fileKey when prior _raw is available, not just fileName", async () => {
+    // Two attachments share the same fileName but have different
+    // fileKeys (a real-world case the codebase already handles via
+    // fileKey prefixing on disk). fileName-only merge would mis-pair
+    // their localPath metadata; fileKey merge keeps each attachment's
+    // metadata aligned to its own file.
+    const within = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString();
+    const prior: WorkflowInstance = {
+      id: "d-dup",
+      documentNumber: "d-dup",
+      templateId: "t",
+      templateName: "t",
+      drafter: { id: "u", name: "n" },
+      draftedAt: within,
+      lastUpdatedAt: within,
+      signatureHash: "old-hash",
+      status: "DONE",
+      approvalLine: [],
+      fields: [],
+      attachments: [
+        {
+          fileName: "report.pdf",
+          localPath: "/cache/d-dup/fk-A_report.pdf",
+          fileSize: 100,
+          mimeType: "application/pdf",
+        },
+        {
+          fileName: "report.pdf",
+          localPath: "/cache/d-dup/fk-B_report.pdf",
+          fileSize: 200,
+          mimeType: "application/pdf",
+        },
+      ],
+      _raw: {
+        document: {
+          attachments: [
+            { idHash: "att-A", file: { fileKey: "fk-A", fileName: "report.pdf", downloadUrl: "" } },
+            { idHash: "att-B", file: { fileKey: "fk-B", fileName: "report.pdf", downloadUrl: "" } },
+          ],
+        },
+      },
+    };
+    const closedDocs = new Map<string, WorkflowInstance>([["d-dup", prior]]);
+    const search = new Map<string, SearchResp>([
+      ["IN_PROGRESS", { documents: [], total: 0, hasNext: false }],
+      ["CANCELED|DECLINED|DONE", { documents: [], total: 0, hasNext: false }],
+    ]);
+    // Detail returns the same two attachments but in swapped order; if
+    // the merge were positional we'd silently mis-pair them. fileKey
+    // merge keeps each metadata bound to its own file.
+    const detailSwapped: DetailResp = { ...detailFor("d-dup", within, "DONE") };
+    detailSwapped.document = { ...detailSwapped.document };
+    (detailSwapped.document as unknown as {
+      attachments: Array<{ idHash: string; file: { fileKey: string; fileName: string; downloadUrl: string } }>;
+    }).attachments = [
+      { idHash: "att-B", file: { fileKey: "fk-B", fileName: "report.pdf", downloadUrl: "" } },
+      { idHash: "att-A", file: { fileKey: "fk-A", fileName: "report.pdf", downloadUrl: "" } },
+    ];
+    setupFetch(search, new Map([["d-dup", detailSwapped]]));
+
+    const config: Config = { ...makeConfig(), closedSweepDays: 30 };
+    const storage = makeStorage({}, new Set(["d-dup"]), closedDocs);
+    await crawlInstances(makeAuth(), config, null, storage, makeLogger());
+
+    const saved = storage._instances.find((i) => i.id === "d-dup");
+    assert.ok(saved);
+    // First attachment in the saved instance corresponds to fk-B (the
+    // first entry of the swapped detail response), so its fileSize
+    // must be 200 — fileName-only merge would have given 100.
+    assert.equal(saved.attachments[0].fileSize, 200, "fk-B metadata must follow fk-B");
+    assert.equal(saved.attachments[1].fileSize, 100, "fk-A metadata must follow fk-A");
+  });
+
   it("disables closed-window sweep when closedSweepDays=0", async () => {
     const within = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString();
     const closedDocs = new Map<string, WorkflowInstance>([

--- a/apps/flex-cli/src/crawlers/instance.test.ts
+++ b/apps/flex-cli/src/crawlers/instance.test.ts
@@ -10,7 +10,11 @@ import {
   type StorageWriter,
   type WatermarkFile,
 } from "../storage/index.js";
-import { crawlInstances } from "./instance.js";
+import {
+  computeSignatureHash,
+  crawlInstances,
+  type DocumentDetailResponse,
+} from "./instance.js";
 import { toKstDate } from "./shared.js";
 
 interface CapturedFetch {
@@ -795,6 +799,7 @@ describe("crawlInstances incremental wiring", () => {
         drafter: { id: "u", name: "n" },
         draftedAt: updatedAt,
         lastUpdatedAt: updatedAt,
+        signatureHash: "test-fixture-hash",
         status,
         approvalLine: [],
         fields: [],
@@ -859,6 +864,7 @@ describe("crawlInstances incremental wiring", () => {
           drafter: { id: "u", name: "n" },
           draftedAt: within,
           lastUpdatedAt: within,
+          signatureHash: "test-fixture-hash",
           status: "DONE",
           approvalLine: [],
           fields: [],
@@ -902,6 +908,7 @@ describe("crawlInstances incremental wiring", () => {
           drafter: { id: "u", name: "n" },
           draftedAt: within,
           lastUpdatedAt: within,
+          signatureHash: "test-fixture-hash",
           status: "DONE",
           approvalLine: [],
           fields: [],
@@ -969,6 +976,141 @@ describe("crawlInstances incremental wiring", () => {
       wmIp?.lastSuccessfulRunAt,
       "2026-04-29T00:00:00Z",
       "in-progress watermark must not be touched by the sweep",
+    );
+  });
+});
+
+describe("computeSignatureHash", () => {
+  function detail(
+    overrides: Partial<DocumentDetailResponse["document"]> = {},
+    processStatus: string | null = "DONE",
+  ): DocumentDetailResponse {
+    return {
+      document: {
+        documentKey: "d1",
+        code: "D-1",
+        templateKey: "t1",
+        status: "DONE",
+        title: "doc",
+        writer: { idHash: "u", name: "n" },
+        writtenAt: "2026-01-01T00:00:00Z",
+        inputs: [],
+        updatedAt: "2026-04-29T12:00:00Z",
+        comments: [],
+        ...overrides,
+      },
+      approvalProcess: processStatus ? { status: processStatus, lines: [] } : undefined,
+    };
+  }
+
+  it("is stable for identical input", () => {
+    assert.equal(computeSignatureHash(detail()), computeSignatureHash(detail()));
+  });
+
+  it("changes when document.updatedAt changes", () => {
+    const a = computeSignatureHash(detail({ updatedAt: "2026-04-29T12:00:00Z" }));
+    const b = computeSignatureHash(detail({ updatedAt: "2026-04-29T12:00:00.500Z" }));
+    assert.notEqual(a, b);
+  });
+
+  it("changes when status changes", () => {
+    const a = computeSignatureHash(detail({ status: "DONE" }));
+    const b = computeSignatureHash(detail({ status: "DECLINED" }));
+    assert.notEqual(a, b);
+  });
+
+  it("changes when a comment is added (length differs)", () => {
+    const empty = computeSignatureHash(detail({ comments: [] }));
+    const one = computeSignatureHash(
+      detail({
+        comments: [
+          {
+            idHash: "c1",
+            writer: { idHash: "u", name: "n" },
+            type: "COMMENT",
+            createdAt: "2026-04-30T00:00:00Z",
+          },
+        ],
+      }),
+    );
+    assert.notEqual(empty, one);
+  });
+
+  it("changes when a comment is edited (updatedAt differs but length is the same)", () => {
+    const before = computeSignatureHash(
+      detail({
+        comments: [
+          {
+            idHash: "c1",
+            writer: { idHash: "u", name: "n" },
+            type: "COMMENT",
+            createdAt: "2026-04-30T00:00:00Z",
+          },
+        ],
+      }),
+    );
+    const after = computeSignatureHash(
+      detail({
+        comments: [
+          {
+            idHash: "c1",
+            writer: { idHash: "u", name: "n" },
+            type: "COMMENT",
+            createdAt: "2026-04-30T00:00:00Z",
+            updatedAt: "2026-04-30T01:00:00Z",
+          },
+        ],
+      }),
+    );
+    assert.notEqual(before, after);
+  });
+
+  it("changes when a same-length comment swap (delete one, add another) happens in the same cycle", () => {
+    // commenters/timestamps may differ but length stays at 1; the
+    // sorted-id portion of the signature catches the swap.
+    const a = computeSignatureHash(
+      detail({
+        comments: [
+          {
+            idHash: "c-old",
+            writer: { idHash: "u", name: "n" },
+            type: "COMMENT",
+            createdAt: "2026-04-30T00:00:00Z",
+          },
+        ],
+      }),
+    );
+    const b = computeSignatureHash(
+      detail({
+        comments: [
+          {
+            idHash: "c-new",
+            writer: { idHash: "u", name: "n" },
+            type: "COMMENT",
+            createdAt: "2026-04-30T00:00:00Z",
+          },
+        ],
+      }),
+    );
+    assert.notEqual(a, b);
+  });
+
+  it("does not depend on comment array order (sorted by idHash)", () => {
+    const c1 = {
+      idHash: "c1",
+      writer: { idHash: "u", name: "n" },
+      type: "COMMENT",
+      createdAt: "2026-04-30T00:00:00Z",
+    };
+    const c2 = {
+      idHash: "c2",
+      writer: { idHash: "u", name: "n" },
+      type: "COMMENT",
+      createdAt: "2026-04-30T00:00:00Z",
+    };
+    assert.equal(
+      computeSignatureHash(detail({ comments: [c1, c2] })),
+      computeSignatureHash(detail({ comments: [c2, c1] })),
     );
   });
 });

--- a/apps/flex-cli/src/crawlers/instance.test.ts
+++ b/apps/flex-cli/src/crawlers/instance.test.ts
@@ -217,7 +217,9 @@ describe("crawlInstances incremental wiring", () => {
     }
 
     const wm = storage._watermarks.approvalDocuments!;
-    assert.equal(wm.groups["in-progress"].lastUpdatedAt, "2026-04-29T12:00:00Z");
+    // in-progress is incrementalEligible=false: never persisted as a
+    // group watermark, even after a successful sweep. Only done lands.
+    assert.equal(wm.groups["in-progress"], undefined);
     assert.equal(wm.groups["done"].lastUpdatedAt, "2026-04-30T03:00:00Z");
     assert.ok(wm.lastFullReconAt, "bootstrap counts as a full recon");
   });
@@ -254,6 +256,9 @@ describe("crawlInstances incremental wiring", () => {
     const todayAfter = toKstDate(new Date());
     const acceptableTodays = new Set([todayBefore, todayAfter]);
 
+    // in-progress is incrementalEligible=false: must always sweep with
+    // no lastUpdatedDateRange, even when a stale watermark sits in the
+    // file (e.g. left over from a pre-policy run).
     const inProgressCall = calls.find(
       (c) =>
         c.url.includes("/user-boxes/search") &&
@@ -261,12 +266,11 @@ describe("crawlInstances incremental wiring", () => {
         (c.body as { filter: { statuses: string[] } }).filter.statuses[0] === "IN_PROGRESS",
     );
     assert.ok(inProgressCall);
-    const ipRange = (
-      (inProgressCall.body as { filter: { lastUpdatedDateRange: { from: string; to: string } } })
-        .filter.lastUpdatedDateRange
+    const ipFilter = (inProgressCall.body as { filter: Record<string, unknown> }).filter;
+    assert.ok(
+      !("lastUpdatedDateRange" in ipFilter),
+      "in-progress must never carry a date range",
     );
-    assert.equal(ipRange.from, "2026-04-28"); // KST(2026-04-29 21:17 KST) - 1d
-    assert.ok(acceptableTodays.has(ipRange.to), `to=${ipRange.to} must be a today-KST value`);
 
     const doneCall = calls.find(
       (c) =>
@@ -319,15 +323,10 @@ describe("crawlInstances incremental wiring", () => {
     }
   });
 
-  it("does not advance a group's watermark when that group has any failure", async () => {
+  it("does not advance the done watermark when that group has any failure", async () => {
     const initial: WatermarkFile = {
       approvalDocuments: {
         groups: {
-          "in-progress": {
-            lastUpdatedAt: "2026-04-29T00:00:00Z",
-            overlapDays: 1,
-            lastSuccessfulRunAt: "2026-04-29T00:00:00Z",
-          },
           done: {
             lastUpdatedAt: "2026-04-29T00:00:00Z",
             overlapDays: 2,
@@ -337,61 +336,45 @@ describe("crawlInstances incremental wiring", () => {
       },
     };
     const search = new Map<string, SearchResp>([
+      ["IN_PROGRESS", { documents: [], total: 0, hasNext: false }],
       [
-        "IN_PROGRESS",
+        "CANCELED|DECLINED|DONE",
         {
           documents: [
-            { document: { documentKey: "ip-ok" } },
-            { document: { documentKey: "ip-fail" } },
+            { document: { documentKey: "done-ok" } },
+            { document: { documentKey: "done-fail" } },
           ],
           total: 2,
           hasNext: false,
         },
       ],
-      [
-        "CANCELED|DECLINED|DONE",
-        { documents: [{ document: { documentKey: "done-ok" } }], total: 1, hasNext: false },
-      ],
     ]);
     const details = new Map<string, DetailResp>([
-      ["ip-ok", detailFor("ip-ok", "2026-05-03T01:00:00Z", "IN_PROGRESS")],
       ["done-ok", detailFor("done-ok", "2026-05-04T05:00:00Z", "DONE")],
     ]);
-    const { calls: _calls } = setupFetch(search, details, new Set(["ip-fail"]));
+    setupFetch(search, details, new Set(["done-fail"]));
 
     const storage = makeStorage(initial);
     const result = await crawlInstances(makeAuth(), makeConfig(), null, storage, makeLogger());
 
     assert.equal(result.failureCount, 1);
-    assert.equal(result.successCount, 2);
-
-    // in-progress had 1 failure → watermark must be unchanged
-    assert.equal(
-      storage._watermarks.approvalDocuments!.groups["in-progress"].lastUpdatedAt,
-      "2026-04-29T00:00:00Z",
-    );
-    // done was clean → watermark advances to the observed max
     assert.equal(
       storage._watermarks.approvalDocuments!.groups["done"].lastUpdatedAt,
-      "2026-05-04T05:00:00Z",
+      "2026-04-29T00:00:00Z",
+      "any failure in the group blocks the watermark advance",
     );
   });
 
   it("treats an invalid watermark.lastUpdatedAt as bootstrap for that group", async () => {
     // Simulates a corrupted/hand-edited watermark file that survived
     // normalization (e.g., string field present but unparseable). The
-    // group must omit lastUpdatedDateRange so the run self-heals into a
-    // full crawl rather than aborting on RangeError.
+    // done group must omit lastUpdatedDateRange so the run self-heals
+    // into a full crawl rather than aborting on RangeError.
     const initial = {
       approvalDocuments: {
         groups: {
-          "in-progress": {
-            lastUpdatedAt: "garbage",
-            overlapDays: 1,
-            lastSuccessfulRunAt: "2026-04-30T00:00:00Z",
-          },
           done: {
-            lastUpdatedAt: "2026-04-25T00:00:00Z",
+            lastUpdatedAt: "garbage",
             overlapDays: 2,
             lastSuccessfulRunAt: "2026-04-30T00:00:00Z",
           },
@@ -400,14 +383,14 @@ describe("crawlInstances incremental wiring", () => {
     } as unknown as WatermarkFile;
 
     const search = new Map<string, SearchResp>([
+      ["IN_PROGRESS", { documents: [], total: 0, hasNext: false }],
       [
-        "IN_PROGRESS",
-        { documents: [{ document: { documentKey: "ip-ok" } }], total: 1, hasNext: false },
+        "CANCELED|DECLINED|DONE",
+        { documents: [{ document: { documentKey: "done-ok" } }], total: 1, hasNext: false },
       ],
-      ["CANCELED|DECLINED|DONE", { documents: [], total: 0, hasNext: false }],
     ]);
     const details = new Map<string, DetailResp>([
-      ["ip-ok", detailFor("ip-ok", "2026-05-05T01:00:00Z", "IN_PROGRESS")],
+      ["done-ok", detailFor("done-ok", "2026-05-05T01:00:00Z", "DONE")],
     ]);
     const { calls } = setupFetch(search, details);
 
@@ -415,13 +398,13 @@ describe("crawlInstances incremental wiring", () => {
     const result = await crawlInstances(makeAuth(), makeConfig(), null, storage, makeLogger());
 
     assert.equal(result.failureCount, 0);
-    const inProgressCall = calls.find(
+    const doneCall = calls.find(
       (c) =>
         c.url.includes("/user-boxes/search") &&
-        (c.body as { filter: { statuses: string[] } }).filter.statuses[0] === "IN_PROGRESS",
+        (c.body as { filter: { statuses: string[] } }).filter.statuses.includes("DONE"),
     );
-    assert.ok(inProgressCall);
-    const filter = (inProgressCall.body as { filter: Record<string, unknown> }).filter;
+    assert.ok(doneCall);
+    const filter = (doneCall.body as { filter: Record<string, unknown> }).filter;
     assert.ok(
       !("lastUpdatedDateRange" in filter),
       "invalid watermark must self-heal by omitting the date range",
@@ -429,7 +412,7 @@ describe("crawlInstances incremental wiring", () => {
     // After a clean run, the corrupted watermark is replaced with the
     // observed max — the file repairs itself.
     assert.equal(
-      storage._watermarks.approvalDocuments!.groups["in-progress"].lastUpdatedAt,
+      storage._watermarks.approvalDocuments!.groups["done"].lastUpdatedAt,
       "2026-05-05T01:00:00Z",
     );
   });
@@ -441,51 +424,46 @@ describe("crawlInstances incremental wiring", () => {
     const initial = {
       approvalDocuments: {
         groups: {
-          "in-progress": {
-            lastUpdatedAt: "2099-01-01T00:00:00Z",
-            overlapDays: 1,
-            lastSuccessfulRunAt: "2099-01-01T00:00:00Z",
-          },
           done: {
-            lastUpdatedAt: "2026-04-25T00:00:00Z",
+            lastUpdatedAt: "2099-01-01T00:00:00Z",
             overlapDays: 2,
-            lastSuccessfulRunAt: "2026-04-25T00:00:00Z",
+            lastSuccessfulRunAt: "2099-01-01T00:00:00Z",
           },
         },
       },
     } as WatermarkFile;
 
     const search = new Map<string, SearchResp>([
+      ["IN_PROGRESS", { documents: [], total: 0, hasNext: false }],
       [
-        "IN_PROGRESS",
-        { documents: [{ document: { documentKey: "ip-ok" } }], total: 1, hasNext: false },
+        "CANCELED|DECLINED|DONE",
+        { documents: [{ document: { documentKey: "done-ok" } }], total: 1, hasNext: false },
       ],
-      ["CANCELED|DECLINED|DONE", { documents: [], total: 0, hasNext: false }],
     ]);
     const details = new Map<string, DetailResp>([
-      ["ip-ok", detailFor("ip-ok", "2026-05-05T01:00:00Z", "IN_PROGRESS")],
+      ["done-ok", detailFor("done-ok", "2026-05-05T01:00:00Z", "DONE")],
     ]);
     const { calls } = setupFetch(search, details);
 
     const storage = makeStorage(initial);
     await crawlInstances(makeAuth(), makeConfig(), null, storage, makeLogger());
 
-    // in-progress had a bad watermark → group dropped at normalize → no
-    // lastUpdatedDateRange in the in-progress search.
-    const inProgressCall = calls.find(
+    // done had a bad watermark → group dropped at normalize → no
+    // lastUpdatedDateRange in the done search.
+    const doneCall = calls.find(
       (c) =>
         c.url.includes("/user-boxes/search") &&
-        (c.body as { filter: { statuses: string[] } }).filter.statuses[0] === "IN_PROGRESS",
+        (c.body as { filter: { statuses: string[] } }).filter.statuses.includes("DONE"),
     );
-    assert.ok(inProgressCall);
-    const filter = (inProgressCall.body as { filter: Record<string, unknown> }).filter;
+    assert.ok(doneCall);
+    const filter = (doneCall.body as { filter: Record<string, unknown> }).filter;
     assert.ok(
       !("lastUpdatedDateRange" in filter),
       "future watermark must self-heal by omitting the date range",
     );
     // Watermark replaced by the freshly observed value.
     assert.equal(
-      storage._watermarks.approvalDocuments!.groups["in-progress"].lastUpdatedAt,
+      storage._watermarks.approvalDocuments!.groups["done"].lastUpdatedAt,
       "2026-05-05T01:00:00Z",
     );
   });
@@ -517,23 +495,23 @@ describe("crawlInstances incremental wiring", () => {
     const initial: WatermarkFile = {
       approvalDocuments: {
         groups: {
-          "in-progress": {
+          done: {
             lastUpdatedAt: "2026-04-29T12:17:44Z",
-            overlapDays: 1,
+            overlapDays: 2,
             lastSuccessfulRunAt: "2026-04-29T12:17:44Z",
           },
         },
       },
     };
     const search = new Map<string, SearchResp>([
+      ["IN_PROGRESS", { documents: [], total: 0, hasNext: false }],
       [
-        "IN_PROGRESS",
+        "CANCELED|DECLINED|DONE",
         { documents: [{ document: { documentKey: "ms-doc" } }], total: 1, hasNext: false },
       ],
-      ["CANCELED|DECLINED|DONE", { documents: [], total: 0, hasNext: false }],
     ]);
     const details = new Map<string, DetailResp>([
-      ["ms-doc", detailFor("ms-doc", "2026-04-29T12:17:44.500Z", "IN_PROGRESS")],
+      ["ms-doc", detailFor("ms-doc", "2026-04-29T12:17:44.500Z", "DONE")],
     ]);
     setupFetch(search, details);
 
@@ -541,7 +519,7 @@ describe("crawlInstances incremental wiring", () => {
     await crawlInstances(makeAuth(), makeConfig(), null, storage, makeLogger());
 
     assert.equal(
-      storage._watermarks.approvalDocuments!.groups["in-progress"].lastUpdatedAt,
+      storage._watermarks.approvalDocuments!.groups["done"].lastUpdatedAt,
       "2026-04-29T12:17:44.500Z",
       "candidate is later in time and must replace the watermark",
     );
@@ -551,9 +529,9 @@ describe("crawlInstances incremental wiring", () => {
     const initial: WatermarkFile = {
       approvalDocuments: {
         groups: {
-          "in-progress": {
+          done: {
             lastUpdatedAt: "2026-04-29T12:00:00Z",
-            overlapDays: 1,
+            overlapDays: 2,
             lastSuccessfulRunAt: "2026-04-30T00:00:00Z",
           },
         },
@@ -569,7 +547,7 @@ describe("crawlInstances incremental wiring", () => {
     const before = Date.now();
     await crawlInstances(makeAuth(), makeConfig(), null, storage, makeLogger());
 
-    const wm = storage._watermarks.approvalDocuments!.groups["in-progress"];
+    const wm = storage._watermarks.approvalDocuments!.groups["done"];
     assert.equal(wm.lastUpdatedAt, "2026-04-29T12:00:00Z", "lastUpdatedAt must be preserved");
     assert.ok(wm.lastSuccessfulRunAt, "lastSuccessfulRunAt must be set");
     const stamped = Date.parse(wm.lastSuccessfulRunAt!);
@@ -763,23 +741,23 @@ describe("crawlInstances incremental wiring", () => {
     const initial: WatermarkFile = {
       approvalDocuments: {
         groups: {
-          "in-progress": {
+          done: {
             lastUpdatedAt: "2026-05-01T00:00:00Z",
-            overlapDays: 1,
+            overlapDays: 2,
             lastSuccessfulRunAt: "2026-05-01T00:00:00Z",
           },
         },
       },
     };
     const search = new Map<string, SearchResp>([
+      ["IN_PROGRESS", { documents: [], total: 0, hasNext: false }],
       [
-        "IN_PROGRESS",
+        "CANCELED|DECLINED|DONE",
         { documents: [{ document: { documentKey: "old-doc" } }], total: 1, hasNext: false },
       ],
-      ["CANCELED|DECLINED|DONE", { documents: [], total: 0, hasNext: false }],
     ]);
     const details = new Map<string, DetailResp>([
-      ["old-doc", detailFor("old-doc", "2026-04-01T00:00:00Z", "IN_PROGRESS")],
+      ["old-doc", detailFor("old-doc", "2026-04-01T00:00:00Z", "DONE")],
     ]);
     setupFetch(search, details);
 
@@ -787,8 +765,62 @@ describe("crawlInstances incremental wiring", () => {
     await crawlInstances(makeAuth(), makeConfig(), null, storage, makeLogger());
 
     assert.equal(
-      storage._watermarks.approvalDocuments!.groups["in-progress"].lastUpdatedAt,
+      storage._watermarks.approvalDocuments!.groups["done"].lastUpdatedAt,
       "2026-05-01T00:00:00Z",
+    );
+  });
+
+  it("always sweeps in-progress without a date range and never persists a watermark for it", async () => {
+    // Even with a stale watermark file claiming an in-progress group
+    // entry (e.g. left over from before this policy or hand-edited),
+    // the search payload must omit lastUpdatedDateRange and the entry
+    // must not survive a clean run.
+    const initial: WatermarkFile = {
+      approvalDocuments: {
+        groups: {
+          "in-progress": {
+            lastUpdatedAt: "2026-04-29T00:00:00Z",
+            overlapDays: 1,
+            lastSuccessfulRunAt: "2026-04-29T00:00:00Z",
+          },
+        },
+      },
+    };
+    const search = new Map<string, SearchResp>([
+      [
+        "IN_PROGRESS",
+        { documents: [{ document: { documentKey: "ip-1" } }], total: 1, hasNext: false },
+      ],
+      ["CANCELED|DECLINED|DONE", { documents: [], total: 0, hasNext: false }],
+    ]);
+    const details = new Map<string, DetailResp>([
+      ["ip-1", detailFor("ip-1", "2026-05-05T01:00:00Z", "IN_PROGRESS")],
+    ]);
+    const { calls } = setupFetch(search, details);
+
+    const storage = makeStorage(initial);
+    await crawlInstances(makeAuth(), makeConfig(), null, storage, makeLogger());
+
+    const inProgressCall = calls.find(
+      (c) =>
+        c.url.includes("/user-boxes/search") &&
+        (c.body as { filter: { statuses: string[] } }).filter.statuses[0] === "IN_PROGRESS",
+    );
+    assert.ok(inProgressCall);
+    const filter = (inProgressCall.body as { filter: Record<string, unknown> }).filter;
+    assert.ok(
+      !("lastUpdatedDateRange" in filter),
+      "in-progress must always sweep without a date range",
+    );
+    // The stale entry from `initial` is left in place by the file's
+    // shape (we don't actively delete it), but a successful sweep must
+    // not advance lastSuccessfulRunAt for it — that's the only externally
+    // visible signal that the policy is in effect.
+    const wmIp = storage._watermarks.approvalDocuments?.groups["in-progress"];
+    assert.equal(
+      wmIp?.lastSuccessfulRunAt,
+      "2026-04-29T00:00:00Z",
+      "in-progress watermark must not be touched by the sweep",
     );
   });
 });

--- a/apps/flex-cli/src/crawlers/instance.test.ts
+++ b/apps/flex-cli/src/crawlers/instance.test.ts
@@ -835,6 +835,13 @@ describe("crawlInstances incremental wiring", () => {
     const result = await crawlInstances(makeAuth(), config, null, storage, makeLogger());
 
     assert.equal(result.closedSweepCount, 1, "only d-fresh-1 should be swept");
+    // success + failure must not exceed totalCount; the sweep counts
+    // attempted candidates into total just like main search counts new
+    // search hits, so the unified counter stays consistent.
+    assert.ok(
+      result.successCount + result.failureCount <= result.totalCount,
+      `counters inconsistent: success=${result.successCount} failure=${result.failureCount} total=${result.totalCount}`,
+    );
     // d-fresh-2 was collected by main search; sweep must not double-fetch
     assert.equal(
       storage._instances.filter((i) => i.id === "d-fresh-2").length,

--- a/apps/flex-cli/src/crawlers/instance.test.ts
+++ b/apps/flex-cli/src/crawlers/instance.test.ts
@@ -858,6 +858,73 @@ describe("crawlInstances incremental wiring", () => {
     assert.ok(!storage._instances.some((i) => i.id === "d-in-progress"));
   });
 
+  it("preserves prior attachment metadata (localPath etc.) when sweeping", async () => {
+    // The sweep refetches detail to pick up late comments, but
+    // attachments themselves rarely change at that point. mapInstance
+    // can only reconstruct fileName from the detail response, so any
+    // prior localPath / fileSize / mimeType must be merged back in by
+    // fileName so the importer keeps writing real local_path values.
+    const within = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString();
+    const prior: WorkflowInstance = {
+      id: "d-fresh",
+      documentNumber: "d-fresh",
+      templateId: "t",
+      templateName: "t",
+      drafter: { id: "u", name: "n" },
+      draftedAt: within,
+      lastUpdatedAt: within,
+      signatureHash: "old-hash",
+      status: "DONE",
+      approvalLine: [],
+      fields: [],
+      attachments: [
+        {
+          fileName: "report.pdf",
+          localPath: "/cache/d-fresh/report.pdf",
+          fileSize: 12345,
+          mimeType: "application/pdf",
+        },
+      ],
+    };
+    const closedDocs = new Map<string, WorkflowInstance>([["d-fresh", prior]]);
+    const search = new Map<string, SearchResp>([
+      ["IN_PROGRESS", { documents: [], total: 0, hasNext: false }],
+      ["CANCELED|DECLINED|DONE", { documents: [], total: 0, hasNext: false }],
+    ]);
+    const detailWithSameAttachment: DetailResp = {
+      ...detailFor("d-fresh", within, "DONE"),
+    };
+    detailWithSameAttachment.document = {
+      ...detailWithSameAttachment.document,
+    };
+    // Inject the same fileName on the detail's attachments so the merge
+    // path actually fires. (detailFor doesn't include attachments by default.)
+    (detailWithSameAttachment.document as unknown as { attachments: Array<{ idHash: string; file: { fileKey: string; fileName: string; downloadUrl: string } }> }).attachments = [
+      {
+        idHash: "att-1",
+        file: {
+          fileKey: "fk-1",
+          fileName: "report.pdf",
+          downloadUrl: "https://example.invalid/x",
+        },
+      },
+    ];
+    const details = new Map<string, DetailResp>([["d-fresh", detailWithSameAttachment]]);
+    setupFetch(search, details);
+
+    const config: Config = { ...makeConfig(), closedSweepDays: 30 };
+    const storage = makeStorage({}, new Set(["d-fresh"]), closedDocs);
+    await crawlInstances(makeAuth(), config, null, storage, makeLogger());
+
+    const saved = storage._instances.find((i) => i.id === "d-fresh");
+    assert.ok(saved, "d-fresh must be saved by the sweep");
+    const att = saved.attachments[0];
+    assert.equal(att.fileName, "report.pdf");
+    assert.equal(att.localPath, "/cache/d-fresh/report.pdf", "localPath must be carried over from prior");
+    assert.equal(att.fileSize, 12345, "fileSize must be carried over from prior");
+    assert.equal(att.mimeType, "application/pdf", "mimeType must be carried over from prior");
+  });
+
   it("disables closed-window sweep when closedSweepDays=0", async () => {
     const within = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString();
     const closedDocs = new Map<string, WorkflowInstance>([

--- a/apps/flex-cli/src/crawlers/instance.test.ts
+++ b/apps/flex-cli/src/crawlers/instance.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import type { AuthContext } from "../auth/index.js";
 import type { Config } from "../config/index.js";
 import type { Logger } from "../logger/index.js";
+import type { WorkflowInstance } from "../types/instance.js";
 import {
   normalizeWatermarkFile,
   type CrawlReport,
@@ -47,6 +48,7 @@ function makeConfig(): Config {
     skipEndpoints: [],
     customers: [],
     flexCrawlMode: "incremental",
+    closedSweepDays: 0, // tests opt in per-case
   };
 }
 
@@ -60,17 +62,19 @@ function makeLogger(): Logger {
 }
 
 interface FakeStorage extends StorageWriter {
-  _instances: unknown[];
+  _instances: WorkflowInstance[];
   _watermarks: WatermarkFile;
   _existingInstanceKeys: Set<string>;
+  _closedDocs: Map<string, WorkflowInstance>;
 }
 
 function makeStorage(
   initial: WatermarkFile = {},
   existingInstanceKeys: Set<string> = new Set(),
+  closedDocs: Map<string, WorkflowInstance> = new Map(),
 ): FakeStorage {
   let watermarks: WatermarkFile = structuredClone(initial);
-  const instances: unknown[] = [];
+  const instances: WorkflowInstance[] = [];
   const writer: FakeStorage = {
     saveTemplate: async () => {},
     saveInstance: async (i) => {
@@ -90,8 +94,10 @@ function makeStorage(
       watermarks = structuredClone(file);
     },
     listExistingInstanceKeys: async () => new Set(existingInstanceKeys),
+    readInstance: async (id) => closedDocs.get(id) ?? null,
     _instances: instances,
     _existingInstanceKeys: existingInstanceKeys,
+    _closedDocs: closedDocs,
     get _watermarks() {
       return watermarks;
     },
@@ -768,6 +774,148 @@ describe("crawlInstances incremental wiring", () => {
       storage._watermarks.approvalDocuments!.groups["done"].lastUpdatedAt,
       "2026-05-01T00:00:00Z",
     );
+  });
+
+  it("re-fetches recently-closed docs (closed-window sweep) and skips ones already collected", async () => {
+    // Disk has three closed docs:
+    //   - d-fresh-1: closed within window, not seen by main search → MUST sweep
+    //   - d-fresh-2: closed within window, ALREADY collected by main search → MUST skip (no double fetch)
+    //   - d-stale: closed outside window → MUST skip
+    // and one in-progress (must be ignored — it's the IN_PROGRESS sweep's job).
+    const now = Date.now();
+    const within = new Date(now - 10 * 24 * 60 * 60 * 1000).toISOString(); // 10d ago
+    const outside = new Date(now - 100 * 24 * 60 * 60 * 1000).toISOString(); // 100d ago
+
+    function closedInstance(id: string, updatedAt: string, status = "DONE"): WorkflowInstance {
+      return {
+        id,
+        documentNumber: id,
+        templateId: "tmpl",
+        templateName: "tmpl",
+        drafter: { id: "u", name: "n" },
+        draftedAt: updatedAt,
+        lastUpdatedAt: updatedAt,
+        status,
+        approvalLine: [],
+        fields: [],
+        attachments: [],
+      };
+    }
+
+    const closedDocs = new Map<string, WorkflowInstance>([
+      ["d-fresh-1", closedInstance("d-fresh-1", within, "DONE")],
+      ["d-fresh-2", closedInstance("d-fresh-2", within, "DECLINED")],
+      ["d-stale", closedInstance("d-stale", outside, "DONE")],
+      ["d-in-progress", closedInstance("d-in-progress", within, "IN_PROGRESS")],
+    ]);
+    const existingKeys = new Set(closedDocs.keys());
+
+    // Main search returns d-fresh-2 in the done group (it just got an
+    // updatedAt bump from a status comment cycle, hypothetically).
+    const search = new Map<string, SearchResp>([
+      ["IN_PROGRESS", { documents: [], total: 0, hasNext: false }],
+      [
+        "CANCELED|DECLINED|DONE",
+        { documents: [{ document: { documentKey: "d-fresh-2" } }], total: 1, hasNext: false },
+      ],
+    ]);
+    const details = new Map<string, DetailResp>([
+      ["d-fresh-1", detailFor("d-fresh-1", within, "DONE")],
+      ["d-fresh-2", detailFor("d-fresh-2", within, "DECLINED")],
+    ]);
+    setupFetch(search, details);
+
+    const config: Config = { ...makeConfig(), closedSweepDays: 30 };
+    const storage = makeStorage({}, existingKeys, closedDocs);
+    const result = await crawlInstances(makeAuth(), config, null, storage, makeLogger());
+
+    assert.equal(result.closedSweepCount, 1, "only d-fresh-1 should be swept");
+    // d-fresh-2 was collected by main search; sweep must not double-fetch
+    assert.equal(
+      storage._instances.filter((i) => i.id === "d-fresh-2").length,
+      1,
+      "d-fresh-2 must be saved exactly once",
+    );
+    // d-fresh-1 came in via sweep
+    assert.ok(
+      storage._instances.some((i) => i.id === "d-fresh-1"),
+      "d-fresh-1 must be in storage after sweep",
+    );
+    // d-stale and d-in-progress must NOT be touched
+    assert.ok(!storage._instances.some((i) => i.id === "d-stale"));
+    assert.ok(!storage._instances.some((i) => i.id === "d-in-progress"));
+  });
+
+  it("disables closed-window sweep when closedSweepDays=0", async () => {
+    const within = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString();
+    const closedDocs = new Map<string, WorkflowInstance>([
+      [
+        "d-fresh",
+        {
+          id: "d-fresh",
+          documentNumber: "d-fresh",
+          templateId: "tmpl",
+          templateName: "tmpl",
+          drafter: { id: "u", name: "n" },
+          draftedAt: within,
+          lastUpdatedAt: within,
+          status: "DONE",
+          approvalLine: [],
+          fields: [],
+          attachments: [],
+        },
+      ],
+    ]);
+    const search = new Map<string, SearchResp>([
+      ["IN_PROGRESS", { documents: [], total: 0, hasNext: false }],
+      ["CANCELED|DECLINED|DONE", { documents: [], total: 0, hasNext: false }],
+    ]);
+    setupFetch(search, new Map());
+
+    const config: Config = { ...makeConfig(), closedSweepDays: 0 };
+    const storage = makeStorage({}, new Set(["d-fresh"]), closedDocs);
+    const result = await crawlInstances(makeAuth(), config, null, storage, makeLogger());
+
+    assert.equal(result.closedSweepCount, 0);
+    assert.equal(storage._instances.length, 0);
+  });
+
+  it("skips closed-window sweep entirely when the list stage threw", async () => {
+    // Permanent search 500 → listStageOk=false → sweep must not run.
+    globalThis.fetch = (async (input: unknown) => {
+      const url = String(input);
+      if (url.includes("/user-boxes/search")) {
+        return new Response("server error", { status: 500 });
+      }
+      return new Response("not found", { status: 404 });
+    }) as typeof fetch;
+
+    const within = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString();
+    const closedDocs = new Map<string, WorkflowInstance>([
+      [
+        "d-fresh",
+        {
+          id: "d-fresh",
+          documentNumber: "d-fresh",
+          templateId: "tmpl",
+          templateName: "tmpl",
+          drafter: { id: "u", name: "n" },
+          draftedAt: within,
+          lastUpdatedAt: within,
+          status: "DONE",
+          approvalLine: [],
+          fields: [],
+          attachments: [],
+        },
+      ],
+    ]);
+
+    const config: Config = { ...makeConfig(), closedSweepDays: 30 };
+    const storage = makeStorage({}, new Set(["d-fresh"]), closedDocs);
+    const result = await crawlInstances(makeAuth(), config, null, storage, makeLogger());
+
+    assert.equal(result.closedSweepCount, 0);
+    assert.ok(result.errors.some((e) => e.target === "instance-list"));
   });
 
   it("always sweeps in-progress without a date range and never persists a watermark for it", async () => {

--- a/apps/flex-cli/src/crawlers/instance.test.ts
+++ b/apps/flex-cli/src/crawlers/instance.test.ts
@@ -886,6 +886,55 @@ describe("crawlInstances incremental wiring", () => {
     assert.equal(storage._instances.length, 0);
   });
 
+  it("surfaces a structured error when readInstance throws during sweep, but keeps sweeping the rest", async () => {
+    // Sibling docs: d-fresh-1 reads cleanly, d-fresh-2's metadata read
+    // throws (e.g. EACCES). The sweep must record the failure on errors,
+    // not silently skip it, and still proceed to fetch d-fresh-1.
+    const within = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString();
+    function inst(id: string): WorkflowInstance {
+      return {
+        id,
+        documentNumber: id,
+        templateId: "t",
+        templateName: "t",
+        drafter: { id: "u", name: "n" },
+        draftedAt: within,
+        lastUpdatedAt: within,
+        signatureHash: "h",
+        status: "DONE",
+        approvalLine: [],
+        fields: [],
+        attachments: [],
+      };
+    }
+    const closedDocs = new Map<string, WorkflowInstance>([
+      ["d-fresh-1", inst("d-fresh-1")],
+      // d-fresh-2 omitted from closedDocs map; readInstance below throws for it
+    ]);
+    const search = new Map<string, SearchResp>([
+      ["IN_PROGRESS", { documents: [], total: 0, hasNext: false }],
+      ["CANCELED|DECLINED|DONE", { documents: [], total: 0, hasNext: false }],
+    ]);
+    const details = new Map<string, DetailResp>([
+      ["d-fresh-1", detailFor("d-fresh-1", within, "DONE")],
+    ]);
+    setupFetch(search, details);
+
+    const config: Config = { ...makeConfig(), closedSweepDays: 30 };
+    const storage = makeStorage({}, new Set(["d-fresh-1", "d-fresh-2"]), closedDocs);
+    storage.readInstance = async (id) => {
+      if (id === "d-fresh-2") throw new Error("EACCES: permission denied");
+      return closedDocs.get(id) ?? null;
+    };
+
+    const result = await crawlInstances(makeAuth(), config, null, storage, makeLogger());
+
+    assert.equal(result.closedSweepCount, 1, "d-fresh-1 must still be swept");
+    const readErr = result.errors.find((e) => e.target === "instance-closed-sweep:d-fresh-2");
+    assert.ok(readErr, "EACCES on d-fresh-2 must surface as a structured error");
+    assert.match(readErr.message, /EACCES/);
+  });
+
   it("skips closed-window sweep entirely when the list stage threw", async () => {
     // Permanent search 500 → listStageOk=false → sweep must not run.
     globalThis.fetch = (async (input: unknown) => {
@@ -1093,6 +1142,39 @@ describe("computeSignatureHash", () => {
       }),
     );
     assert.notEqual(a, b);
+  });
+
+  it("uses epoch-ms compare for the comment max-stamp, not lexicographic", () => {
+    // Lexicographically `2026-04-30T00:00:00.500Z` < `2026-04-30T00:00:00Z`
+    // (ms form sorts before the trailing-Z form), but the ms form is later
+    // in time. If the signature picked the lex-max it would silently equal
+    // a later run that adds the ms-form stamp on top of the trailing-Z one.
+    const baseline = computeSignatureHash(
+      detail({
+        comments: [
+          {
+            idHash: "c1",
+            writer: { idHash: "u", name: "n" },
+            type: "COMMENT",
+            createdAt: "2026-04-30T00:00:00Z",
+          },
+        ],
+      }),
+    );
+    const withMsEdit = computeSignatureHash(
+      detail({
+        comments: [
+          {
+            idHash: "c1",
+            writer: { idHash: "u", name: "n" },
+            type: "COMMENT",
+            createdAt: "2026-04-30T00:00:00Z",
+            updatedAt: "2026-04-30T00:00:00.500Z",
+          },
+        ],
+      }),
+    );
+    assert.notEqual(baseline, withMsEdit);
   });
 
   it("does not depend on comment array order (sorted by idHash)", () => {

--- a/apps/flex-cli/src/crawlers/instance.ts
+++ b/apps/flex-cli/src/crawlers/instance.ts
@@ -326,10 +326,30 @@ async function sweepRecentlyClosed(
     return 0;
   }
 
+  // 메타 로드를 병렬화. 인스턴스 파일이 많을수록 순차 read는 매 cycle
+  // O(N) I/O로 누적된다.
+  const eligibleIds = [...existingKeys].filter((id) => !collectedKeys.has(id));
+  const loaded = await pooledMap(eligibleIds, config.concurrency, async (id) => {
+    try {
+      return { id, inst: await storage.readInstance(id) };
+    } catch (err) {
+      // readInstance는 ENOENT/JSON parse 실패만 null로 swallow하고 나머지는
+      // throw하기로 약속한다(권한/디스크 등). 한 파일 실패가 sweep 전체를
+      // abort시키지 않게 하되, 운영자가 알 수 있도록 errors에는 push.
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error(`closed sweep: 인스턴스 메타 로드 실패: ${id}`, { error: message });
+      result.errors.push({
+        target: `instance-closed-sweep:${id}`,
+        phase: "list-existing",
+        message,
+        timestamp: nowISO(),
+      });
+      return { id, inst: null };
+    }
+  });
+
   const candidates: string[] = [];
-  for (const id of existingKeys) {
-    if (collectedKeys.has(id)) continue;
-    const inst = await storage.readInstance(id).catch(() => null);
+  for (const { inst, id } of loaded) {
     if (!inst) continue;
     if (!CLOSED_STATUSES.has(inst.status)) continue;
     if (!inst.lastUpdatedAt) continue;
@@ -728,8 +748,12 @@ export function computeSignatureHash(detail: DocumentDetailResponse): string {
   let commentMaxStamp: string | null = null;
   for (const c of comments) {
     const stamp = c.updatedAt ?? c.createdAt;
-    if (stamp && (!commentMaxStamp || stamp > commentMaxStamp)) {
-      commentMaxStamp = stamp;
+    // Lexicographic compare on ISO strings is unsafe across `...00Z` vs
+    // `...00.500Z` mixes — use the same epoch-ms helper the watermark
+    // commit logic uses, so signature stays stable across millisecond
+    // formatting drift.
+    if (isLaterIso(stamp, commentMaxStamp)) {
+      commentMaxStamp = stamp ?? null;
     }
   }
   const commentIds = comments.map((c) => c.idHash).sort().join(",");

--- a/apps/flex-cli/src/crawlers/instance.ts
+++ b/apps/flex-cli/src/crawlers/instance.ts
@@ -363,6 +363,9 @@ async function sweepRecentlyClosed(
     logger.info("closed sweep: 윈도우 내 종결 문서 없음", { windowDays });
     return 0;
   }
+  // 메인 검색 단계의 카운터와 일관되게 — sweep도 "처리 시도한 doc 수"를
+  // totalCount에 더해야 success+failure ≤ total 불변량이 깨지지 않는다.
+  result.totalCount += candidates.length;
   logger.info("closed sweep 시작", { windowDays, candidates: candidates.length });
 
   const hasPathParam = /\{[^}]+\}/.test(detailBase);

--- a/apps/flex-cli/src/crawlers/instance.ts
+++ b/apps/flex-cli/src/crawlers/instance.ts
@@ -348,7 +348,7 @@ async function sweepRecentlyClosed(
     }
   });
 
-  const candidates: string[] = [];
+  const candidates: Array<{ id: string; prior: WorkflowInstance }> = [];
   for (const { inst, id } of loaded) {
     if (!inst) continue;
     if (!CLOSED_STATUSES.has(inst.status)) continue;
@@ -356,7 +356,7 @@ async function sweepRecentlyClosed(
     const ms = Date.parse(inst.lastUpdatedAt);
     if (!Number.isFinite(ms)) continue;
     if (ms < cutoffMs) continue;
-    candidates.push(id);
+    candidates.push({ id, prior: inst });
   }
 
   if (candidates.length === 0) {
@@ -371,7 +371,7 @@ async function sweepRecentlyClosed(
   const hasPathParam = /\{[^}]+\}/.test(detailBase);
   let sweptCount = 0;
 
-  await pooledMap(candidates, config.concurrency, async (docKey) => {
+  await pooledMap(candidates, config.concurrency, async ({ id: docKey, prior }) => {
     try {
       const detailUrl = hasPathParam
         ? detailBase.replace(/\{[^}]+\}/, docKey)
@@ -383,9 +383,15 @@ async function sweepRecentlyClosed(
       // 첨부는 이미 받았다고 가정하고 재다운로드 안 함 (sweep 비용 절감).
       // 댓글이 첨부 추가를 동반하는 케이스는 흔치 않고, 본문 변경은
       // updatedAt이 갱신되어 워터마크 search가 잡는다.
-      const attachments = (detail.document.attachments ?? []).map((att) => ({
-        fileName: att.file.fileName,
-      }));
+      // mapInstance는 detail 응답으로부터 fileName만 재구성할 수 있으므로,
+      // 기존에 저장된 instance가 보유한 localPath/fileSize/mimeType 같은
+      // 부가 메타는 fileName 매칭으로 이번 결과에 다시 채워준다 — 그렇지
+      // 않으면 sweep이 import 시 local_path를 NULL로 덮어쓰게 된다.
+      const priorByName = new Map(prior.attachments.map((a) => [a.fileName, a]));
+      const attachments = (detail.document.attachments ?? []).map((att) => {
+        const fallback = priorByName.get(att.file.fileName);
+        return fallback ?? { fileName: att.file.fileName };
+      });
       const instance = mapInstance(detail, attachments);
       await storage.saveInstance(instance);
       collectedKeys.add(docKey);

--- a/apps/flex-cli/src/crawlers/instance.ts
+++ b/apps/flex-cli/src/crawlers/instance.ts
@@ -384,13 +384,26 @@ async function sweepRecentlyClosed(
       // 댓글이 첨부 추가를 동반하는 케이스는 흔치 않고, 본문 변경은
       // updatedAt이 갱신되어 워터마크 search가 잡는다.
       // mapInstance는 detail 응답으로부터 fileName만 재구성할 수 있으므로,
-      // 기존에 저장된 instance가 보유한 localPath/fileSize/mimeType 같은
-      // 부가 메타는 fileName 매칭으로 이번 결과에 다시 채워준다 — 그렇지
-      // 않으면 sweep이 import 시 local_path를 NULL로 덮어쓰게 된다.
-      const priorByName = new Map(prior.attachments.map((a) => [a.fileName, a]));
+      // 기존 instance가 보유한 localPath/fileSize/mimeType 같은 부가 메타는
+      // fileKey 우선 매칭으로 이번 결과에 다시 채워준다. 같은 fileName 첨부
+      // 두 개가 다른 fileKey로 존재할 수 있으므로 fileName-only 매칭은
+      // mis-association 위험이 있다. fileKey가 어느 한쪽에라도 없을 때만
+      // fileName 폴백을 쓴다.
+      const priorRaw = prior._raw as
+        | { document?: { attachments?: Array<{ file?: { fileKey?: unknown } }> } }
+        | undefined;
+      const priorRawAtts = priorRaw?.document?.attachments ?? [];
+      const priorByFileKey = new Map<string, AttachmentInfo>();
+      const priorByFileName = new Map<string, AttachmentInfo>();
+      for (let i = 0; i < prior.attachments.length; i++) {
+        const meta = prior.attachments[i];
+        const fk = priorRawAtts[i]?.file?.fileKey;
+        if (typeof fk === "string") priorByFileKey.set(fk, meta);
+        priorByFileName.set(meta.fileName, meta);
+      }
       const attachments = (detail.document.attachments ?? []).map((att) => {
-        const fallback = priorByName.get(att.file.fileName);
-        return fallback ?? { fileName: att.file.fileName };
+        const byKey = att.file.fileKey ? priorByFileKey.get(att.file.fileKey) : undefined;
+        return byKey ?? priorByFileName.get(att.file.fileName) ?? { fileName: att.file.fileName };
       });
       const instance = mapInstance(detail, attachments);
       await storage.saveInstance(instance);

--- a/apps/flex-cli/src/crawlers/instance.ts
+++ b/apps/flex-cli/src/crawlers/instance.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { type AuthContext, apiHeaders } from "../auth/index.js";
 import type { Config } from "../config/index.js";
 import type { Logger } from "../logger/index.js";
@@ -604,7 +605,7 @@ interface SearchResponse {
   }>;
 }
 
-interface DocumentDetailResponse {
+export interface DocumentDetailResponse {
   document: {
     documentKey: string;
     code: string;
@@ -643,6 +644,7 @@ interface DocumentDetailResponse {
       content?: string;
       writtenBySystem?: boolean;
       createdAt: string;
+      updatedAt?: string;
     }>;
     createdAt?: string;
     updatedAt?: string;
@@ -695,6 +697,7 @@ function mapInstance(detail: DocumentDetailResponse, attachments: AttachmentInfo
     drafter: { id: doc.writer.idHash, name: doc.writer.name },
     draftedAt: doc.writtenAt,
     lastUpdatedAt: doc.updatedAt ?? null,
+    signatureHash: computeSignatureHash(detail),
     status: doc.status,
     approvalLine,
     fields,
@@ -706,6 +709,39 @@ function mapInstance(detail: DocumentDetailResponse, attachments: AttachmentInfo
     })),
     _raw: detail,
   };
+}
+
+/**
+ * 다운스트림 변경 감지용 sha1 hash. `document.updatedAt`이 댓글 mutation을
+ * 반영하지 않는 한계를 보완한다 — 같은 doc 두 번 fetch 시 댓글이 추가/수정/
+ * 삭제됐으면 hash가 바뀐다. 단순 `comments.length`만 비교하면 (i) 같은 cycle
+ * 내 add+delete (ii) 댓글 내용 수정만 발생, 두 케이스에서 false negative.
+ *
+ * Input shape (longfin's recommendation in planetarium/reflex#38):
+ *   document.updatedAt | document.status | approvalProcess.status |
+ *   comments.length | max(comments[].updatedAt ?? comments[].createdAt) |
+ *   sorted(comments[].idHash).join(",")
+ */
+export function computeSignatureHash(detail: DocumentDetailResponse): string {
+  const doc = detail.document;
+  const comments = doc.comments ?? [];
+  let commentMaxStamp: string | null = null;
+  for (const c of comments) {
+    const stamp = c.updatedAt ?? c.createdAt;
+    if (stamp && (!commentMaxStamp || stamp > commentMaxStamp)) {
+      commentMaxStamp = stamp;
+    }
+  }
+  const commentIds = comments.map((c) => c.idHash).sort().join(",");
+  const payload = JSON.stringify([
+    doc.updatedAt ?? null,
+    doc.status,
+    detail.approvalProcess?.status ?? null,
+    comments.length,
+    commentMaxStamp,
+    commentIds,
+  ]);
+  return createHash("sha1").update(payload).digest("hex");
 }
 
 async function processAttachments(

--- a/apps/flex-cli/src/crawlers/instance.ts
+++ b/apps/flex-cli/src/crawlers/instance.ts
@@ -60,18 +60,35 @@ export async function crawlInstances(
     "/api/v3/approval-document/approval-documents",
   );
 
+  // 결재 문서 댓글 mutation은 `document.updatedAt`을 갱신하지 않는다
+  // (planetarium/reflex#38 검증). 그래서 워터마크 검색만으로는 IN_PROGRESS
+  // 동안의 댓글 변화를 잡을 수 없다. IN_PROGRESS는 모집단이 작고 어차피 곧
+  // 상태 전이될 가능성이 높아 매 실행 전수 sweep이 안전하고 저렴하다.
+  // → incrementalEligible=false: dateRange 안 박고 그룹 워터마크도 안 만듦.
   const searchGroups: SearchGroup[] = [
-    { label: "in-progress", statuses: ["IN_PROGRESS"], defaultOverlapDays: 1 },
-    { label: "done", statuses: ["DONE", "DECLINED", "CANCELED"], defaultOverlapDays: 2 },
+    {
+      label: "in-progress",
+      statuses: ["IN_PROGRESS"],
+      defaultOverlapDays: 1,
+      incrementalEligible: false,
+    },
+    {
+      label: "done",
+      statuses: ["DONE", "DECLINED", "CANCELED"],
+      defaultOverlapDays: 2,
+      incrementalEligible: true,
+    },
   ];
 
   const watermarks = await storage.loadWatermarks();
   const domainState: WatermarkDomainState =
     watermarks[APPROVAL_DOCUMENTS_DOMAIN] ?? { groups: {} };
-  // 모든 그룹에 워터마크가 모두 비어 있다면 부트스트랩 — 사실상 풀크롤로 동작.
-  const noWatermarks = searchGroups.every(
-    (g) => !domainState.groups[g.label]?.lastUpdatedAt,
-  );
+  // incremental-eligible 그룹들에 워터마크가 모두 비어 있다면 부트스트랩 —
+  // 사실상 풀크롤. 비-eligible 그룹(IN_PROGRESS sweep)은 어차피 매 실행
+  // 전수 fetch라 effectiveFull 판정에서 제외한다.
+  const noWatermarks = searchGroups
+    .filter((g) => g.incrementalEligible)
+    .every((g) => !domainState.groups[g.label]?.lastUpdatedAt);
   const effectiveFull = mode === "full" || noWatermarks;
   if (mode === "incremental" && noWatermarks) {
     logger.info("워터마크 없음 — bootstrap 풀크롤로 진행");
@@ -111,9 +128,11 @@ export async function crawlInstances(
   try {
     for (const group of searchGroups) {
       const existing = domainState.groups[group.label];
-      const dateRange = effectiveFull
-        ? undefined
-        : computeDateRange(existing, group.defaultOverlapDays, todayKst);
+      // incrementalEligible=false 그룹은 워터마크/풀모드 무관 항상 전수 sweep.
+      const dateRange =
+        !group.incrementalEligible || effectiveFull
+          ? undefined
+          : computeDateRange(existing, group.defaultOverlapDays, todayKst);
 
       const groupSuccessBefore = result.successCount;
       const groupFailureBefore = result.failureCount;
@@ -135,10 +154,14 @@ export async function crawlInstances(
       const groupFailure = result.failureCount - groupFailureBefore;
 
       // 그룹 단위로 워터마크 갱신 정책:
+      //   - incrementalEligible=false 그룹은 워터마크 자체를 만들지/갱신하지 않음.
+      //     IN_PROGRESS sweep은 댓글 변화 흡수가 목적이라 워터마크가 무의미하고,
+      //     watermark.json에 entry를 남기면 다음 실행의 effectiveFull 판정도
+      //     흐려진다.
       //   - 그룹 내 실패가 단 1건이라도 있으면 갱신 보류 (다음 실행에서 재시도)
       //   - 후퇴 금지 — 새 max가 기존보다 작으면 기존 lastUpdatedAt 유지
       //   - 0건 처리됐어도 그룹 자체가 클린하게 끝났으면 lastSuccessfulRunAt은 갱신
-      if (groupFailure === 0) {
+      if (group.incrementalEligible && groupFailure === 0) {
         const prev = existing?.lastUpdatedAt ?? null;
         if (observedMaxUpdatedAt && isLaterIso(observedMaxUpdatedAt, prev)) {
           domainState.groups[group.label] = {
@@ -232,6 +255,14 @@ interface SearchGroup {
   label: string;
   statuses: string[];
   defaultOverlapDays: number;
+  /**
+   * true: 워터마크 기반 증분 검색(`lastUpdatedDateRange`) + 그룹별 워터마크
+   * 갱신을 적용한다.
+   * false: 매 실행 전수 sweep. 워터마크를 사용하지도, 만들지도 않는다.
+   * (예: IN_PROGRESS — 댓글 mutation이 `document.updatedAt`을 안 건드려서
+   * 워터마크 검색만으로는 댓글 변화를 흡수 못 함)
+   */
+  incrementalEligible: boolean;
 }
 
 function computeDateRange(

--- a/apps/flex-cli/src/crawlers/instance.ts
+++ b/apps/flex-cli/src/crawlers/instance.ts
@@ -40,7 +40,11 @@ export async function crawlInstances(
   logger: Logger,
   mode: CrawlMode = "incremental",
 ): Promise<
-  CrawlResult & { collectedKeys: Set<string>; missingKeys: string[] }
+  CrawlResult & {
+    collectedKeys: Set<string>;
+    missingKeys: string[];
+    closedSweepCount: number;
+  }
 > {
   const startTime = Date.now();
   const result = emptyCrawlResult();
@@ -48,6 +52,8 @@ export async function crawlInstances(
   // full recon이 아닐 땐 의미가 없으므로 비워둔다 (incremental은 변경된
   // 문서만 재방문하니 disk-vs-collected diff는 거짓양성 폭증).
   let missingKeys: string[] = [];
+  // 종결 문서 closed-window sweep에서 재조회한 건 수 (informational).
+  let closedSweepCount = 0;
 
   logger.info("인스턴스(결재 문서) 수집 시작", { mode });
 
@@ -200,6 +206,21 @@ export async function crawlInstances(
     });
   }
 
+  // 종결 후 N일 윈도우 sweep — 댓글 mutation은 `document.updatedAt`을 갱신
+  // 하지 않아 워터마크 검색이 종결 후의 댓글 변화를 흡수할 수 없다. list 단계가
+  // 정상 종료된 경우에만 진행 (list가 깨지면 어차피 신뢰할 수 없는 cycle).
+  if (listStageOk && config.closedSweepDays > 0) {
+    closedSweepCount = await sweepRecentlyClosed(
+      authCtx,
+      config,
+      storage,
+      logger,
+      detailBase,
+      collectedKeys,
+      result,
+    );
+  }
+
   // 사실상 풀크롤로 돌았고 list 단계가 끝까지 살아남았으며 인스턴스 단계에
   // 단 1건의 실패도 없었을 때만 lastFullReconAt 갱신. 실패/list-throw가 섞이면
   // "전체 recon 완료" 의미가 흐려지므로, 후속 cadence-기반 자동 풀크롤
@@ -248,7 +269,7 @@ export async function crawlInstances(
 
   result.durationMs = Date.now() - startTime;
   logger.info(`\n인스턴스 수집 완료: 성공 ${result.successCount}, 실패 ${result.failureCount}`);
-  return { ...result, collectedKeys, missingKeys };
+  return { ...result, collectedKeys, missingKeys, closedSweepCount };
 }
 
 interface SearchGroup {
@@ -263,6 +284,109 @@ interface SearchGroup {
    * 워터마크 검색만으로는 댓글 변화를 흡수 못 함)
    */
   incrementalEligible: boolean;
+}
+
+const CLOSED_STATUSES = new Set(["DONE", "DECLINED", "CANCELED"]);
+
+/**
+ * 디스크에 저장된 종결 문서 중 종결된 지 N일 이내인 것들을 detail 재조회로
+ * sweep한다. 댓글 mutation은 `document.updatedAt`을 갱신하지 않으므로
+ * 워터마크 검색만으론 종결 후 댓글 변화를 흡수할 수 없다. 종결 직후 일정
+ * 시간 안에 달리는 댓글이 거의 전부이므로 N일(기본 30) 윈도우면 실무상
+ * 충분하고, 더 오래된 doc은 acceptance criteria에 한계로 명시한다.
+ *
+ * 이미 같은 cycle에서 search → detail로 잡힌 doc(`collectedKeys.has`)은
+ * 중복 fetch를 피하기 위해 skip한다.
+ */
+async function sweepRecentlyClosed(
+  authCtx: AuthContext,
+  config: Config,
+  storage: StorageWriter,
+  logger: Logger,
+  detailBase: string,
+  collectedKeys: Set<string>,
+  result: CrawlResult,
+): Promise<number> {
+  const windowDays = config.closedSweepDays;
+  const cutoffMs = Date.now() - windowDays * MS_PER_DAY;
+
+  let existingKeys: Set<string>;
+  try {
+    existingKeys = await storage.listExistingInstanceKeys();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error("closed sweep: 디스크 enumerate 실패 — sweep 생략", { error: message });
+    result.errors.push({
+      target: "instance-closed-sweep",
+      phase: "list-existing",
+      message,
+      timestamp: nowISO(),
+    });
+    return 0;
+  }
+
+  const candidates: string[] = [];
+  for (const id of existingKeys) {
+    if (collectedKeys.has(id)) continue;
+    const inst = await storage.readInstance(id).catch(() => null);
+    if (!inst) continue;
+    if (!CLOSED_STATUSES.has(inst.status)) continue;
+    if (!inst.lastUpdatedAt) continue;
+    const ms = Date.parse(inst.lastUpdatedAt);
+    if (!Number.isFinite(ms)) continue;
+    if (ms < cutoffMs) continue;
+    candidates.push(id);
+  }
+
+  if (candidates.length === 0) {
+    logger.info("closed sweep: 윈도우 내 종결 문서 없음", { windowDays });
+    return 0;
+  }
+  logger.info("closed sweep 시작", { windowDays, candidates: candidates.length });
+
+  const hasPathParam = /\{[^}]+\}/.test(detailBase);
+  let sweptCount = 0;
+
+  await pooledMap(candidates, config.concurrency, async (docKey) => {
+    try {
+      const detailUrl = hasPathParam
+        ? detailBase.replace(/\{[^}]+\}/, docKey)
+        : `${detailBase}/${docKey}`;
+      const detail = await withRetry(
+        () => flexFetch<DocumentDetailResponse>(authCtx, detailUrl),
+        { maxRetries: config.maxRetries, delayMs: config.requestDelayMs },
+      );
+      // 첨부는 이미 받았다고 가정하고 재다운로드 안 함 (sweep 비용 절감).
+      // 댓글이 첨부 추가를 동반하는 케이스는 흔치 않고, 본문 변경은
+      // updatedAt이 갱신되어 워터마크 search가 잡는다.
+      const attachments = (detail.document.attachments ?? []).map((att) => ({
+        fileName: att.file.fileName,
+      }));
+      const instance = mapInstance(detail, attachments);
+      await storage.saveInstance(instance);
+      collectedKeys.add(docKey);
+      result.successCount++;
+      sweptCount++;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      result.failureCount++;
+      result.errors.push({
+        target: `instance-closed-sweep:${docKey}`,
+        phase: "detail",
+        message,
+        timestamp: nowISO(),
+      });
+      logger.error(`closed sweep 실패: ${docKey}`, { error: message });
+    }
+  });
+
+  logger.info("closed sweep 완료", {
+    windowDays,
+    candidates: candidates.length,
+    swept: sweptCount,
+    failed: candidates.length - sweptCount,
+  });
+  return sweptCount;
 }
 
 function computeDateRange(

--- a/apps/flex-cli/src/db/import.ts
+++ b/apps/flex-cli/src/db/import.ts
@@ -90,8 +90,8 @@ export async function importToSqlite(
       INSERT OR IGNORE INTO templates (id, name) VALUES (?, ?)
     `),
     instance: db.prepare(`
-      INSERT OR REPLACE INTO instances (id, document_number, template_id, drafter_id, drafted_at, last_updated_at, status, content_html, raw)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT OR REPLACE INTO instances (id, document_number, template_id, drafter_id, drafted_at, last_updated_at, signature_hash, status, content_html, raw)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `),
     fieldValue: db.prepare(`
       INSERT OR REPLACE INTO field_values (instance_id, field_name, field_type, value_text, value_number, value_date, currency)
@@ -274,6 +274,7 @@ function importInstance(
     drafter?.id ?? null,
     data.draftedAt,
     data.lastUpdatedAt ?? doc?.updatedAt ?? null,
+    data.signatureHash ?? null,
     data.status,
     (doc?.content as string) ?? null,
     JSON.stringify(raw ?? null),
@@ -392,11 +393,18 @@ function runMigrations(db: Database): void {
   const instanceCols = db
     .query("PRAGMA table_info(instances)")
     .all() as { name: string }[];
-  if (!instanceCols.some((c) => c.name === "last_updated_at")) {
+  const hasCol = (name: string) => instanceCols.some((c) => c.name === name);
+  if (!hasCol("last_updated_at")) {
     db.exec("ALTER TABLE instances ADD COLUMN last_updated_at TEXT");
+  }
+  if (!hasCol("signature_hash")) {
+    db.exec("ALTER TABLE instances ADD COLUMN signature_hash TEXT");
   }
   db.exec(
     "CREATE INDEX IF NOT EXISTS idx_instances_last_updated_at ON instances(last_updated_at DESC)",
+  );
+  db.exec(
+    "CREATE INDEX IF NOT EXISTS idx_instances_signature_hash ON instances(signature_hash)",
   );
 }
 

--- a/apps/flex-cli/src/db/schema.sql
+++ b/apps/flex-cli/src/db/schema.sql
@@ -54,6 +54,7 @@ CREATE TABLE IF NOT EXISTS instances (
   drafter_id      TEXT REFERENCES users(id),
   drafted_at      TEXT NOT NULL,          -- [PG] → TIMESTAMPTZ
   last_updated_at TEXT,                   -- [PG] → TIMESTAMPTZ, flex document.updatedAt
+  signature_hash  TEXT,                   -- 변경 감지 sha1 (comments + status + updatedAt 등)
   status          TEXT NOT NULL,
   content_html    TEXT,
   raw             TEXT                    -- [PG] → JSONB
@@ -64,10 +65,11 @@ CREATE INDEX IF NOT EXISTS idx_instances_drafter         ON instances(drafter_id
 CREATE INDEX IF NOT EXISTS idx_instances_drafted_at      ON instances(drafted_at);
 CREATE INDEX IF NOT EXISTS idx_instances_status          ON instances(status);
 CREATE INDEX IF NOT EXISTS idx_instances_doc_number      ON instances(document_number);
--- idx_instances_last_updated_at: see runMigrations() in import.ts. The index
--- depends on a column that was added after the initial schema, so creating it
--- here would abort `db.exec(schemaSql)` on older DB files where the column
--- has not yet been ALTERed in.
+-- idx_instances_last_updated_at / idx_instances_signature_hash: see
+-- runMigrations() in import.ts. These indexes depend on columns that were
+-- added after the initial schema, so creating them here would abort
+-- `db.exec(schemaSql)` on older DB files where the column has not yet been
+-- ALTERed in.
 
 -- ============================================================
 -- 필드값 (EAV)

--- a/apps/flex-cli/src/storage/index.test.ts
+++ b/apps/flex-cli/src/storage/index.test.ts
@@ -220,6 +220,54 @@ describe("createStorageWriter listExistingInstanceKeys", () => {
   });
 });
 
+describe("createStorageWriter readInstance", () => {
+  it("returns null for a missing file (ENOENT)", async () => {
+    const dir = await tmpStorageDir();
+    const writer = createStorageWriter(dir, path.join(dir, "catalog.json"));
+    assert.equal(await writer.readInstance("does-not-exist"), null);
+  });
+
+  it("returns null when JSON is malformed", async () => {
+    const dir = await tmpStorageDir();
+    await mkdir(path.join(dir, "instances"));
+    await writeFile(path.join(dir, "instances", "bad.json"), "{ not json", "utf-8");
+    const writer = createStorageWriter(dir, path.join(dir, "catalog.json"));
+    assert.equal(await writer.readInstance("bad"), null);
+  });
+
+  it("normalizes legacy on-disk shapes that pre-date later columns", async () => {
+    // An instance JSON written before signatureHash / lastUpdatedAt /
+    // attachments existed must still come back with those slots filled
+    // in (as null / []), not undefined, so downstream null-checks and
+    // .length reads don't fault.
+    const dir = await tmpStorageDir();
+    await mkdir(path.join(dir, "instances"));
+    const legacy = {
+      id: "old",
+      documentNumber: "old-1",
+      templateId: "t",
+      templateName: "t",
+      drafter: { id: "u", name: "n" },
+      draftedAt: "2025-01-01T00:00:00Z",
+      status: "DONE",
+      // signatureHash, lastUpdatedAt, attachments, fields, approvalLine all absent
+    };
+    await writeFile(
+      path.join(dir, "instances", "old.json"),
+      JSON.stringify(legacy),
+      "utf-8",
+    );
+    const writer = createStorageWriter(dir, path.join(dir, "catalog.json"));
+    const inst = await writer.readInstance("old");
+    assert.ok(inst);
+    assert.equal(inst.signatureHash, null);
+    assert.equal(inst.lastUpdatedAt, null);
+    assert.deepEqual(inst.attachments, []);
+    assert.deepEqual(inst.fields, []);
+    assert.deepEqual(inst.approvalLine, []);
+  });
+});
+
 describe("createStorageWriter loadWatermarks", () => {
   it("returns {} when watermark.json is missing (ENOENT)", async () => {
     const dir = await tmpStorageDir();

--- a/apps/flex-cli/src/storage/index.test.ts
+++ b/apps/flex-cli/src/storage/index.test.ts
@@ -235,6 +235,34 @@ describe("createStorageWriter readInstance", () => {
     assert.equal(await writer.readInstance("bad"), null);
   });
 
+  it("backfills lastUpdatedAt from _raw.document.updatedAt when the top-level field is absent", async () => {
+    // Pre-PR#51 instance JSONs lack `lastUpdatedAt` at the top level
+    // but still carry `_raw.document.updatedAt`. closed-window sweep
+    // depends on the top-level field, so without backfill it would
+    // skip every legacy-shape doc forever.
+    const dir = await tmpStorageDir();
+    await mkdir(path.join(dir, "instances"));
+    const legacy = {
+      id: "old",
+      documentNumber: "old-1",
+      templateId: "t",
+      templateName: "t",
+      drafter: { id: "u", name: "n" },
+      draftedAt: "2025-01-01T00:00:00Z",
+      status: "DONE",
+      _raw: { document: { updatedAt: "2025-01-02T03:04:05Z" } },
+    };
+    await writeFile(
+      path.join(dir, "instances", "old.json"),
+      JSON.stringify(legacy),
+      "utf-8",
+    );
+    const writer = createStorageWriter(dir, path.join(dir, "catalog.json"));
+    const inst = await writer.readInstance("old");
+    assert.ok(inst);
+    assert.equal(inst.lastUpdatedAt, "2025-01-02T03:04:05Z");
+  });
+
   it("normalizes legacy on-disk shapes that pre-date later columns", async () => {
     // An instance JSON written before signatureHash / lastUpdatedAt /
     // attachments existed must still come back with those slots filled

--- a/apps/flex-cli/src/storage/index.test.ts
+++ b/apps/flex-cli/src/storage/index.test.ts
@@ -235,6 +235,20 @@ describe("createStorageWriter readInstance", () => {
     assert.equal(await writer.readInstance("bad"), null);
   });
 
+  it("returns null when the parsed object lacks required fields", async () => {
+    const dir = await tmpStorageDir();
+    await mkdir(path.join(dir, "instances"));
+    // missing id, status, drafter — type-laundering this into a
+    // WorkflowInstance would let downstream code fault on undefined.
+    await writeFile(
+      path.join(dir, "instances", "broken.json"),
+      JSON.stringify({ documentNumber: "x", templateId: "t" }),
+      "utf-8",
+    );
+    const writer = createStorageWriter(dir, path.join(dir, "catalog.json"));
+    assert.equal(await writer.readInstance("broken"), null);
+  });
+
   it("backfills lastUpdatedAt from _raw.document.updatedAt when the top-level field is absent", async () => {
     // Pre-PR#51 instance JSONs lack `lastUpdatedAt` at the top level
     // but still carry `_raw.document.updatedAt`. closed-window sweep

--- a/apps/flex-cli/src/storage/index.ts
+++ b/apps/flex-cli/src/storage/index.ts
@@ -72,6 +72,11 @@ export interface StorageWriter {
    * 디렉토리가 없으면 빈 set. full reconciliation diff 계산에 쓰인다.
    */
   listExistingInstanceKeys(): Promise<Set<string>>;
+  /**
+   * 저장된 단일 인스턴스 JSON을 읽는다. 없거나 파싱 실패면 null.
+   * closed-window sweep이 status / lastUpdatedAt 메타만 보기 위해 사용한다.
+   */
+  readInstance(id: string): Promise<WorkflowInstance | null>;
 }
 
 async function ensureDir(dir: string): Promise<void> {
@@ -231,6 +236,23 @@ export function createStorageWriter(outputDir: string, catalogPath: string): Sto
 
     async saveWatermarks(file) {
       await writeJson(path.join(outputDir, "watermark.json"), file);
+    },
+
+    async readInstance(id) {
+      const safeId = path.basename(id);
+      const filePath = path.join(outputDir, "instances", `${safeId}.json`);
+      let content: string;
+      try {
+        content = await readFile(filePath, "utf-8");
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+        throw err;
+      }
+      try {
+        return JSON.parse(content) as WorkflowInstance;
+      } catch {
+        return null;
+      }
     },
 
     async listExistingInstanceKeys() {

--- a/apps/flex-cli/src/storage/index.ts
+++ b/apps/flex-cli/src/storage/index.ts
@@ -261,7 +261,15 @@ export function createStorageWriter(outputDir: string, catalogPath: string): Sto
       // 채워 옛 파일도 새 shape에 맞게 읽히도록 한다.
       const obj = parsed as Record<string, unknown>;
       if (obj.signatureHash === undefined) obj.signatureHash = null;
-      if (obj.lastUpdatedAt === undefined) obj.lastUpdatedAt = null;
+      if (obj.lastUpdatedAt === undefined) {
+        // PR #51 이전 인스턴스 JSON엔 top-level lastUpdatedAt이 없지만
+        // `_raw.document.updatedAt`은 보존되어 있다. 이걸 채우지 않으면
+        // closed-window sweep이 옛 데이터에 한해선 영영 후보를 못 만든다.
+        // import.ts도 같은 폴백 패턴(data.lastUpdatedAt ?? doc.updatedAt)을 쓴다.
+        const raw = obj._raw as { document?: { updatedAt?: unknown } } | undefined;
+        const rawUpdatedAt = raw?.document?.updatedAt;
+        obj.lastUpdatedAt = typeof rawUpdatedAt === "string" ? rawUpdatedAt : null;
+      }
       if (!Array.isArray(obj.attachments)) obj.attachments = [];
       if (!Array.isArray(obj.fields)) obj.fields = [];
       if (!Array.isArray(obj.approvalLine)) obj.approvalLine = [];

--- a/apps/flex-cli/src/storage/index.ts
+++ b/apps/flex-cli/src/storage/index.ts
@@ -255,11 +255,15 @@ export function createStorageWriter(outputDir: string, catalogPath: string): Sto
         return null;
       }
       if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+      const obj = parsed as Record<string, unknown>;
+      // 필수 필드 검증 — 누락/타입 불일치면 type-cast로 거짓말하지 말고 null
+      // 반환. 호출자(closed-window sweep 등)는 이미 null을 정상 처리한다.
+      if (typeof obj.id !== "string" || obj.id.length === 0) return null;
+      if (typeof obj.status !== "string") return null;
       // 정규화 — instance JSON이 디스크에 쓰일 당시 schema에 없던 필드는
       // undefined로 들어오는데, 캐스트만 하면 type system은 이를 모르고
       // downstream의 null 비교가 어긋난다. 누락 필드를 명시적인 기본값으로
       // 채워 옛 파일도 새 shape에 맞게 읽히도록 한다.
-      const obj = parsed as Record<string, unknown>;
       if (obj.signatureHash === undefined) obj.signatureHash = null;
       if (obj.lastUpdatedAt === undefined) {
         // PR #51 이전 인스턴스 JSON엔 top-level lastUpdatedAt이 없지만

--- a/apps/flex-cli/src/storage/index.ts
+++ b/apps/flex-cli/src/storage/index.ts
@@ -248,11 +248,24 @@ export function createStorageWriter(outputDir: string, catalogPath: string): Sto
         if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
         throw err;
       }
+      let parsed: unknown;
       try {
-        return JSON.parse(content) as WorkflowInstance;
+        parsed = JSON.parse(content);
       } catch {
         return null;
       }
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+      // 정규화 — instance JSON이 디스크에 쓰일 당시 schema에 없던 필드는
+      // undefined로 들어오는데, 캐스트만 하면 type system은 이를 모르고
+      // downstream의 null 비교가 어긋난다. 누락 필드를 명시적인 기본값으로
+      // 채워 옛 파일도 새 shape에 맞게 읽히도록 한다.
+      const obj = parsed as Record<string, unknown>;
+      if (obj.signatureHash === undefined) obj.signatureHash = null;
+      if (obj.lastUpdatedAt === undefined) obj.lastUpdatedAt = null;
+      if (!Array.isArray(obj.attachments)) obj.attachments = [];
+      if (!Array.isArray(obj.fields)) obj.fields = [];
+      if (!Array.isArray(obj.approvalLine)) obj.approvalLine = [];
+      return obj as unknown as WorkflowInstance;
     },
 
     async listExistingInstanceKeys() {

--- a/apps/flex-cli/src/types/instance.ts
+++ b/apps/flex-cli/src/types/instance.ts
@@ -15,6 +15,14 @@ export interface WorkflowInstance {
   drafter: UserInfo;
   draftedAt: string;
   lastUpdatedAt: string | null;
+  /**
+   * 다운스트림 (reflex 등)에서 raw upsert / CDC fanout의 noop write를
+   * 거르기 위한 변경 감지 해시. `document.updatedAt`이 댓글 mutation을
+   * 반영하지 않는 한계를 보완한다 — 댓글 idHash 집합 + 최대 updatedAt /
+   * createdAt + status / approvalProcess.status 등을 함께 hash해서, 같은
+   * doc 두 번 fetch 시 변경이 있을 때만 hash가 달라진다.
+   */
+  signatureHash: string;
   status: ApprovalStatus;
   approvalLine: ApprovalStep[];
   fields: FieldValue[];

--- a/apps/flex-cli/src/types/instance.ts
+++ b/apps/flex-cli/src/types/instance.ts
@@ -21,8 +21,13 @@ export interface WorkflowInstance {
    * 반영하지 않는 한계를 보완한다 — 댓글 idHash 집합 + 최대 updatedAt /
    * createdAt + status / approvalProcess.status 등을 함께 hash해서, 같은
    * doc 두 번 fetch 시 변경이 있을 때만 hash가 달라진다.
+   *
+   * 새로 매핑하는 인스턴스는 항상 string이지만, 이 필드가 추가되기 전에
+   * 디스크에 저장된 JSON을 readInstance로 읽으면 누락 상태가 가능하므로
+   * downstream/import 경로의 타입 안전성을 위해 nullable로 모델링한다.
+   * 누락 시 import는 `data.signatureHash ?? null`로 컬럼을 NULL로 박는다.
    */
-  signatureHash: string;
+  signatureHash: string | null;
   status: ApprovalStatus;
   approvalLine: ApprovalStep[];
   fields: FieldValue[];


### PR DESCRIPTION
## Background
flex.team의 `document.updatedAt`은 댓글 add/edit/delete를 갱신하지 않는다 (planetarium/reflex#38에서 longfin이 live 검증). 따라서 PR #52까지 구현한 워터마크 기반 증분만으로는 댓글 변화를 흡수할 수 없다. 이 PR은 longfin의 코멘트 #4 정책을 그대로 구현한다 — (b) IN_PROGRESS 전수 sweep, (d) 종결 후 N일 윈도우 reconciliation, (c) 변경 감지 signature hash.

## Commits

### 1. `9f9c735` — IN_PROGRESS는 워터마크 무시 매 cycle 전수 sweep
- `SearchGroup.incrementalEligible` 플래그. `in-progress: false` / `done: true`.
- false인 그룹은 `lastUpdatedDateRange`를 안 박고, 그룹 워터마크를 만들지/갱신하지 않으며, `noWatermarks` 판정에서도 빠진다 — 즉 stale `in-progress` entry가 정책을 흐리지 못함.
- 영향: longfin 데이터 기준 IN_PROGRESS는 0.8–50% (≤47/1606) 비율, 매 cycle 전수 fetch도 ~273KB로 무관.

### 2. `b3e3925` — 종결 후 N일 윈도우 sweep
- `crawlInstances` 끝에 `sweepRecentlyClosed` 단계 추가.
- 디스크의 종결(DONE/DECLINED/CANCELED) doc 중 `lastUpdatedAt`이 N일 이내인 것을 detail 재조회 → 디스크 overwrite.
- `collectedKeys`에 이미 있는 doc는 skip (중복 fetch 방지).
- `closedSweepDays = 0`이면 비활성. list-stage가 throw했으면 sweep 건너뜀.
- 새 `StorageWriter.readInstance(id)` 헬퍼.
- `FLEX_CLOSED_SWEEP_DAYS=30` env (기본 30).

### 3. `e18a793` — `instances.signature_hash` 변경 감지 해시
- `WorkflowInstance.signatureHash` (sha1) 추가, `mapInstance`에서 계산.
- 입력: `updatedAt | status | process.status | comments.length | max(commentTimestamps) | sorted(commentIds)`.
- 같은 길이 add+delete, 내용 수정, 배열 순서 swap 모두 검출. 단순 `comments.length`만으로는 false negative 가능한 케이스 커버.
- SQLite `instances.signature_hash` 컬럼 + `idx_instances_signature_hash` 인덱스. PR #51 패턴으로 `runMigrations`에서 ALTER TABLE.
- flex-cli는 계산/저장까지. 실제 early-exit은 downstream (reflex 등)에서 사용.

## Issue acceptance criteria 정정 (planetarium/reflex#38 longfin 코멘트 4번)
- [x] (b) 매 cycle `statuses=[IN_PROGRESS]` 전수 sweep
- [x] (d) "종결 후 N일" 윈도우 reconciliation (env로 토글, 기본 30, 0이면 비활성)
- [x] (c) detail 직후 signature 비교용 컬럼 노출 (실 비교는 downstream)
- [ ] 본문/필드 수정 시 `updatedAt` 갱신은 직접 검증 — 별 트랙 (코드 측은 이 PR로 닫힘)

## Test plan
- [x] `bunx tsc --noEmit` 클린
- [x] `bun test` 90/90 (신규 11: in-progress 전수 sweep 검증, closed sweep 3, signature hash 7)
- [x] schema migration in-process 검증 (구버전 DB → ALTER로 두 컬럼/두 인덱스 모두 정상 추가, INSERT 동작)
- [ ] 실제 워크스페이스에서 cycle 1회 — IN_PROGRESS dateRange null + closed sweep candidates 로그 + watermark.json에 in-progress entry 안 생기는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)