### PR TITLE
feat(flex-cli): expose retry counts and detail-phase timings

### DIFF
--- a/apps/flex-cli/package.json
+++ b/apps/flex-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flex-ax",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "private": true,
   "type": "module",
   "description": "flex HR SaaS AX CLI - discover, crawl, and manage flex data",

--- a/apps/flex-cli/src/commands/crawl.ts
+++ b/apps/flex-cli/src/commands/crawl.ts
@@ -242,5 +242,5 @@ function isSafeIdHash(id: string): boolean {
 }
 
 function emptyResult(): CrawlResult {
-  return { totalCount: 0, successCount: 0, failureCount: 0, errors: [], durationMs: 0 };
+  return { totalCount: 0, successCount: 0, failureCount: 0, errors: [], durationMs: 0, retries: 0 };
 }

--- a/apps/flex-cli/src/commands/crawl.ts
+++ b/apps/flex-cli/src/commands/crawl.ts
@@ -17,7 +17,7 @@ import { crawlInstances, type CrawlMode } from "../crawlers/instance.js";
 import { crawlAttendanceApprovals } from "../crawlers/attendance.js";
 import { crawlCatalogEndpoints } from "../crawlers/catalog-endpoints.js";
 import type { CrawlError } from "../types/common.js";
-import type { CrawlResult } from "../crawlers/shared.js";
+import { type CrawlResult, emptyCrawlResult } from "../crawlers/shared.js";
 
 export async function runCrawl(args: string[] = process.argv.slice(3)): Promise<void> {
   const logger = createLogger("CRAWL");
@@ -156,10 +156,10 @@ async function runCrawlForCustomer(
 
   const startedAt = new Date().toISOString();
   const startTime = Date.now();
-  let templateResult: CrawlResult = emptyResult();
-  let instanceResult: CrawlResult = emptyResult();
-  let attendanceResult: CrawlResult = emptyResult();
-  let catalogEndpointsResult: CrawlResult = emptyResult();
+  let templateResult: CrawlResult = emptyCrawlResult();
+  let instanceResult: CrawlResult = emptyCrawlResult();
+  let attendanceResult: CrawlResult = emptyCrawlResult();
+  let catalogEndpointsResult: CrawlResult = emptyCrawlResult();
   let instancesMissing: string[] = [];
   let fatalError: CrawlError | null = null;
 
@@ -241,6 +241,3 @@ function isSafeIdHash(id: string): boolean {
   return typeof id === "string" && id.length > 0 && id.length <= 64 && /^[A-Za-z0-9_-]+$/.test(id);
 }
 
-function emptyResult(): CrawlResult {
-  return { totalCount: 0, successCount: 0, failureCount: 0, errors: [], durationMs: 0, retries: 0 };
-}

--- a/apps/flex-cli/src/crawlers/attendance.ts
+++ b/apps/flex-cli/src/crawlers/attendance.ts
@@ -39,7 +39,7 @@ export async function crawlAttendanceApprovals(
   logger.info("근태/휴가 승인 수집 시작");
 
   // 현재 사용자 ID를 먼저 확인
-  const userId = await getUserId(authCtx, config, logger);
+  const userId = await getUserId(authCtx, config, logger, () => result.retries++);
   if (!userId) {
     logger.error("사용자 ID를 확인할 수 없습니다");
     result.failureCount++;
@@ -68,7 +68,11 @@ export async function crawlAttendanceApprovals(
       const pageUrl = buildTimeOffUsesUrl(url, continuationToken, nextCursor);
       const data = await withRetry(
         () => flexFetch<TimeOffUsesResponse>(authCtx, pageUrl),
-        { maxRetries: config.maxRetries, delayMs: config.requestDelayMs },
+        {
+          maxRetries: config.maxRetries,
+          delayMs: config.requestDelayMs,
+          onRetry: () => result.retries++,
+        },
       );
 
       const uses = data.timeOffUses ?? [];
@@ -181,6 +185,7 @@ async function getUserId(
   authCtx: AuthContext,
   config: Config,
   logger: Logger,
+  onRetry?: () => void,
 ): Promise<string | null> {
   try {
     // /api/v2/core/me는 404이므로, workspace-users에서 currentUser를 가져옴.
@@ -193,7 +198,7 @@ async function getUserId(
           authCtx,
           `${config.flexBaseUrl}/api/v2/core/users/me/workspace-users-corp-group-affiliates`,
         ),
-      { maxRetries: config.maxRetries, delayMs: config.requestDelayMs },
+      { maxRetries: config.maxRetries, delayMs: config.requestDelayMs, onRetry },
     );
     const userId = data.currentUser?.user?.userIdHash ?? null;
     if (userId) {

--- a/apps/flex-cli/src/crawlers/attendance.ts
+++ b/apps/flex-cli/src/crawlers/attendance.ts
@@ -185,7 +185,7 @@ async function getUserId(
   authCtx: AuthContext,
   config: Config,
   logger: Logger,
-  onRetry?: () => void,
+  onRetry?: (attempt: number, error: unknown) => void,
 ): Promise<string | null> {
   try {
     // /api/v2/core/me는 404이므로, workspace-users에서 currentUser를 가져옴.

--- a/apps/flex-cli/src/crawlers/catalog-endpoints.ts
+++ b/apps/flex-cli/src/crawlers/catalog-endpoints.ts
@@ -146,6 +146,7 @@ export async function crawlCatalogEndpoints(
           // 4xx는 권한 미보유/미구독 등 영구적 실패가 대부분이므로 재시도하지 않는다.
           // (5xx와 네트워크 에러만 재시도)
           shouldRetry: (err) => !is4xxError(err),
+          onRetry: () => result.retries++,
         },
       );
 

--- a/apps/flex-cli/src/crawlers/instance.ts
+++ b/apps/flex-cli/src/crawlers/instance.ts
@@ -276,10 +276,12 @@ async function crawlSearchGroup(
   let groupMaxUpdatedAt: string | null = null;
   // detail/attachment/save 단계별 cumulative ms. 동시 처리이므로 모두 더하면
   // wall clock보다 크게 나온다 — 그래서 평균(=mean)과 카운트도 함께 노출해
-  // "어디서 시간을 쓰는지"를 비교 가능하게 한다.
+  // "어디서 시간을 쓰는지"를 비교 가능하게 한다. 카운트는 단계별로 따로 세야
+  // 한다: detail 실패 시 attachments/save는 시작도 안 하므로, detailCount로
+  // 모든 mean을 나누면 attachments/save 평균이 저평가된다.
   const phaseTotals = { detailMs: 0, attachmentsMs: 0, saveMs: 0 };
   const phaseMaxes = { detailMs: 0, attachmentsMs: 0, saveMs: 0 };
-  let detailCount = 0;
+  const phaseCounts = { detail: 0, attachments: 0, save: 0 };
 
   while (hasMore) {
     const searchBody = {
@@ -368,12 +370,12 @@ async function crawlSearchGroup(
           const detailMs = Date.now() - detailStart;
           phaseTotals.detailMs += detailMs;
           if (detailMs > phaseMaxes.detailMs) phaseMaxes.detailMs = detailMs;
-          detailCount++;
+          phaseCounts.detail++;
         }
 
         currentPhase = "attachments";
         const attachStart = Date.now();
-        let attachments;
+        let attachments: AttachmentInfo[];
         try {
           attachments = await processAttachments(
             authCtx, config, docKey, detail.document.attachments ?? [], storage, logger,
@@ -382,6 +384,7 @@ async function crawlSearchGroup(
           const attachMs = Date.now() - attachStart;
           phaseTotals.attachmentsMs += attachMs;
           if (attachMs > phaseMaxes.attachmentsMs) phaseMaxes.attachmentsMs = attachMs;
+          phaseCounts.attachments++;
         }
 
         currentPhase = "save";
@@ -393,6 +396,7 @@ async function crawlSearchGroup(
           const saveMs = Date.now() - saveStart;
           phaseTotals.saveMs += saveMs;
           if (saveMs > phaseMaxes.saveMs) phaseMaxes.saveMs = saveMs;
+          phaseCounts.save++;
         }
 
         const observed = detail.document.updatedAt ?? null;
@@ -453,30 +457,33 @@ async function crawlSearchGroup(
     continuationToken = nextContinuationToken;
   }
 
-  // 단계별 소요시간 요약. detailCount=0 이면 평균이 의미 없으니 0으로 둔다.
-  // mean은 동시성에 영향을 받지 않는 per-document 비용. wall은 실제 그룹
-  // wall-clock. wall-mean 비율이 ~concurrency에 가까워야 detail이 진짜 병목.
+  // 단계별 소요시간 요약. mean은 해당 단계가 실제로 시작된 횟수로 나눈다 —
+  // detail 실패 시 attachments/save는 시작도 안 하므로 attachments/save mean을
+  // detailCount로 나누면 저평가된다. wall은 실제 그룹 wall-clock으로,
+  // sum/wall 비율이 ~concurrency에 가까워야 그 단계가 진짜 병목.
   const groupWallMs = Date.now() - groupStartedAt;
-  const detailMean = detailCount > 0 ? phaseTotals.detailMs / detailCount : 0;
-  const attachmentsMean = detailCount > 0 ? phaseTotals.attachmentsMs / detailCount : 0;
-  const saveMean = detailCount > 0 ? phaseTotals.saveMs / detailCount : 0;
+  const meanOf = (totalMs: number, count: number): number =>
+    count > 0 ? Math.round(totalMs / count) : 0;
   logger.info("인스턴스 그룹 단계별 소요시간", {
     group: group.label,
-    docs: detailCount,
+    docs: phaseCounts.detail,
     wallMs: groupWallMs,
     detail: {
+      count: phaseCounts.detail,
       totalMs: phaseTotals.detailMs,
-      meanMs: Math.round(detailMean),
+      meanMs: meanOf(phaseTotals.detailMs, phaseCounts.detail),
       maxMs: phaseMaxes.detailMs,
     },
     attachments: {
+      count: phaseCounts.attachments,
       totalMs: phaseTotals.attachmentsMs,
-      meanMs: Math.round(attachmentsMean),
+      meanMs: meanOf(phaseTotals.attachmentsMs, phaseCounts.attachments),
       maxMs: phaseMaxes.attachmentsMs,
     },
     save: {
+      count: phaseCounts.save,
       totalMs: phaseTotals.saveMs,
-      meanMs: Math.round(saveMean),
+      meanMs: meanOf(phaseTotals.saveMs, phaseCounts.save),
       maxMs: phaseMaxes.saveMs,
     },
     concurrency: config.concurrency,

--- a/apps/flex-cli/src/crawlers/instance.ts
+++ b/apps/flex-cli/src/crawlers/instance.ts
@@ -278,8 +278,8 @@ async function crawlSearchGroup(
   // wall clock보다 크게 나온다 — 그래서 평균(=mean)과 카운트도 함께 노출해
   // "어디서 시간을 쓰는지"를 비교 가능하게 한다.
   const phaseTotals = { detailMs: 0, attachmentsMs: 0, saveMs: 0 };
+  const phaseMaxes = { detailMs: 0, attachmentsMs: 0, saveMs: 0 };
   let detailCount = 0;
-  let detailMaxMs = 0;
 
   while (hasMore) {
     const searchBody = {
@@ -360,19 +360,23 @@ async function crawlSearchGroup(
         );
         const detailMs = Date.now() - detailStart;
         phaseTotals.detailMs += detailMs;
-        if (detailMs > detailMaxMs) detailMaxMs = detailMs;
+        if (detailMs > phaseMaxes.detailMs) phaseMaxes.detailMs = detailMs;
         detailCount++;
 
         const attachStart = Date.now();
         const attachments = await processAttachments(
           authCtx, config, docKey, detail.document.attachments ?? [], storage, logger,
         );
-        phaseTotals.attachmentsMs += Date.now() - attachStart;
+        const attachMs = Date.now() - attachStart;
+        phaseTotals.attachmentsMs += attachMs;
+        if (attachMs > phaseMaxes.attachmentsMs) phaseMaxes.attachmentsMs = attachMs;
 
         const instance = mapInstance(detail, attachments);
         const saveStart = Date.now();
         await storage.saveInstance(instance);
-        phaseTotals.saveMs += Date.now() - saveStart;
+        const saveMs = Date.now() - saveStart;
+        phaseTotals.saveMs += saveMs;
+        if (saveMs > phaseMaxes.saveMs) phaseMaxes.saveMs = saveMs;
         const observed = detail.document.updatedAt ?? null;
         if (isLaterIso(observed, groupMaxUpdatedAt)) {
           groupMaxUpdatedAt = observed;
@@ -444,10 +448,18 @@ async function crawlSearchGroup(
     detail: {
       totalMs: phaseTotals.detailMs,
       meanMs: Math.round(detailMean),
-      maxMs: detailMaxMs,
+      maxMs: phaseMaxes.detailMs,
     },
-    attachments: { totalMs: phaseTotals.attachmentsMs, meanMs: Math.round(attachmentsMean) },
-    save: { totalMs: phaseTotals.saveMs, meanMs: Math.round(saveMean) },
+    attachments: {
+      totalMs: phaseTotals.attachmentsMs,
+      meanMs: Math.round(attachmentsMean),
+      maxMs: phaseMaxes.attachmentsMs,
+    },
+    save: {
+      totalMs: phaseTotals.saveMs,
+      meanMs: Math.round(saveMean),
+      maxMs: phaseMaxes.saveMs,
+    },
     concurrency: config.concurrency,
   });
 

--- a/apps/flex-cli/src/crawlers/instance.ts
+++ b/apps/flex-cli/src/crawlers/instance.ts
@@ -267,12 +267,19 @@ async function crawlSearchGroup(
     lastUpdatedDateRange: dateRange ?? null,
   });
 
+  const groupStartedAt = Date.now();
   let continuationToken: string | undefined;
   let hasMore = true;
   let isFirstPage = true;
   // 이번 그룹에서 성공적으로 상세까지 가져온 문서들의 document.updatedAt
   // 최댓값. 워커가 동시에 갱신하므로 단순 비교/대입(JS 단일 스레드 보장).
   let groupMaxUpdatedAt: string | null = null;
+  // detail/attachment/save 단계별 cumulative ms. 동시 처리이므로 모두 더하면
+  // wall clock보다 크게 나온다 — 그래서 평균(=mean)과 카운트도 함께 노출해
+  // "어디서 시간을 쓰는지"를 비교 가능하게 한다.
+  const phaseTotals = { detailMs: 0, attachmentsMs: 0, saveMs: 0 };
+  let detailCount = 0;
+  let detailMaxMs = 0;
 
   while (hasMore) {
     const searchBody = {
@@ -303,7 +310,11 @@ async function crawlSearchGroup(
         `${searchUrl}?${searchParams.toString()}`,
         searchBody,
       ),
-      { maxRetries: config.maxRetries, delayMs: config.requestDelayMs },
+      {
+        maxRetries: config.maxRetries,
+        delayMs: config.requestDelayMs,
+        onRetry: () => result.retries++,
+      },
     );
 
     const docs = page.documents ?? [];
@@ -338,17 +349,30 @@ async function crawlSearchGroup(
           ? detailBase.replace(/\{[^}]+\}/, docKey)
           : `${detailBase}/${docKey}`;
 
+        const detailStart = Date.now();
         const detail = await withRetry(
           () => flexFetch<DocumentDetailResponse>(authCtx, detailUrl),
-          { maxRetries: config.maxRetries, delayMs: config.requestDelayMs },
+          {
+            maxRetries: config.maxRetries,
+            delayMs: config.requestDelayMs,
+            onRetry: () => result.retries++,
+          },
         );
+        const detailMs = Date.now() - detailStart;
+        phaseTotals.detailMs += detailMs;
+        if (detailMs > detailMaxMs) detailMaxMs = detailMs;
+        detailCount++;
 
+        const attachStart = Date.now();
         const attachments = await processAttachments(
           authCtx, config, docKey, detail.document.attachments ?? [], storage, logger,
         );
+        phaseTotals.attachmentsMs += Date.now() - attachStart;
 
         const instance = mapInstance(detail, attachments);
+        const saveStart = Date.now();
         await storage.saveInstance(instance);
+        phaseTotals.saveMs += Date.now() - saveStart;
         const observed = detail.document.updatedAt ?? null;
         if (isLaterIso(observed, groupMaxUpdatedAt)) {
           groupMaxUpdatedAt = observed;
@@ -405,6 +429,27 @@ async function crawlSearchGroup(
 
     continuationToken = nextContinuationToken;
   }
+
+  // 단계별 소요시간 요약. detailCount=0 이면 평균이 의미 없으니 0으로 둔다.
+  // mean은 동시성에 영향을 받지 않는 per-document 비용. wall은 실제 그룹
+  // wall-clock. wall-mean 비율이 ~concurrency에 가까워야 detail이 진짜 병목.
+  const groupWallMs = Date.now() - groupStartedAt;
+  const detailMean = detailCount > 0 ? phaseTotals.detailMs / detailCount : 0;
+  const attachmentsMean = detailCount > 0 ? phaseTotals.attachmentsMs / detailCount : 0;
+  const saveMean = detailCount > 0 ? phaseTotals.saveMs / detailCount : 0;
+  logger.info("인스턴스 그룹 단계별 소요시간", {
+    group: group.label,
+    docs: detailCount,
+    wallMs: groupWallMs,
+    detail: {
+      totalMs: phaseTotals.detailMs,
+      meanMs: Math.round(detailMean),
+      maxMs: detailMaxMs,
+    },
+    attachments: { totalMs: phaseTotals.attachmentsMs, meanMs: Math.round(attachmentsMean) },
+    save: { totalMs: phaseTotals.saveMs, meanMs: Math.round(saveMean) },
+    concurrency: config.concurrency,
+  });
 
   return groupMaxUpdatedAt;
 }

--- a/apps/flex-cli/src/crawlers/instance.ts
+++ b/apps/flex-cli/src/crawlers/instance.ts
@@ -343,6 +343,10 @@ async function crawlSearchGroup(
 
     await pooledMap(newDocs, config.concurrency, async (doc) => {
       const docKey = doc.document.documentKey;
+      // 실패한 단계를 정확히 에러 레코드에 남기기 위한 추적자. 단계별 finally
+      // 안에서 phase 누적도 함께 일어나므로, 실패한 문서의 시간도 phase totals/
+      // max에 반영되어 "에러 케이스가 병목을 숨기는" 케이스를 피한다.
+      let currentPhase: "detail" | "attachments" | "save" = "detail";
       try {
         const hasPathParam = /\{[^}]+\}/.test(detailBase);
         const detailUrl = hasPathParam
@@ -350,33 +354,47 @@ async function crawlSearchGroup(
           : `${detailBase}/${docKey}`;
 
         const detailStart = Date.now();
-        const detail = await withRetry(
-          () => flexFetch<DocumentDetailResponse>(authCtx, detailUrl),
-          {
-            maxRetries: config.maxRetries,
-            delayMs: config.requestDelayMs,
-            onRetry: () => result.retries++,
-          },
-        );
-        const detailMs = Date.now() - detailStart;
-        phaseTotals.detailMs += detailMs;
-        if (detailMs > phaseMaxes.detailMs) phaseMaxes.detailMs = detailMs;
-        detailCount++;
+        let detail: DocumentDetailResponse;
+        try {
+          detail = await withRetry(
+            () => flexFetch<DocumentDetailResponse>(authCtx, detailUrl),
+            {
+              maxRetries: config.maxRetries,
+              delayMs: config.requestDelayMs,
+              onRetry: () => result.retries++,
+            },
+          );
+        } finally {
+          const detailMs = Date.now() - detailStart;
+          phaseTotals.detailMs += detailMs;
+          if (detailMs > phaseMaxes.detailMs) phaseMaxes.detailMs = detailMs;
+          detailCount++;
+        }
 
+        currentPhase = "attachments";
         const attachStart = Date.now();
-        const attachments = await processAttachments(
-          authCtx, config, docKey, detail.document.attachments ?? [], storage, logger,
-        );
-        const attachMs = Date.now() - attachStart;
-        phaseTotals.attachmentsMs += attachMs;
-        if (attachMs > phaseMaxes.attachmentsMs) phaseMaxes.attachmentsMs = attachMs;
+        let attachments;
+        try {
+          attachments = await processAttachments(
+            authCtx, config, docKey, detail.document.attachments ?? [], storage, logger,
+          );
+        } finally {
+          const attachMs = Date.now() - attachStart;
+          phaseTotals.attachmentsMs += attachMs;
+          if (attachMs > phaseMaxes.attachmentsMs) phaseMaxes.attachmentsMs = attachMs;
+        }
 
+        currentPhase = "save";
         const instance = mapInstance(detail, attachments);
         const saveStart = Date.now();
-        await storage.saveInstance(instance);
-        const saveMs = Date.now() - saveStart;
-        phaseTotals.saveMs += saveMs;
-        if (saveMs > phaseMaxes.saveMs) phaseMaxes.saveMs = saveMs;
+        try {
+          await storage.saveInstance(instance);
+        } finally {
+          const saveMs = Date.now() - saveStart;
+          phaseTotals.saveMs += saveMs;
+          if (saveMs > phaseMaxes.saveMs) phaseMaxes.saveMs = saveMs;
+        }
+
         const observed = detail.document.updatedAt ?? null;
         if (isLaterIso(observed, groupMaxUpdatedAt)) {
           groupMaxUpdatedAt = observed;
@@ -388,11 +406,12 @@ async function crawlSearchGroup(
         result.failureCount++;
         result.errors.push({
           target: `instance:${docKey}`,
-          phase: "detail",
+          phase: currentPhase,
           message: error instanceof Error ? error.message : String(error),
           timestamp: nowISO(),
         });
         logger.error(`인스턴스 수집 실패: ${docKey}`, {
+          phase: currentPhase,
           error: error instanceof Error ? error.message : String(error),
         });
       } finally {

--- a/apps/flex-cli/src/crawlers/shared.test.ts
+++ b/apps/flex-cli/src/crawlers/shared.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { isLaterIso, toKstDate } from "./shared.js";
+import { isLaterIso, toKstDate, withRetry } from "./shared.js";
 
 describe("isLaterIso", () => {
   it("compares by epoch ms, not lexicographically", () => {
@@ -25,6 +25,93 @@ describe("isLaterIso", () => {
 
   it("treats invalid baseline as -infinity (any valid candidate wins)", () => {
     assert.equal(isLaterIso("2026-01-01T00:00:00Z", "garbage"), true);
+  });
+});
+
+describe("withRetry onRetry callback", () => {
+  it("invokes onRetry once per actual retry with 0-based attempt index", async () => {
+    const seen: number[] = [];
+    let calls = 0;
+    const result = await withRetry(
+      async () => {
+        calls++;
+        if (calls < 3) throw new Error("boom");
+        return "ok";
+      },
+      {
+        maxRetries: 5,
+        delayMs: 0,
+        onRetry: (attempt) => {
+          seen.push(attempt);
+        },
+      },
+    );
+    assert.equal(result, "ok");
+    // 3번 호출 = 2번 재시도 직전에 콜백. attempt는 직전 실패 시도의 0-base 인덱스.
+    assert.deepEqual(seen, [0, 1]);
+  });
+
+  it("does not invoke onRetry when maxRetries is exhausted", async () => {
+    let onRetryCalls = 0;
+    let fnCalls = 0;
+    await assert.rejects(
+      withRetry(
+        async () => {
+          fnCalls++;
+          throw new Error("always");
+        },
+        {
+          maxRetries: 2,
+          delayMs: 0,
+          onRetry: () => {
+            onRetryCalls++;
+          },
+        },
+      ),
+    );
+    // 총 3회 호출(초기 + 재시도 2회), 콜백은 재시도 직전 2회만.
+    assert.equal(fnCalls, 3);
+    assert.equal(onRetryCalls, 2);
+  });
+
+  it("swallows errors thrown by onRetry so retry loop continues", async () => {
+    let calls = 0;
+    const result = await withRetry(
+      async () => {
+        calls++;
+        if (calls < 2) throw new Error("transient");
+        return "recovered";
+      },
+      {
+        maxRetries: 3,
+        delayMs: 0,
+        onRetry: () => {
+          throw new Error("instrumentation broken");
+        },
+      },
+    );
+    assert.equal(result, "recovered");
+    assert.equal(calls, 2);
+  });
+
+  it("does not invoke onRetry when shouldRetry rejects the error", async () => {
+    let onRetryCalls = 0;
+    await assert.rejects(
+      withRetry(
+        async () => {
+          throw new Error("non-retriable");
+        },
+        {
+          maxRetries: 5,
+          delayMs: 0,
+          shouldRetry: () => false,
+          onRetry: () => {
+            onRetryCalls++;
+          },
+        },
+      ),
+    );
+    assert.equal(onRetryCalls, 0);
   });
 });
 

--- a/apps/flex-cli/src/crawlers/shared.test.ts
+++ b/apps/flex-cli/src/crawlers/shared.test.ts
@@ -40,7 +40,7 @@ describe("withRetry onRetry callback", () => {
       },
       {
         maxRetries: 5,
-        delayMs: 0,
+        delayMs: 1,
         onRetry: (attempt) => {
           seen.push(attempt);
         },
@@ -62,7 +62,7 @@ describe("withRetry onRetry callback", () => {
         },
         {
           maxRetries: 2,
-          delayMs: 0,
+          delayMs: 1,
           onRetry: () => {
             onRetryCalls++;
           },
@@ -84,7 +84,7 @@ describe("withRetry onRetry callback", () => {
       },
       {
         maxRetries: 3,
-        delayMs: 0,
+        delayMs: 1,
         onRetry: () => {
           throw new Error("instrumentation broken");
         },
@@ -103,7 +103,7 @@ describe("withRetry onRetry callback", () => {
         },
         {
           maxRetries: 5,
-          delayMs: 0,
+          delayMs: 1,
           shouldRetry: () => false,
           onRetry: () => {
             onRetryCalls++;

--- a/apps/flex-cli/src/crawlers/shared.ts
+++ b/apps/flex-cli/src/crawlers/shared.ts
@@ -98,7 +98,14 @@ export async function withRetry<T>(
       }
 
       if (attempt < options.maxRetries) {
-        options.onRetry?.(attempt, error);
+        // 관측/카운팅 콜백이 throw해도 retry 루프는 계속되어야 한다 — 그래야
+        // instrumentation 버그가 실제 호출 실패를 가리지 않는다. 콜백에서 던진
+        // 예외는 무시한다(자체 로깅이 콜백 책임).
+        try {
+          options.onRetry?.(attempt, error);
+        } catch {
+          // ignore instrumentation errors
+        }
         const retryAfter =
           error instanceof FlexHttpError && error.status === 429 ? error.retryAfterMs : undefined;
         const baseDelay = options.delayMs > 0 ? options.delayMs : 250;

--- a/apps/flex-cli/src/crawlers/shared.ts
+++ b/apps/flex-cli/src/crawlers/shared.ts
@@ -9,6 +9,12 @@ export interface CrawlResult {
   failureCount: number;
   errors: CrawlError[];
   durationMs: number;
+  /**
+   * withRetry가 실제로 발사한 재시도 횟수 합계. 초기 시도는 포함하지 않으며
+   * (n번 재시도 = n+1번 호출), 최종 성공/실패 여부와 무관하게 누적된다.
+   * crawl-report.json에서 throttling/네트워크 불안정 신호로 활용.
+   */
+  retries: number;
 }
 
 /** 페이지네이션 헬퍼 */
@@ -71,6 +77,12 @@ export async function withRetry<T>(
     maxRetries: number;
     delayMs: number;
     shouldRetry?: (error: unknown) => boolean;
+    /**
+     * 다음 재시도 직전에 1회 호출된다. attempt는 0-base로 직전 실패한 시도의
+     * 인덱스(즉 곧 발사할 재시도는 attempt+1번째 호출). 호출자가 재시도 횟수를
+     * 누적하려면 이 콜백에서 카운터를 올리면 된다.
+     */
+    onRetry?: (attempt: number, error: unknown) => void;
   },
 ): Promise<T> {
   let lastError: unknown;
@@ -86,6 +98,7 @@ export async function withRetry<T>(
       }
 
       if (attempt < options.maxRetries) {
+        options.onRetry?.(attempt, error);
         const retryAfter =
           error instanceof FlexHttpError && error.status === 429 ? error.retryAfterMs : undefined;
         const baseDelay = options.delayMs > 0 ? options.delayMs : 250;
@@ -176,6 +189,7 @@ export function emptyCrawlResult(): CrawlResult {
     failureCount: 0,
     errors: [],
     durationMs: 0,
+    retries: 0,
   };
 }
 

--- a/apps/flex-cli/src/crawlers/template.ts
+++ b/apps/flex-cli/src/crawlers/template.ts
@@ -34,7 +34,11 @@ export async function crawlTemplates(
   try {
     const data = await withRetry(
       () => flexFetch<{ templates: RawTemplate[] }>(authCtx, listUrl),
-      { maxRetries: config.maxRetries, delayMs: config.requestDelayMs },
+      {
+        maxRetries: config.maxRetries,
+        delayMs: config.requestDelayMs,
+        onRetry: () => result.retries++,
+      },
     );
 
     const rawTemplates = data.templates ?? [];
@@ -58,7 +62,11 @@ export async function crawlTemplates(
 
         const detail = await withRetry(
           () => flexFetch<{ template: RawTemplateDetail }>(authCtx, finalDetailUrl),
-          { maxRetries: config.maxRetries, delayMs: config.requestDelayMs },
+          {
+            maxRetries: config.maxRetries,
+            delayMs: config.requestDelayMs,
+            onRetry: () => result.retries++,
+          },
         );
 
         const template = mapTemplate(raw, detail.template);


### PR DESCRIPTION
## Summary
- `withRetry` gains an `onRetry` callback; every crawler now plumbs it into a new `CrawlResult.retries` counter so `crawl-report.json` reports total retry attempts per domain (throttling/instability signal).
- Instance crawler groups now emit per-phase timings (`detail` GET, `attachments`, `saveInstance`) with `totalMs / meanMs / maxMs` plus group `wallMs` and `concurrency`, so it's clear where remaining time is spent.
- Bumps `flex-cli` to 0.9.0 for release.

Closes the remaining acceptance criteria on planetarium/reflex#41 — earlier criteria (default delay, page size, detail/attachment concurrency, fast `DOWNLOAD_ATTACHMENTS=false` mode) already shipped in #40.

## Test plan
- [x] `bun run lint` clean
- [x] `bun test` (79 pass)
- [ ] One real crawl run to eyeball the new `인스턴스 그룹 단계별 소요시간` log line and the `retries` field in `crawl-report.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)