### PR TITLE
fix(flex-cli): correct --gui help wording

### DIFF
--- a/apps/flex-cli/src/cli-help.ts
+++ b/apps/flex-cli/src/cli-help.ts
@@ -54,7 +54,7 @@ const COMMAND_HELP: Record<string, string> = {
   login: `Usage: flex-ax login [--gui] [--password-stdin]
 
 이메일/비밀번호를 등록합니다.
---gui 를 사용하면 브라우저 대신 플랫폼 기본 대화상자로 입력합니다.
+--gui 를 사용하면 터미널 프롬프트 대신 플랫폼 기본 대화상자로 입력합니다.
 --password-stdin 을 사용하면 stdin 파이프로 비밀번호를 주입할 수 있습니다.`,
   logout: `Usage: flex-ax logout [--gui]
 


### PR DESCRIPTION
## Summary
- `flex-ax login` 도움말이 `--gui` 옵션을 \"브라우저 대신 플랫폼 기본 대화상자\"로 안내하지만, 실제 기본 동작은 TTY 터미널 프롬프트(`promptLine` / `promptPassword`)이며 브라우저 흐름은 존재하지 않습니다.
- 문구를 \"터미널 프롬프트 대신 플랫폼 기본 대화상자\"로 수정합니다.

## Test plan
- [ ] `flex-ax login --help` 출력에서 새 문구 확인
- [ ] `flex-ax help login` 출력에서 새 문구 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)