### PR TITLE
fix(flex-cli): crawl approval docs from customer-boxes scope

### DIFF
--- a/apps/flex-cli/src/commands/crawl.ts
+++ b/apps/flex-cli/src/commands/crawl.ts
@@ -13,7 +13,7 @@ import {
 import { createStorageWriter, type CrawlReport, type StorageWriter } from "../storage/index.js";
 import type { ApiCatalog } from "../types/catalog.js";
 import { crawlTemplates } from "../crawlers/template.js";
-import { crawlInstances, type CrawlMode } from "../crawlers/instance.js";
+import { crawlInstances, type BoxScope, type CrawlMode } from "../crawlers/instance.js";
 import { crawlAttendanceApprovals } from "../crawlers/attendance.js";
 import { crawlCatalogEndpoints } from "../crawlers/catalog-endpoints.js";
 import type { CrawlError } from "../types/common.js";
@@ -161,25 +161,29 @@ async function runCrawlForCustomer(
   let attendanceResult: CrawlResult = emptyCrawlResult();
   let catalogEndpointsResult: CrawlResult = emptyCrawlResult();
   let instancesMissing: string[] = [];
+  let instancesBoxScope: BoxScope | undefined;
   let fatalError: CrawlError | null = null;
 
   try {
     templateResult = await crawlTemplates(authCtx, config, catalog, storage, logger);
     const instanceCrawlResult = await crawlInstances(authCtx, config, catalog, storage, logger, mode);
     // crawlInstances는 in-process 배선용으로 collectedKeys / missingKeys /
-    // closedSweepCount를 추가로 반환한다. report.instances에는 plain CrawlResult
-    // 만 들어가야 JSON 직렬화에서 Set이 `{}`로 새거나 추가 필드가 노출되는 일이
-    // 없다. closedSweepCount는 instance.ts 안에서 logger.info로 이미 보고되므로
-    // 여기서는 destructure로 떼어내기만 한다.
+    // closedSweepCount / boxScope를 추가로 반환한다. report.instances에는
+    // plain CrawlResult 만 들어가야 JSON 직렬화에서 Set이 `{}`로 새거나 추가
+    // 필드가 노출되는 일이 없다. closedSweepCount는 instance.ts 안에서
+    // logger.info로 이미 보고되므로 여기서는 destructure로 떼어내기만 한다.
+    // boxScope는 report 상위에 별도로 올려 운영자가 모집단 범위를 알 수 있게 한다.
     const {
       collectedKeys,
       missingKeys,
       closedSweepCount: _closedSweepCount,
+      boxScope,
       ...instancePlain
     } = instanceCrawlResult;
     void _closedSweepCount;
     instanceResult = instancePlain;
     instancesMissing = missingKeys;
+    instancesBoxScope = boxScope;
     attendanceResult = await crawlAttendanceApprovals(
       authCtx, config, catalog, storage, logger, collectedKeys,
     );
@@ -216,6 +220,7 @@ async function runCrawlForCustomer(
     attendance: attendanceResult,
     catalogEndpoints: catalogEndpointsResult,
     instancesMissing: instancesMissing.length > 0 ? instancesMissing : undefined,
+    instancesBoxScope,
     totalErrors,
   };
 

--- a/apps/flex-cli/src/crawlers/instance.test.ts
+++ b/apps/flex-cli/src/crawlers/instance.test.ts
@@ -1444,10 +1444,14 @@ describe("crawlInstances box scope resolution", () => {
         `after fallback, real search must hit user-boxes, got ${c.url}`,
       );
     }
-    // 폴백은 silent하지 않아야 한다 — result.errors에 scope-detect 항목.
-    const scopeErr = result.errors.find((e) => e.target === "instance-scope");
-    assert.ok(scopeErr, "fallback must push an instance-scope error for visibility");
-    assert.equal(scopeErr?.phase, "scope-detect");
+    // 폴백은 "성공이지만 모집단이 좁아짐"의 비치명 신호 — `result.errors`에
+    // 절대 새지 않아야 한다 (그러면 flex-ax crawl이 exit code 2로 죽어 CI/cron이
+    // 진짜 실패와 구분 못 함). 가시성은 boxScope="user"로 충분히 확보됨.
+    assert.equal(
+      result.errors.find((e) => e.target === "instance-scope"),
+      undefined,
+      "scope fallback must NOT push to result.errors (would fail CI exit code)",
+    );
     // 폴백 자체는 failure로 안 카운트해서 워터마크 갱신을 막지 않는다 — 운영자가
     // 비관리자 계정으로 의도적으로 user-boxes 모집단을 받고 있을 수 있다.
     assert.equal(result.failureCount, 0);

--- a/apps/flex-cli/src/crawlers/instance.test.ts
+++ b/apps/flex-cli/src/crawlers/instance.test.ts
@@ -251,6 +251,7 @@ describe("crawlInstances incremental wiring", () => {
   it("injects lastUpdatedDateRange (KST) when watermarks exist and mode=incremental", async () => {
     const initial: WatermarkFile = {
       approvalDocuments: {
+        lastCrawledBoxScope: "customer",
         groups: {
           "in-progress": {
             lastUpdatedAt: "2026-04-29T12:17:44Z",
@@ -313,6 +314,7 @@ describe("crawlInstances incremental wiring", () => {
   it("mode=full ignores existing watermarks and skips lastUpdatedDateRange", async () => {
     const initial: WatermarkFile = {
       approvalDocuments: {
+        lastCrawledBoxScope: "customer",
         groups: {
           "in-progress": {
             lastUpdatedAt: "2026-04-29T12:00:00Z",
@@ -350,6 +352,7 @@ describe("crawlInstances incremental wiring", () => {
   it("does not advance the done watermark when that group has any failure", async () => {
     const initial: WatermarkFile = {
       approvalDocuments: {
+        lastCrawledBoxScope: "customer",
         groups: {
           done: {
             lastUpdatedAt: "2026-04-29T00:00:00Z",
@@ -396,6 +399,7 @@ describe("crawlInstances incremental wiring", () => {
     // into a full crawl rather than aborting on RangeError.
     const initial = {
       approvalDocuments: {
+        lastCrawledBoxScope: "customer",
         groups: {
           done: {
             lastUpdatedAt: "garbage",
@@ -447,6 +451,7 @@ describe("crawlInstances incremental wiring", () => {
     // would return nothing forever.
     const initial = {
       approvalDocuments: {
+        lastCrawledBoxScope: "customer",
         groups: {
           done: {
             lastUpdatedAt: "2099-01-01T00:00:00Z",
@@ -518,6 +523,7 @@ describe("crawlInstances incremental wiring", () => {
     // candidate first and refuse to advance. epoch-ms comparison fixes it.
     const initial: WatermarkFile = {
       approvalDocuments: {
+        lastCrawledBoxScope: "customer",
         groups: {
           done: {
             lastUpdatedAt: "2026-04-29T12:17:44Z",
@@ -552,6 +558,7 @@ describe("crawlInstances incremental wiring", () => {
   it("stamps lastSuccessfulRunAt on a clean zero-doc run while preserving lastUpdatedAt", async () => {
     const initial: WatermarkFile = {
       approvalDocuments: {
+        lastCrawledBoxScope: "customer",
         groups: {
           done: {
             lastUpdatedAt: "2026-04-29T12:00:00Z",
@@ -648,6 +655,7 @@ describe("crawlInstances incremental wiring", () => {
     // changed docs — disk-vs-collected diff would be hugely noisy.
     const initial: WatermarkFile = {
       approvalDocuments: {
+        lastCrawledBoxScope: "customer",
         groups: {
           "in-progress": {
             lastUpdatedAt: "2026-04-01T00:00:00Z",
@@ -764,6 +772,7 @@ describe("crawlInstances incremental wiring", () => {
     // date and observe an even-older one.
     const initial: WatermarkFile = {
       approvalDocuments: {
+        lastCrawledBoxScope: "customer",
         groups: {
           done: {
             lastUpdatedAt: "2026-05-01T00:00:00Z",
@@ -1142,6 +1151,7 @@ describe("crawlInstances incremental wiring", () => {
     // must not survive a clean run.
     const initial: WatermarkFile = {
       approvalDocuments: {
+        lastCrawledBoxScope: "customer",
         groups: {
           "in-progress": {
             lastUpdatedAt: "2026-04-29T00:00:00Z",
@@ -1465,5 +1475,221 @@ describe("crawlInstances box scope resolution", () => {
     const wm = storage._watermarks.approvalDocuments;
     assert.deepEqual(wm?.groups ?? {}, {});
     assert.equal(wm?.lastFullReconAt, undefined);
+    // 스코프도 안 박혀야 함 (실패 cycle이므로 다음 run에서 자가복구 가능).
+    assert.equal(wm?.lastCrawledBoxScope, undefined);
+  });
+});
+
+describe("crawlInstances scope-aware migration", () => {
+  beforeEach(() => {
+    globalThis.fetch = ORIGINAL_FETCH;
+  });
+  afterEach(() => {
+    globalThis.fetch = ORIGINAL_FETCH;
+  });
+
+  // 헬퍼: customer-boxes 200 + 빈 응답을 돌려주는 mock. scope 결정은 200이면
+  // customer로 떨어지므로, 이걸로 모든 시나리오의 "정상 scope detection"을 잡는다.
+  function setupCustomerScopeFetch(): { calls: CapturedFetch[] } {
+    const calls: CapturedFetch[] = [];
+    globalThis.fetch = (async (input: unknown, init?: { method?: string; body?: string }) => {
+      const url = String(input);
+      const method = init?.method ?? "GET";
+      calls.push({ url, method, body: init?.body ? JSON.parse(init.body) : null });
+      if (url.includes("/customer-boxes/search") || url.includes("/user-boxes/search")) {
+        return new Response(JSON.stringify({ documents: [], total: 0, hasNext: false }), {
+          status: 200,
+        });
+      }
+      return new Response("nf", { status: 404 });
+    }) as typeof fetch;
+    return { calls };
+  }
+
+  it("missing lastCrawledBoxScope on existing watermark forces full this cycle (migration path)", async () => {
+    // user-boxes 시절 운영하던 환경 시뮬레이션 — 워터마크는 있는데 scope 필드는 없음.
+    const initial: WatermarkFile = {
+      approvalDocuments: {
+        groups: {
+          done: {
+            lastUpdatedAt: "2026-04-25T03:00:00Z",
+            overlapDays: 2,
+            lastSuccessfulRunAt: "2026-04-30T00:00:00Z",
+          },
+        },
+      },
+    };
+    const { calls } = setupCustomerScopeFetch();
+    const storage = makeStorage(initial);
+
+    const result = await crawlInstances(makeAuth(), makeConfig(), null, storage, makeLogger());
+
+    // scope mismatch 감지 → effectiveFull → 어느 그룹도 lastUpdatedDateRange를 안 보냄.
+    for (const c of calls.filter(isRealSearchCall)) {
+      const filter = (c.body as { filter: Record<string, unknown> }).filter;
+      assert.ok(
+        !("lastUpdatedDateRange" in filter),
+        `migration cycle must not narrow with lastUpdatedDateRange, got ${JSON.stringify(filter)}`,
+      );
+    }
+    // 새 scope이 박혀야 함 → 다음 run은 정상 incremental.
+    assert.equal(result.boxScope, "customer");
+    assert.equal(
+      storage._watermarks.approvalDocuments?.lastCrawledBoxScope,
+      "customer",
+    );
+    // full recon로 처리됐으니 lastFullReconAt도 갱신.
+    assert.ok(storage._watermarks.approvalDocuments?.lastFullReconAt);
+  });
+
+  it("matching lastCrawledBoxScope keeps incremental (no force-full)", async () => {
+    const initial: WatermarkFile = {
+      approvalDocuments: {
+        lastCrawledBoxScope: "customer",
+        groups: {
+          done: {
+            lastUpdatedAt: "2026-04-25T03:00:00Z",
+            overlapDays: 2,
+            lastSuccessfulRunAt: "2026-04-30T00:00:00Z",
+          },
+        },
+      },
+    };
+    const { calls } = setupCustomerScopeFetch();
+
+    await crawlInstances(makeAuth(), makeConfig(), null, makeStorage(initial), makeLogger());
+
+    // done 그룹은 dateRange를 받아야 한다 (= incremental 유지).
+    const doneCall = calls.find(
+      (c) =>
+        isRealSearchCall(c) &&
+        (c.body as { filter: { statuses: string[] } }).filter.statuses.includes("DONE"),
+    );
+    assert.ok(doneCall);
+    const filter = (doneCall.body as { filter: Record<string, unknown> }).filter;
+    assert.ok(
+      "lastUpdatedDateRange" in filter,
+      "matching scope must preserve incremental behavior",
+    );
+  });
+
+  it("scope change customer→user (admin revoked) forces full this cycle", async () => {
+    const initial: WatermarkFile = {
+      approvalDocuments: {
+        lastCrawledBoxScope: "customer",
+        groups: {
+          done: {
+            lastUpdatedAt: "2026-04-25T03:00:00Z",
+            overlapDays: 2,
+            lastSuccessfulRunAt: "2026-04-30T00:00:00Z",
+          },
+        },
+      },
+    };
+    // customer-boxes는 403 → user-boxes로 폴백. 즉 boxScope는 "user".
+    const calls: CapturedFetch[] = [];
+    globalThis.fetch = (async (input: unknown, init?: { method?: string; body?: string }) => {
+      const url = String(input);
+      const method = init?.method ?? "GET";
+      calls.push({ url, method, body: init?.body ? JSON.parse(init.body) : null });
+      if (url.includes("/customer-boxes/search")) {
+        return new Response(JSON.stringify({ message: "권한 없음" }), { status: 403 });
+      }
+      if (url.includes("/user-boxes/search")) {
+        return new Response(JSON.stringify({ documents: [], total: 0, hasNext: false }), {
+          status: 200,
+        });
+      }
+      return new Response("nf", { status: 404 });
+    }) as typeof fetch;
+    const storage = makeStorage(initial);
+
+    const result = await crawlInstances(makeAuth(), makeConfig(), null, storage, makeLogger());
+
+    assert.equal(result.boxScope, "user");
+    // mismatch → full → done 그룹도 dateRange 없이 전수.
+    const doneCall = calls.find(
+      (c) =>
+        isRealSearchCall(c) &&
+        (c.body as { filter: { statuses: string[] } }).filter.statuses.includes("DONE"),
+    );
+    assert.ok(doneCall);
+    const filter = (doneCall.body as { filter: Record<string, unknown> }).filter;
+    assert.ok(
+      !("lastUpdatedDateRange" in filter),
+      "scope downgrade must trigger a full sweep, not incremental",
+    );
+    // 새 scope 박힘 → 이후로는 user 스코프에서 incremental 유지.
+    assert.equal(
+      storage._watermarks.approvalDocuments?.lastCrawledBoxScope,
+      "user",
+    );
+  });
+
+  it("partial-failure cycle does NOT commit lastCrawledBoxScope (preserves self-heal)", async () => {
+    // scope=customer로 떨어지지만 detail 1건이 실패하는 시나리오. failureCount>0 이면
+    // 스코프가 안 박혀야 한다 — 그래야 다음 run에서 같은 mismatch 경로가 다시
+    // 트리거되어 자가복구가 막히지 않는다.
+    const initial: WatermarkFile = {
+      approvalDocuments: {
+        // scope 필드 없음 — migration trigger 상태로 시작.
+        groups: {
+          done: {
+            lastUpdatedAt: "2026-04-25T03:00:00Z",
+            overlapDays: 2,
+            lastSuccessfulRunAt: "2026-04-30T00:00:00Z",
+          },
+        },
+      },
+    };
+    const calls: CapturedFetch[] = [];
+    globalThis.fetch = (async (input: unknown, init?: { method?: string; body?: string }) => {
+      const url = String(input);
+      const method = init?.method ?? "GET";
+      calls.push({ url, method, body: init?.body ? JSON.parse(init.body) : null });
+      if (url.includes("/customer-boxes/search")) {
+        if (/[?&]size=1(?:&|$)/.test(url)) {
+          // scope probe — 200 빈 응답.
+          return new Response(JSON.stringify({ documents: [], total: 0, hasNext: false }), {
+            status: 200,
+          });
+        }
+        // 실제 search — done 그룹에 1건 반환.
+        const body = init?.body ? JSON.parse(init.body) : null;
+        const statuses = body?.filter?.statuses ?? [];
+        if (statuses.includes("DONE")) {
+          return new Response(
+            JSON.stringify({
+              documents: [{ document: { documentKey: "boom" } }],
+              total: 1,
+              hasNext: false,
+            }),
+            { status: 200 },
+          );
+        }
+        return new Response(JSON.stringify({ documents: [], total: 0, hasNext: false }), {
+          status: 200,
+        });
+      }
+      // detail GET → 500. failureCount=1.
+      return new Response("server error", { status: 500 });
+    }) as typeof fetch;
+    const storage = makeStorage(initial);
+
+    const result = await crawlInstances(
+      makeAuth(),
+      { ...makeConfig(), maxRetries: 0 },
+      null,
+      storage,
+      makeLogger(),
+    );
+
+    assert.ok(result.failureCount > 0, "test setup must produce at least one detail failure");
+    // 부분 실패 cycle — scope 미커밋.
+    assert.equal(
+      storage._watermarks.approvalDocuments?.lastCrawledBoxScope,
+      undefined,
+      "scope must not be committed on partial-failure cycle (self-heal preservation)",
+    );
   });
 });

--- a/apps/flex-cli/src/crawlers/instance.test.ts
+++ b/apps/flex-cli/src/crawlers/instance.test.ts
@@ -1478,6 +1478,67 @@ describe("crawlInstances box scope resolution", () => {
     // 스코프도 안 박혀야 함 (실패 cycle이므로 다음 run에서 자가복구 가능).
     assert.equal(wm?.lastCrawledBoxScope, undefined);
   });
+
+  it("scope probe retries on transient 5xx and recovers", async () => {
+    // 그룹 search와 동일한 회복력 — 일시적 5xx에서 scope detection이 죽지
+    // 않아야 한다. 첫 호출만 503, 그 다음부터 200.
+    let probeCalls = 0;
+    globalThis.fetch = (async (input: unknown, init?: { method?: string; body?: string }) => {
+      const url = String(input);
+      if (url.includes("/customer-boxes/search")) {
+        probeCalls++;
+        if (probeCalls === 1) {
+          return new Response("temporary", { status: 503 });
+        }
+        return new Response(JSON.stringify({ documents: [], total: 0, hasNext: false }), {
+          status: 200,
+        });
+      }
+      return new Response("nf", { status: 404 });
+    }) as typeof fetch;
+
+    const result = await crawlInstances(
+      makeAuth(),
+      // probe + groups 모두 합쳐 최소 1 retry 허용.
+      { ...makeConfig(), maxRetries: 2, requestDelayMs: 0 },
+      null,
+      makeStorage(),
+      makeLogger(),
+    );
+
+    assert.equal(result.boxScope, "customer");
+    assert.ok(probeCalls >= 2, `probe must retry on 5xx, called ${probeCalls} times`);
+    // withRetry의 onRetry로 retries 카운터가 누적되었는지 — 그룹 search 단계도
+    // 자체 retry가 있으나, 본 mock은 그쪽에서 5xx를 주지 않으므로 retries는
+    // 정확히 1 (probe의 한 번)이어야 한다.
+    assert.equal(result.retries, 1);
+  });
+
+  it("scope probe does not retry on 4xx (e.g. 401 unauthorized) — fast-fail to list-stage error", async () => {
+    // 4xx는 영구 실패로 간주해 backoff 낭비를 피한다. 401은 403과 달리 fallback
+    // 대상도 아니므로 그대로 list-stage catch로 떨어져 listStageOk=false.
+    let probeCalls = 0;
+    globalThis.fetch = (async (input: unknown) => {
+      const url = String(input);
+      if (url.includes("/customer-boxes/search")) {
+        probeCalls++;
+        return new Response("unauthorized", { status: 401 });
+      }
+      return new Response("nf", { status: 404 });
+    }) as typeof fetch;
+
+    const result = await crawlInstances(
+      makeAuth(),
+      { ...makeConfig(), maxRetries: 3, requestDelayMs: 0 },
+      null,
+      makeStorage(),
+      makeLogger(),
+    );
+
+    assert.equal(probeCalls, 1, "4xx must not be retried");
+    // listStageOk=false 경로 — instance-list 에러 1건.
+    assert.ok(result.errors.find((e) => e.target === "instance-list"));
+  });
 });
 
 describe("crawlInstances scope-aware migration", () => {

--- a/apps/flex-cli/src/crawlers/instance.test.ts
+++ b/apps/flex-cli/src/crawlers/instance.test.ts
@@ -4,6 +4,7 @@ import type { AuthContext } from "../auth/index.js";
 import type { Config } from "../config/index.js";
 import type { Logger } from "../logger/index.js";
 import type { WorkflowInstance } from "../types/instance.js";
+import type { ApiCatalog } from "../types/catalog.js";
 import {
   normalizeWatermarkFile,
   type CrawlReport,
@@ -1512,6 +1513,77 @@ describe("crawlInstances box scope resolution", () => {
     // 자체 retry가 있으나, 본 mock은 그쪽에서 5xx를 주지 않으므로 retries는
     // 정확히 1 (probe의 한 번)이어야 한다.
     assert.equal(result.retries, 1);
+  });
+
+  it("user-boxes fallback URL honors catalog override; customer-boxes stays hardcoded", async () => {
+    // catalog가 `instance-search`에 다른 urlPattern을 박아둔 환경(버전/테넌트
+    // 분기) 시뮬레이션. customer-boxes는 카탈로그에 없는 신규 path라 항상
+    // 하드코드를 써야 하고, 403 폴백 시의 user-boxes는 catalog override를
+    // 존중해야 한다.
+    const catalog: ApiCatalog = {
+      version: "test",
+      capturedAt: "2026-05-13T00:00:00Z",
+      flexBaseUrl: "https://flex.test",
+      discoveredPages: [],
+      entries: [
+        {
+          id: "instance-search",
+          discoveredFrom: "test",
+          method: "POST",
+          urlPattern: "/api/v9/custom-tenant/approval-document/user-boxes/search",
+          exampleUrl: "/api/v9/custom-tenant/approval-document/user-boxes/search",
+          statusCode: 200,
+          capturedAt: "2026-05-13T00:00:00Z",
+        },
+      ],
+      unclassified: [],
+    };
+    const calls: CapturedFetch[] = [];
+    globalThis.fetch = (async (input: unknown, init?: { method?: string; body?: string }) => {
+      const url = String(input);
+      const method = init?.method ?? "GET";
+      calls.push({ url, method, body: init?.body ? JSON.parse(init.body) : null });
+      // customer probe → 403 → fallback to user-boxes.
+      if (url.includes("/customer-boxes/search")) {
+        return new Response(JSON.stringify({ message: "권한 없음" }), { status: 403 });
+      }
+      // user-boxes 호출은 catalog override URL로 들어와야 한다.
+      if (url.includes("/api/v9/custom-tenant/approval-document/user-boxes/search")) {
+        return new Response(JSON.stringify({ documents: [], total: 0, hasNext: false }), {
+          status: 200,
+        });
+      }
+      return new Response("nf", { status: 404 });
+    }) as typeof fetch;
+
+    const result = await crawlInstances(
+      makeAuth(),
+      makeConfig(),
+      catalog,
+      makeStorage(),
+      makeLogger(),
+    );
+
+    assert.equal(result.boxScope, "user");
+    // customer probe는 하드코드된 path로 나가야 함 — catalog override가
+    // customer 쪽으로 새지 않는다는 보장.
+    const customerProbe = calls.find((c) =>
+      c.url.includes("/action/v3/approval-document/customer-boxes/search"),
+    );
+    assert.ok(customerProbe, "customer probe must use hardcoded path");
+    // 폴백 후 그룹 search는 catalog override를 탄 user-boxes 경로로 가야 함.
+    const overrideHits = calls.filter((c) =>
+      c.url.includes("/api/v9/custom-tenant/approval-document/user-boxes/search"),
+    );
+    assert.ok(overrideHits.length > 0, "user-boxes searches must honor catalog override");
+    // 하드코드 path로 user-boxes 검색이 새지 않았는지 (override가 무시되지 않았는지).
+    const hardcodedUserHits = calls.filter((c) =>
+      c.url.includes("/action/v3/approval-document/user-boxes/search"),
+    );
+    assert.equal(
+      hardcodedUserHits.length, 0,
+      "must not fall back to hardcoded user-boxes path when catalog overrides it",
+    );
   });
 
   it("scope probe does not retry on 4xx (e.g. 401 unauthorized) — fast-fail to list-stage error", async () => {

--- a/apps/flex-cli/src/crawlers/instance.test.ts
+++ b/apps/flex-cli/src/crawlers/instance.test.ts
@@ -1478,6 +1478,9 @@ describe("crawlInstances box scope resolution", () => {
     assert.equal(wm?.lastFullReconAt, undefined);
     // 스코프도 안 박혀야 함 (실패 cycle이므로 다음 run에서 자가복구 가능).
     assert.equal(wm?.lastCrawledBoxScope, undefined);
+    // 반환값의 boxScope도 undefined여야 한다 — 운영자가 보고서에서 "어느
+    // 스코프로 돌았다"고 오판하지 않게.
+    assert.equal(result.boxScope, undefined);
   });
 
   it("scope probe retries on transient 5xx and recovers", async () => {
@@ -1610,6 +1613,8 @@ describe("crawlInstances box scope resolution", () => {
     assert.equal(probeCalls, 1, "4xx must not be retried");
     // listStageOk=false 경로 — instance-list 에러 1건.
     assert.ok(result.errors.find((e) => e.target === "instance-list"));
+    // 401은 fallback 대상도 아니므로 scope가 결정 안 됨 → undefined.
+    assert.equal(result.boxScope, undefined);
   });
 });
 

--- a/apps/flex-cli/src/crawlers/instance.test.ts
+++ b/apps/flex-cli/src/crawlers/instance.test.ts
@@ -1589,6 +1589,41 @@ describe("crawlInstances box scope resolution", () => {
     );
   });
 
+  it("scope probe retries on 429 (rate-limited)", async () => {
+    // 429는 일시적 throttle 신호 → retry 허용. group search와 동일 동작.
+    let probeCalls = 0;
+    globalThis.fetch = (async (input: unknown) => {
+      const url = String(input);
+      if (url.includes("/customer-boxes/search")) {
+        probeCalls++;
+        if (probeCalls === 1) {
+          return new Response("rate limited", {
+            status: 429,
+            // retry-after 0 — 테스트 속도 위해.
+            headers: { "retry-after": "0" },
+          });
+        }
+        return new Response(JSON.stringify({ documents: [], total: 0, hasNext: false }), {
+          status: 200,
+        });
+      }
+      return new Response("nf", { status: 404 });
+    }) as typeof fetch;
+
+    const result = await crawlInstances(
+      makeAuth(),
+      { ...makeConfig(), maxRetries: 2, requestDelayMs: 0 },
+      null,
+      makeStorage(),
+      makeLogger(),
+    );
+
+    assert.equal(result.boxScope, "customer", "must succeed after 429 retry");
+    assert.ok(probeCalls >= 2, `429 must trigger retry, called ${probeCalls} times`);
+    // 429 retry 1회가 retries 카운터에 잡혀야 한다.
+    assert.equal(result.retries, 1);
+  });
+
   it("scope probe does not retry on 4xx (e.g. 401 unauthorized) — fast-fail to list-stage error", async () => {
     // 4xx는 영구 실패로 간주해 backoff 낭비를 피한다. 401은 403과 달리 fallback
     // 대상도 아니므로 그대로 list-stage catch로 떨어져 listStageOk=false.

--- a/apps/flex-cli/src/crawlers/instance.test.ts
+++ b/apps/flex-cli/src/crawlers/instance.test.ts
@@ -23,6 +23,20 @@ interface CapturedFetch {
   body: unknown;
 }
 
+/**
+ * 그룹 단위 실제 search 호출만 골라내는 헬퍼. crawlInstances는 시작 시 스코프
+ * 결정을 위해 customer-boxes에 `size=1` probe를 한 번 쏘는데, 테스트에서
+ * "이번 실행이 보낸 search call들" 같은 assertion에는 이 probe를 제외하고
+ * 봐야 한다.
+ */
+function isRealSearchCall(c: { url: string }): boolean {
+  if (!c.url.includes("/customer-boxes/search") && !c.url.includes("/user-boxes/search")) {
+    return false;
+  }
+  // 스코프 probe는 query에 size=1, 실제 그룹 search는 searchPageSize(테스트 기본 100).
+  return !/[?&]size=1(?:&|$)/.test(c.url);
+}
+
 const ORIGINAL_FETCH = globalThis.fetch;
 
 function makeAuth(): AuthContext {
@@ -162,7 +176,7 @@ function setupFetch(
     const body = init?.body ? JSON.parse(init.body) : null;
     calls.push({ url, method, body });
 
-    if (url.includes("/user-boxes/search")) {
+    if (url.includes("/customer-boxes/search") || url.includes("/user-boxes/search")) {
       const statuses: string[] = body?.filter?.statuses ?? [];
       const key = statuses.sort().join("|");
       const resp = searchResponses.get(key);
@@ -217,7 +231,7 @@ describe("crawlInstances incremental wiring", () => {
     const result = await crawlInstances(makeAuth(), makeConfig(), null, storage, makeLogger());
 
     assert.equal(result.successCount, 2);
-    const searchCalls = calls.filter((c) => c.url.includes("/user-boxes/search"));
+    const searchCalls = calls.filter((c) => isRealSearchCall(c));
     for (const c of searchCalls) {
       const filter = (c.body as { filter: Record<string, unknown> }).filter;
       assert.ok(
@@ -271,7 +285,7 @@ describe("crawlInstances incremental wiring", () => {
     // file (e.g. left over from a pre-policy run).
     const inProgressCall = calls.find(
       (c) =>
-        c.url.includes("/user-boxes/search") &&
+        isRealSearchCall(c) &&
         Array.isArray((c.body as { filter: { statuses: string[] } }).filter.statuses) &&
         (c.body as { filter: { statuses: string[] } }).filter.statuses[0] === "IN_PROGRESS",
     );
@@ -284,7 +298,7 @@ describe("crawlInstances incremental wiring", () => {
 
     const doneCall = calls.find(
       (c) =>
-        c.url.includes("/user-boxes/search") &&
+        isRealSearchCall(c) &&
         (c.body as { filter: { statuses: string[] } }).filter.statuses.includes("DONE"),
     );
     assert.ok(doneCall);
@@ -323,7 +337,7 @@ describe("crawlInstances incremental wiring", () => {
       "full",
     );
 
-    const searchCalls = calls.filter((c) => c.url.includes("/user-boxes/search"));
+    const searchCalls = calls.filter((c) => isRealSearchCall(c));
     for (const c of searchCalls) {
       const filter = (c.body as { filter: Record<string, unknown> }).filter;
       assert.ok(
@@ -410,7 +424,7 @@ describe("crawlInstances incremental wiring", () => {
     assert.equal(result.failureCount, 0);
     const doneCall = calls.find(
       (c) =>
-        c.url.includes("/user-boxes/search") &&
+        isRealSearchCall(c) &&
         (c.body as { filter: { statuses: string[] } }).filter.statuses.includes("DONE"),
     );
     assert.ok(doneCall);
@@ -462,7 +476,7 @@ describe("crawlInstances incremental wiring", () => {
     // lastUpdatedDateRange in the done search.
     const doneCall = calls.find(
       (c) =>
-        c.url.includes("/user-boxes/search") &&
+        isRealSearchCall(c) &&
         (c.body as { filter: { statuses: string[] } }).filter.statuses.includes("DONE"),
     );
     assert.ok(doneCall);
@@ -697,7 +711,7 @@ describe("crawlInstances incremental wiring", () => {
     // listStageOk flag must still block the full-recon outcomes.
     globalThis.fetch = (async (input: unknown) => {
       const url = String(input);
-      if (url.includes("/user-boxes/search")) {
+      if (url.includes("/customer-boxes/search") || url.includes("/user-boxes/search")) {
         return new Response("server error", { status: 500 });
       }
       return new Response("not found", { status: 404 });
@@ -1086,7 +1100,7 @@ describe("crawlInstances incremental wiring", () => {
     // Permanent search 500 → listStageOk=false → sweep must not run.
     globalThis.fetch = (async (input: unknown) => {
       const url = String(input);
-      if (url.includes("/user-boxes/search")) {
+      if (url.includes("/customer-boxes/search") || url.includes("/user-boxes/search")) {
         return new Response("server error", { status: 500 });
       }
       return new Response("not found", { status: 404 });
@@ -1154,7 +1168,7 @@ describe("crawlInstances incremental wiring", () => {
 
     const inProgressCall = calls.find(
       (c) =>
-        c.url.includes("/user-boxes/search") &&
+        isRealSearchCall(c) &&
         (c.body as { filter: { statuses: string[] } }).filter.statuses[0] === "IN_PROGRESS",
     );
     assert.ok(inProgressCall);
@@ -1341,5 +1355,115 @@ describe("computeSignatureHash", () => {
       computeSignatureHash(detail({ comments: [c1, c2] })),
       computeSignatureHash(detail({ comments: [c2, c1] })),
     );
+  });
+});
+
+describe("crawlInstances box scope resolution", () => {
+  beforeEach(() => {
+    globalThis.fetch = ORIGINAL_FETCH;
+  });
+  afterEach(() => {
+    globalThis.fetch = ORIGINAL_FETCH;
+  });
+
+  it("uses customer-boxes when scope probe returns 200", async () => {
+    const calls: CapturedFetch[] = [];
+    globalThis.fetch = (async (input: unknown, init?: { method?: string; body?: string }) => {
+      const url = String(input);
+      const method = init?.method ?? "GET";
+      calls.push({ url, method, body: init?.body ? JSON.parse(init.body) : null });
+      if (url.includes("/customer-boxes/search") || url.includes("/user-boxes/search")) {
+        return new Response(JSON.stringify({ documents: [], total: 0, hasNext: false }), {
+          status: 200,
+        });
+      }
+      return new Response("nf", { status: 404 });
+    }) as typeof fetch;
+
+    const result = await crawlInstances(
+      makeAuth(), makeConfig(), null, makeStorage(), makeLogger(),
+    );
+
+    assert.equal(result.boxScope, "customer");
+    const realSearches = calls.filter(isRealSearchCall);
+    assert.ok(realSearches.length > 0, "must have made at least one real search call");
+    for (const c of realSearches) {
+      assert.ok(
+        c.url.includes("/customer-boxes/search"),
+        `real search must hit customer-boxes, got ${c.url}`,
+      );
+    }
+    // 403 폴백 분기는 트리거되지 않아야 하므로 scope-detect 에러도 없어야 한다.
+    assert.equal(
+      result.errors.find((e) => e.target === "instance-scope"),
+      undefined,
+    );
+  });
+
+  it("falls back to user-boxes when customer-boxes probe returns 403", async () => {
+    const calls: CapturedFetch[] = [];
+    globalThis.fetch = (async (input: unknown, init?: { method?: string; body?: string }) => {
+      const url = String(input);
+      const method = init?.method ?? "GET";
+      calls.push({ url, method, body: init?.body ? JSON.parse(init.body) : null });
+      if (url.includes("/customer-boxes/search")) {
+        return new Response(
+          JSON.stringify({ status: 403, code: "PERM_403_000", message: "권한이 없습니다" }),
+          { status: 403 },
+        );
+      }
+      if (url.includes("/user-boxes/search")) {
+        return new Response(JSON.stringify({ documents: [], total: 0, hasNext: false }), {
+          status: 200,
+        });
+      }
+      return new Response("nf", { status: 404 });
+    }) as typeof fetch;
+
+    const storage = makeStorage();
+    const result = await crawlInstances(makeAuth(), makeConfig(), null, storage, makeLogger());
+
+    assert.equal(result.boxScope, "user");
+    // 폴백 후 실제 그룹 search는 모두 user-boxes로 가야 한다.
+    const realSearches = calls.filter(isRealSearchCall);
+    assert.ok(realSearches.length > 0, "must have made at least one real search call");
+    for (const c of realSearches) {
+      assert.ok(
+        c.url.includes("/user-boxes/search"),
+        `after fallback, real search must hit user-boxes, got ${c.url}`,
+      );
+    }
+    // 폴백은 silent하지 않아야 한다 — result.errors에 scope-detect 항목.
+    const scopeErr = result.errors.find((e) => e.target === "instance-scope");
+    assert.ok(scopeErr, "fallback must push an instance-scope error for visibility");
+    assert.equal(scopeErr?.phase, "scope-detect");
+    // 폴백 자체는 failure로 안 카운트해서 워터마크 갱신을 막지 않는다 — 운영자가
+    // 비관리자 계정으로 의도적으로 user-boxes 모집단을 받고 있을 수 있다.
+    assert.equal(result.failureCount, 0);
+  });
+
+  it("non-403 probe failure aborts the list stage (listStageOk=false path)", async () => {
+    const calls: CapturedFetch[] = [];
+    globalThis.fetch = (async (input: unknown, init?: { method?: string; body?: string }) => {
+      const url = String(input);
+      const method = init?.method ?? "GET";
+      calls.push({ url, method, body: init?.body ? JSON.parse(init.body) : null });
+      if (url.includes("/customer-boxes/search")) {
+        return new Response("server error", { status: 500 });
+      }
+      return new Response("nf", { status: 404 });
+    }) as typeof fetch;
+
+    const storage = makeStorage();
+    const result = await crawlInstances(makeAuth(), makeConfig(), null, storage, makeLogger());
+
+    // probe가 500으로 throw → list-stage catch로 떨어져 instance-list 에러 1건.
+    const listErr = result.errors.find((e) => e.target === "instance-list");
+    assert.ok(listErr, "non-403 probe failure must be recorded as a list-stage error");
+    // 그룹 루프에 진입하기 전이라 그룹 워터마크도 lastFullReconAt도 안 박혀야 한다.
+    // (domain entry 자체는 빈 groups로 저장되지만 의미 있는 진행은 없음.)
+    const wm = storage._watermarks.approvalDocuments;
+    assert.deepEqual(wm?.groups ?? {}, {});
+    assert.equal(wm?.lastFullReconAt, undefined);
   });
 });

--- a/apps/flex-cli/src/crawlers/instance.ts
+++ b/apps/flex-cli/src/crawlers/instance.ts
@@ -387,13 +387,20 @@ async function resolveBoxScope(
   const probeUrl = `${customerUrl}?size=1&sortType=LAST_UPDATED_AT&direction=DESC`;
   try {
     // 그룹 search와 동일한 회복력을 갖도록 withRetry로 감싼다 — 그렇지 않으면
-    // 일시적 429/5xx/네트워크 블립이 list-stage 전체를 죽인다. 단 403은
-    // "권한 없음 = user-boxes로 폴백"의 신호로 사용하므로 재시도 대상에서
-    // 제외 — `shouldRetry`로 4xx 전부를 차단해 4xx류는 단발 throw로 끝낸다.
+    // 일시적 429/5xx/네트워크 블립이 list-stage 전체를 죽인다. 재시도 정책:
+    //   - 429: rate-limited → withRetry가 `retryAfterMs`를 존중하며 재시도.
+    //   - 5xx, 네트워크/파싱 에러: 재시도.
+    //   - 그 외 4xx (400/401/403/404): 영구 실패 — 재시도 무의미하므로 fast-fail.
+    //     특히 403은 "권한 없음 = user-boxes로 폴백"의 신호로 사용된다.
     await withRetry(() => flexPost(authCtx, probeUrl, probeBody), {
       maxRetries: config.maxRetries,
       delayMs: config.requestDelayMs,
-      shouldRetry: (e) => !(e instanceof FlexHttpError && e.status >= 400 && e.status < 500),
+      shouldRetry: (e) => {
+        if (!(e instanceof FlexHttpError)) return true;
+        if (e.status === 429) return true;
+        if (e.status >= 400 && e.status < 500) return false;
+        return true;
+      },
       onRetry: () => result.retries++,
     });
     logger.info("결재 문서 검색 스코프: customer (워크스페이스 전체)");

--- a/apps/flex-cli/src/crawlers/instance.ts
+++ b/apps/flex-cli/src/crawlers/instance.ts
@@ -64,8 +64,9 @@ export async function crawlInstances(
      * 이번 run이 실제로 사용한 검색 스코프. scope probe가 throw해서 그룹 루프에
      * 진입조차 못 한 경우 undefined — "어느 스코프로 돌았다"고 잘못 보고하지
      * 않기 위함. 호출자가 보고서/자동화에서 이 값만 보고 분기하더라도 안전하다.
-     * 실패 경위는 `result.errors`의 `instance-list`/`instance-scope` 항목에서
-     * 확인 가능.
+     * 실패한 cycle의 원인은 `result.errors`의 `instance-list` 항목에서 확인.
+     * 403→user 폴백은 실패가 아니므로 errors에 새지 않는다 — 보고서의
+     * `instancesBoxScope: "user"` 값과 logger.warn 한 줄로만 신호한다.
      */
     boxScope: BoxScope | undefined;
   }
@@ -139,10 +140,11 @@ export async function crawlInstances(
 
   try {
     // 검색 스코프 probe — customer-boxes(워크스페이스 전체)를 우선 시도하고
-    // 403(관리자 권한 부재)이면 user-boxes로 폴백. 폴백은 silent하지 않게
-    // warn 로그 + result.errors push로 운영자에게 노출한다. 403 외 에러
-    // (네트워크/5xx 등)는 그대로 throw → 아래 catch가 listStageOk=false로
-    // 떨어뜨려 워터마크/lastFullReconAt 갱신을 보류한다.
+    // 403(관리자 권한 부재)이면 user-boxes로 폴백. 폴백은 비치명이므로 errors
+    // 에는 새지 않고 logger.warn 한 줄 + 보고서의 `instancesBoxScope: "user"`
+    // 값으로만 신호한다 (errors에 넣으면 flex-ax crawl이 exit code 2로 죽음).
+    // 403 외 에러 (네트워크/5xx 등)는 그대로 throw → 아래 catch가
+    // listStageOk=false로 떨어뜨려 워터마크/lastFullReconAt 갱신을 보류한다.
     const resolved = await resolveBoxScope(authCtx, config, catalog, logger, result);
     boxScope = resolved.scope;
     searchUrl = resolved.url;
@@ -348,9 +350,11 @@ export async function crawlInstances(
 /**
  * 검색 스코프(customer vs user)를 한 번의 size=1 probe로 결정한다.
  * customer-boxes는 관리자 권한이 있어야 200을 받고, 권한 없으면 403이 떨어진다.
- * 비관리자 계정에서도 크롤이 멈추지 않도록 user-boxes로 폴백하되, 운영자가
- * 알 수 있게 warn + result.errors에 기록 — silent하게 모집단이 줄어드는 것
- * 방지가 목적이다(planetarium/reflex#49 참조).
+ * 비관리자 계정에서도 크롤이 멈추지 않도록 user-boxes로 폴백하되, silent하게
+ * 모집단이 줄어들지 않도록 logger.warn으로 알린다. 폴백은 "성공이지만 좁아진"
+ * 비치명 상태이므로 result.errors에는 push하지 않는다 — CLI exit code가
+ * 진짜 실패와 구분되지 않게 된다. 보고서의 `instancesBoxScope: "user"` 값이
+ * 운영자가 보고서만 봐도 알아챌 수 있는 통합 신호다 (planetarium/reflex#49 참조).
  *
  * 403 외의 에러는 라우팅·서비스 장애일 수 있으므로 그대로 throw하여 호출자
  * 레벨의 list-stage catch가 처리하게 한다 (이때 listStageOk=false로 떨어져

--- a/apps/flex-cli/src/crawlers/instance.ts
+++ b/apps/flex-cli/src/crawlers/instance.ts
@@ -13,6 +13,7 @@ import type { ApprovalStep, AttachmentInfo, FieldValue } from "../types/common.j
 import {
   type CrawlResult,
   emptyCrawlResult,
+  FlexHttpError,
   nowISO,
   isLaterIso,
   toKstDate,
@@ -27,6 +28,20 @@ export type CrawlMode = "incremental" | "full";
 
 const APPROVAL_DOCUMENTS_DOMAIN = "approvalDocuments";
 const MS_PER_DAY = 86_400_000;
+
+/**
+ * 결재 문서 검색 스코프.
+ *  - "customer": `/customer-boxes/search` — 워크스페이스 전체. 관리자 권한 필요.
+ *  - "user":     `/user-boxes/search`     — 로그인 계정이 작성자/결재자/참조자로
+ *                                          포함된 문서만 (작성함/결재함/참조함/즐겨찾기).
+ * 디폴트는 "customer"로 시도하고 403이 떨어지면 "user"로 폴백한다.
+ * planetarium/reflex#49 참조 — 비-customer 스코프에서 큰 워크스페이스는
+ * 워크스페이스 모집단의 ~30% 수준만 보인다.
+ */
+export type BoxScope = "customer" | "user";
+
+const CUSTOMER_BOXES_SEARCH_PATH = "/action/v3/approval-document/customer-boxes/search";
+const USER_BOXES_SEARCH_PATH = "/action/v3/approval-document/user-boxes/search";
 
 interface DateRange {
   from: string;
@@ -45,6 +60,7 @@ export async function crawlInstances(
     collectedKeys: Set<string>;
     missingKeys: string[];
     closedSweepCount: number;
+    boxScope: BoxScope;
   }
 > {
   const startTime = Date.now();
@@ -58,10 +74,13 @@ export async function crawlInstances(
 
   logger.info("인스턴스(결재 문서) 수집 시작", { mode });
 
-  const searchUrl = resolveUrl(
-    config.flexBaseUrl, catalog, "instance-search",
-    "/action/v3/approval-document/user-boxes/search",
-  );
+  // 스코프 결정은 list-stage try 안에서 수행한다 (아래 참조). 여기서는 catch
+  // 경로에서도 의미를 갖는 안전한 디폴트만 박아둔다 — list-stage가 throw해도
+  // 반환 객체의 boxScope는 undefined가 아니라 "customer"가 되어 운영자가
+  // "스코프 결정 전에 죽음"을 한눈에 식별할 수 있다 (errors에 스코프 probe
+  // 실패가 함께 기록되므로 모집단이 좁아진 fallback 케이스와 헷갈리지 않는다).
+  let boxScope: BoxScope = "customer";
+  let searchUrl = `${config.flexBaseUrl}${CUSTOMER_BOXES_SEARCH_PATH}`;
   const detailBase = resolveUrl(
     config.flexBaseUrl, catalog, "instance-detail",
     "/api/v3/approval-document/approval-documents",
@@ -133,6 +152,15 @@ export async function crawlInstances(
   let listStageOk = true;
 
   try {
+    // 검색 스코프 probe — customer-boxes(워크스페이스 전체)를 우선 시도하고
+    // 403(관리자 권한 부재)이면 user-boxes로 폴백. 폴백은 silent하지 않게
+    // warn 로그 + result.errors push로 운영자에게 노출한다. 403 외 에러
+    // (네트워크/5xx 등)는 그대로 throw → 아래 catch가 listStageOk=false로
+    // 떨어뜨려 워터마크/lastFullReconAt 갱신을 보류한다.
+    const resolved = await resolveBoxScope(authCtx, config, logger, result);
+    boxScope = resolved.scope;
+    searchUrl = resolved.url;
+
     for (const group of searchGroups) {
       const existing = domainState.groups[group.label];
       // incrementalEligible=false 그룹은 워터마크/풀모드 무관 항상 전수 sweep.
@@ -270,7 +298,61 @@ export async function crawlInstances(
 
   result.durationMs = Date.now() - startTime;
   logger.info(`\n인스턴스 수집 완료: 성공 ${result.successCount}, 실패 ${result.failureCount}`);
-  return { ...result, collectedKeys, missingKeys, closedSweepCount };
+  return { ...result, collectedKeys, missingKeys, closedSweepCount, boxScope };
+}
+
+/**
+ * 검색 스코프(customer vs user)를 한 번의 size=1 probe로 결정한다.
+ * customer-boxes는 관리자 권한이 있어야 200을 받고, 권한 없으면 403이 떨어진다.
+ * 비관리자 계정에서도 크롤이 멈추지 않도록 user-boxes로 폴백하되, 운영자가
+ * 알 수 있게 warn + result.errors에 기록 — silent하게 모집단이 줄어드는 것
+ * 방지가 목적이다(planetarium/reflex#49 참조).
+ *
+ * 403 외의 에러는 라우팅·서비스 장애일 수 있으므로 그대로 throw하여 호출자
+ * 레벨의 list-stage catch가 처리하게 한다 (이때 listStageOk=false로 떨어져
+ * watermark/lastFullReconAt 갱신이 보류된다).
+ */
+async function resolveBoxScope(
+  authCtx: AuthContext,
+  config: Config,
+  logger: Logger,
+  result: CrawlResult,
+): Promise<{ scope: BoxScope; url: string }> {
+  const customerUrl = `${config.flexBaseUrl}${CUSTOMER_BOXES_SEARCH_PATH}`;
+  const userUrl = `${config.flexBaseUrl}${USER_BOXES_SEARCH_PATH}`;
+  const probeBody = {
+    filter: {
+      statuses: ["DONE"],
+      templateKeys: [],
+      writerHashedIds: [],
+      approverTargets: [],
+      referrerTargets: [],
+      starred: false,
+    },
+    search: { keyword: "", type: "ALL" },
+  };
+  const probeUrl = `${customerUrl}?size=1&sortType=LAST_UPDATED_AT&direction=DESC`;
+  try {
+    await flexPost(authCtx, probeUrl, probeBody);
+    logger.info("결재 문서 검색 스코프: customer (워크스페이스 전체)");
+    return { scope: "customer", url: customerUrl };
+  } catch (err) {
+    if (err instanceof FlexHttpError && err.status === 403) {
+      logger.warn(
+        "customer-boxes/search 403 — user-boxes로 폴백. 워크스페이스 전체가 아닌 " +
+          "로그인 계정이 관여한 문서만 수집됩니다. 전체 모집단을 보려면 크롤러 계정에 " +
+          "관리자 권한을 부여하세요. (planetarium/reflex#49)",
+      );
+      result.errors.push({
+        target: "instance-scope",
+        phase: "scope-detect",
+        message: "customer-boxes 403, fallback to user-boxes (narrower scope)",
+        timestamp: nowISO(),
+      });
+      return { scope: "user", url: userUrl };
+    }
+    throw err;
+  }
 }
 
 interface SearchGroup {

--- a/apps/flex-cli/src/crawlers/instance.ts
+++ b/apps/flex-cli/src/crawlers/instance.ts
@@ -412,12 +412,11 @@ async function resolveBoxScope(
           "로그인 계정이 관여한 문서만 수집됩니다. 전체 모집단을 보려면 크롤러 계정에 " +
           "관리자 권한을 부여하세요. (planetarium/reflex#49)",
       );
-      result.errors.push({
-        target: "instance-scope",
-        phase: "scope-detect",
-        message: "customer-boxes 403, fallback to user-boxes (narrower scope)",
-        timestamp: nowISO(),
-      });
+      // 폴백은 "성공이지만 모집단이 좁아진" 상태이지 실패가 아니다 —
+      // result.errors에 넣으면 `flex-ax crawl`이 exit code 2로 죽어 CI/cron이
+      // 진짜 실패와 구분 못 한다. 가시성은 (a) logger.warn 한 줄 + (b) 보고서의
+      // `instancesBoxScope: "user"` 값으로 확보 — 비관리자로 의도적으로 돌리는
+      // 운영도, 권한이 회수되어 좁아진 상태도 같은 두 신호로 다 잡힌다.
       return { scope: "user", url: userUrl };
     }
     throw err;

--- a/apps/flex-cli/src/crawlers/instance.ts
+++ b/apps/flex-cli/src/crawlers/instance.ts
@@ -122,10 +122,11 @@ export async function crawlInstances(
 
   // effectiveFull / existingBeforeRun은 검색 스코프(`boxScope`) 결정 후에야
   // 확정할 수 있다 (스코프 변경 시 자동 풀크롤 트리거 때문). 따라서 try 안에서
-  // 결정하고, 외부에서는 fallback 의미의 디폴트만 잡아둔다.
-  //   - effectiveFull: scope probe가 throw해서 try에 진입하기 전에 catch로
-  //     떨어진 경우, "정상 진행 못함"이므로 false로 둔다. listStageOk=false도
-  //     함께 잡혀 lastFullReconAt이 갱신되지 않는다.
+  // 결정하고, 여기서는 catch로 떨어졌을 때 사용되는 디폴트만 박아둔다.
+  //   - effectiveFull: scope probe가 try 내부에서 throw하면 catch로 떨어져
+  //     이 값이 그대로 사용된다. 명시적 `--mode=full` 외에는 false — "정상 진행
+  //     못함"이므로 풀크롤 stamp/missing diff를 트리거하지 않는다. catch에서
+  //     함께 listStageOk=false가 되어 lastFullReconAt 갱신은 어차피 막힌다.
   //   - existingBeforeRun: null이면 missing diff 자체를 생략 — 부분 결과에서
   //     missing 후보를 만들면 false positive 폭증.
   let effectiveFull = mode === "full";

--- a/apps/flex-cli/src/crawlers/instance.ts
+++ b/apps/flex-cli/src/crawlers/instance.ts
@@ -134,7 +134,7 @@ export async function crawlInstances(
     // warn 로그 + result.errors push로 운영자에게 노출한다. 403 외 에러
     // (네트워크/5xx 등)는 그대로 throw → 아래 catch가 listStageOk=false로
     // 떨어뜨려 워터마크/lastFullReconAt 갱신을 보류한다.
-    const resolved = await resolveBoxScope(authCtx, config, logger, result);
+    const resolved = await resolveBoxScope(authCtx, config, catalog, logger, result);
     boxScope = resolved.scope;
     searchUrl = resolved.url;
 
@@ -350,11 +350,20 @@ export async function crawlInstances(
 async function resolveBoxScope(
   authCtx: AuthContext,
   config: Config,
+  catalog: ApiCatalog | null,
   logger: Logger,
   result: CrawlResult,
 ): Promise<{ scope: BoxScope; url: string }> {
+  // user-boxes는 기존 크롤러가 쓰던 경로라 카탈로그에 `instance-search` 엔트리가
+  // 이미 박혀 있을 수 있다(버전·테넌트별 분기를 카탈로그가 흡수). 폴백 경로에서도
+  // 그 override를 존중하기 위해 resolveUrl로 푼다.
+  // customer-boxes는 신규 도입 path이고 카탈로그 발견 대상이 아니므로(`instance-search`
+  // 가 user-boxes에 묶여 있기 때문에) 하드코드 유지 — catalog override를 적용하면
+  // 잘못된 URL에 customer-scope query를 쏘게 된다.
   const customerUrl = `${config.flexBaseUrl}${CUSTOMER_BOXES_SEARCH_PATH}`;
-  const userUrl = `${config.flexBaseUrl}${USER_BOXES_SEARCH_PATH}`;
+  const userUrl = resolveUrl(
+    config.flexBaseUrl, catalog, "instance-search", USER_BOXES_SEARCH_PATH,
+  );
   const probeBody = {
     filter: {
       statuses: ["DONE"],

--- a/apps/flex-cli/src/crawlers/instance.ts
+++ b/apps/flex-cli/src/crawlers/instance.ts
@@ -60,7 +60,14 @@ export async function crawlInstances(
     collectedKeys: Set<string>;
     missingKeys: string[];
     closedSweepCount: number;
-    boxScope: BoxScope;
+    /**
+     * 이번 run이 실제로 사용한 검색 스코프. scope probe가 throw해서 그룹 루프에
+     * 진입조차 못 한 경우 undefined — "어느 스코프로 돌았다"고 잘못 보고하지
+     * 않기 위함. 호출자가 보고서/자동화에서 이 값만 보고 분기하더라도 안전하다.
+     * 실패 경위는 `result.errors`의 `instance-list`/`instance-scope` 항목에서
+     * 확인 가능.
+     */
+    boxScope: BoxScope | undefined;
   }
 > {
   const startTime = Date.now();
@@ -74,13 +81,14 @@ export async function crawlInstances(
 
   logger.info("인스턴스(결재 문서) 수집 시작", { mode });
 
-  // 스코프 결정은 list-stage try 안에서 수행한다 (아래 참조). 여기서는 catch
-  // 경로에서도 의미를 갖는 안전한 디폴트만 박아둔다 — list-stage가 throw해도
-  // 반환 객체의 boxScope는 undefined가 아니라 "customer"가 되어 운영자가
-  // "스코프 결정 전에 죽음"을 한눈에 식별할 수 있다 (errors에 스코프 probe
-  // 실패가 함께 기록되므로 모집단이 좁아진 fallback 케이스와 헷갈리지 않는다).
-  let boxScope: BoxScope = "customer";
-  let searchUrl = `${config.flexBaseUrl}${CUSTOMER_BOXES_SEARCH_PATH}`;
+  // boxScope는 scope probe가 성공한 뒤에만 채워진다 — probe가 throw해서 그룹
+  // 루프에 진입조차 못 한 경우에는 undefined로 남아 보고서에 그대로 흘러간다.
+  // "운영자가 scope 필드만 보고도 어느 스코프로 돌았는지 분명히 알 수 있어야
+  // 한다"는 원칙: 5xx/401 등으로 실패한 cycle에 임의의 디폴트("customer")를
+  // 박아두면 자동화/대시보드가 "customer로 정상 동작 중"이라고 오판할 위험.
+  // searchUrl은 try 안에서만 실제로 사용되므로 catch 경로에서의 값은 의미 없음.
+  let boxScope: BoxScope | undefined;
+  let searchUrl = "";
   const detailBase = resolveUrl(
     config.flexBaseUrl, catalog, "instance-detail",
     "/api/v3/approval-document/approval-documents",

--- a/apps/flex-cli/src/crawlers/instance.ts
+++ b/apps/flex-cli/src/crawlers/instance.ts
@@ -109,42 +109,19 @@ export async function crawlInstances(
   const watermarks = await storage.loadWatermarks();
   const domainState: WatermarkDomainState =
     watermarks[APPROVAL_DOCUMENTS_DOMAIN] ?? { groups: {} };
-  // incremental-eligible 그룹들에 워터마크가 모두 비어 있다면 부트스트랩 —
-  // 사실상 풀크롤. 비-eligible 그룹(IN_PROGRESS sweep)은 어차피 매 실행
-  // 전수 fetch라 effectiveFull 판정에서 제외한다.
-  const noWatermarks = searchGroups
-    .filter((g) => g.incrementalEligible)
-    .every((g) => !domainState.groups[g.label]?.lastUpdatedAt);
-  const effectiveFull = mode === "full" || noWatermarks;
-  if (mode === "incremental" && noWatermarks) {
-    logger.info("워터마크 없음 — bootstrap 풀크롤로 진행");
-  }
   // to 날짜는 그룹 진입 전에 한 번 캡처해서 페이지/그룹 간 일관되게 사용.
   const todayKst = toKstDate(new Date());
 
-  // full reconciliation diff: effectiveFull일 때만 시작 시점의 디스크 상
-  // docKey 집합을 캡처해두고, 종료 후 collectedKeys와 차집합을 missing
-  // 후보로 보고서에 노출. 자동 tombstone은 별도 트랙.
+  // effectiveFull / existingBeforeRun은 검색 스코프(`boxScope`) 결정 후에야
+  // 확정할 수 있다 (스코프 변경 시 자동 풀크롤 트리거 때문). 따라서 try 안에서
+  // 결정하고, 외부에서는 fallback 의미의 디폴트만 잡아둔다.
+  //   - effectiveFull: scope probe가 throw해서 try에 진입하기 전에 catch로
+  //     떨어진 경우, "정상 진행 못함"이므로 false로 둔다. listStageOk=false도
+  //     함께 잡혀 lastFullReconAt이 갱신되지 않는다.
+  //   - existingBeforeRun: null이면 missing diff 자체를 생략 — 부분 결과에서
+  //     missing 후보를 만들면 false positive 폭증.
+  let effectiveFull = mode === "full";
   let existingBeforeRun: Set<string> | null = null;
-  if (effectiveFull) {
-    try {
-      existingBeforeRun = await storage.listExistingInstanceKeys();
-      logger.info("full recon — 기존 docKey 스냅샷 캡처", {
-        count: existingBeforeRun.size,
-      });
-    } catch (err) {
-      // 스냅샷 실패는 missing diff만 비우고 크롤은 계속 진행 (비치명적).
-      logger.error("기존 docKey 스냅샷 실패 — missing diff 생략", {
-        error: err instanceof Error ? err.message : String(err),
-      });
-      result.errors.push({
-        target: "instance-recon",
-        phase: "list-existing",
-        message: err instanceof Error ? err.message : String(err),
-        timestamp: nowISO(),
-      });
-    }
-  }
 
   // list-stage(검색 단계)가 try 끝까지 도달했는지 추적. crawlSearchGroup이
   // 재시도 후에도 throw하면 catch에서 false로 전환. failureCount는 doc 단위
@@ -160,6 +137,55 @@ export async function crawlInstances(
     const resolved = await resolveBoxScope(authCtx, config, logger, result);
     boxScope = resolved.scope;
     searchUrl = resolved.url;
+
+    // incremental-eligible 그룹들에 워터마크가 모두 비어 있다면 부트스트랩 —
+    // 사실상 풀크롤. 비-eligible 그룹(IN_PROGRESS sweep)은 어차피 매 실행
+    // 전수 fetch라 effectiveFull 판정에서 제외한다.
+    const noWatermarks = searchGroups
+      .filter((g) => g.incrementalEligible)
+      .every((g) => !domainState.groups[g.label]?.lastUpdatedAt);
+    // 스코프가 직전 성공 run과 다르면(또는 처음 보는 필드면) 이번 사이클을
+    // 풀크롤로 강제. 핵심 케이스: user-boxes 시절 워터마크가 있는 환경이
+    // customer-boxes로 업그레이드된 직후, 운영자가 `--mode=full`을 명시적으로
+    // 주지 않아도 자동으로 백필이 일어난다 (planetarium/reflex#49 후속).
+    // 이미 부트스트랩이거나 풀모드면 굳이 mismatch 로그를 띄우지 않는다.
+    const scopeMismatch =
+      !noWatermarks && domainState.lastCrawledBoxScope !== boxScope;
+    if (mode === "full") {
+      // 명시적 풀모드 — effectiveFull은 이미 true로 초기화됨, 추가 로그 없음.
+    } else if (noWatermarks) {
+      effectiveFull = true;
+      logger.info("워터마크 없음 — bootstrap 풀크롤로 진행");
+    } else if (scopeMismatch) {
+      effectiveFull = true;
+      logger.info("결재 문서 검색 스코프 변경 감지 — 이번 사이클은 풀크롤로 진행", {
+        previousScope: domainState.lastCrawledBoxScope ?? null,
+        currentScope: boxScope,
+      });
+    }
+
+    // full reconciliation diff: effectiveFull일 때만 시작 시점의 디스크 상
+    // docKey 집합을 캡처해두고, 종료 후 collectedKeys와 차집합을 missing
+    // 후보로 보고서에 노출. 자동 tombstone은 별도 트랙.
+    if (effectiveFull) {
+      try {
+        existingBeforeRun = await storage.listExistingInstanceKeys();
+        logger.info("full recon — 기존 docKey 스냅샷 캡처", {
+          count: existingBeforeRun.size,
+        });
+      } catch (err) {
+        // 스냅샷 실패는 missing diff만 비우고 크롤은 계속 진행 (비치명적).
+        logger.error("기존 docKey 스냅샷 실패 — missing diff 생략", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+        result.errors.push({
+          target: "instance-recon",
+          phase: "list-existing",
+          message: err instanceof Error ? err.message : String(err),
+          timestamp: nowISO(),
+        });
+      }
+    }
 
     for (const group of searchGroups) {
       const existing = domainState.groups[group.label];
@@ -258,6 +284,15 @@ export async function crawlInstances(
   // 대상이다 — successCount는 게이트하지 않는다.
   if (effectiveFull && listStageOk && result.failureCount === 0) {
     domainState.lastFullReconAt = nowISO();
+  }
+
+  // 직전 성공 run의 스코프를 기록한다. listStageOk && failureCount===0 일 때만
+  // 박는다 — 부분 실패 cycle에서 갱신하면 다음 run이 "스코프 일치"로 오판해
+  // 자동 풀크롤 트리거를 놓칠 수 있다 (자가복구 경로가 막힘). effectiveFull은
+  // 게이트하지 않는다 — incremental 사이클에서도 "여전히 같은 스코프"라는
+  // 사실은 확정할 가치가 있다.
+  if (listStageOk && result.failureCount === 0) {
+    domainState.lastCrawledBoxScope = boxScope;
   }
 
   // Full recon diff — 디스크에 있었지만 이번 실행 목록에서 사라진 docKey들.

--- a/apps/flex-cli/src/crawlers/instance.ts
+++ b/apps/flex-cli/src/crawlers/instance.ts
@@ -368,7 +368,16 @@ async function resolveBoxScope(
   };
   const probeUrl = `${customerUrl}?size=1&sortType=LAST_UPDATED_AT&direction=DESC`;
   try {
-    await flexPost(authCtx, probeUrl, probeBody);
+    // 그룹 search와 동일한 회복력을 갖도록 withRetry로 감싼다 — 그렇지 않으면
+    // 일시적 429/5xx/네트워크 블립이 list-stage 전체를 죽인다. 단 403은
+    // "권한 없음 = user-boxes로 폴백"의 신호로 사용하므로 재시도 대상에서
+    // 제외 — `shouldRetry`로 4xx 전부를 차단해 4xx류는 단발 throw로 끝낸다.
+    await withRetry(() => flexPost(authCtx, probeUrl, probeBody), {
+      maxRetries: config.maxRetries,
+      delayMs: config.requestDelayMs,
+      shouldRetry: (e) => !(e instanceof FlexHttpError && e.status >= 400 && e.status < 500),
+      onRetry: () => result.retries++,
+    });
     logger.info("결재 문서 검색 스코프: customer (워크스페이스 전체)");
     return { scope: "customer", url: customerUrl };
   } catch (err) {

--- a/apps/flex-cli/src/storage/index.test.ts
+++ b/apps/flex-cli/src/storage/index.test.ts
@@ -34,8 +34,16 @@ describe("normalizeWatermarkFile", () => {
       approvalDocuments: { groups: "not-an-object" },
       other: { groups: [1, 2] },
     });
-    assert.deepEqual(result.approvalDocuments, { groups: {}, lastFullReconAt: undefined });
-    assert.deepEqual(result.other, { groups: {}, lastFullReconAt: undefined });
+    assert.deepEqual(result.approvalDocuments, {
+      groups: {},
+      lastFullReconAt: undefined,
+      lastCrawledBoxScope: undefined,
+    });
+    assert.deepEqual(result.other, {
+      groups: {},
+      lastFullReconAt: undefined,
+      lastCrawledBoxScope: undefined,
+    });
   });
 
   it("drops malformed group entries while keeping well-formed siblings", () => {
@@ -179,10 +187,27 @@ describe("normalizeWatermarkFile", () => {
           },
         },
         lastFullReconAt: "2026-04-20T00:00:00Z",
+        lastCrawledBoxScope: "customer",
       },
     };
     const result = normalizeWatermarkFile(raw);
     assert.deepEqual(result, raw);
+  });
+
+  it("normalizes lastCrawledBoxScope: keeps customer/user, drops garbage", () => {
+    const result = normalizeWatermarkFile({
+      a: { groups: {}, lastCrawledBoxScope: "customer" },
+      b: { groups: {}, lastCrawledBoxScope: "user" },
+      c: { groups: {}, lastCrawledBoxScope: "admin" }, // not in enum
+      d: { groups: {}, lastCrawledBoxScope: 42 },
+      e: { groups: {} }, // absent
+    });
+    assert.equal(result.a!.lastCrawledBoxScope, "customer");
+    assert.equal(result.b!.lastCrawledBoxScope, "user");
+    // 손상된 값은 undefined로 떨어져 다음 run에서 scope mismatch 경로로 자가복구.
+    assert.equal(result.c!.lastCrawledBoxScope, undefined);
+    assert.equal(result.d!.lastCrawledBoxScope, undefined);
+    assert.equal(result.e!.lastCrawledBoxScope, undefined);
   });
 });
 

--- a/apps/flex-cli/src/storage/index.ts
+++ b/apps/flex-cli/src/storage/index.ts
@@ -34,6 +34,19 @@ const MAX_OVERLAP_DAYS = 365;
 export interface WatermarkDomainState {
   groups: Record<string, WatermarkGroupState>;
   lastFullReconAt?: string;
+  /**
+   * 직전 성공 run이 사용한 검색 스코프. approval-documents 도메인 한정 — 다른
+   * 도메인은 이 필드를 사용하지 않는다.
+   *
+   * 다음 run에서 결정된 스코프와 비교해, 다르거나 비어 있으면 그 run을
+   * effectiveFull로 강제한다. 핵심 사용 케이스 두 가지:
+   *   1. user-boxes 시절 워터마크를 가진 환경이 customer-boxes로 업그레이드된
+   *      직후: 디스크에 이 필드가 없음 → 첫 run 자동 full → 백필.
+   *      운영자가 `--mode=full`을 까먹어도 같은 결과.
+   *   2. 관리자 권한이 회수/부여되어 스코프가 user↔customer로 바뀌는 경우도
+   *      같은 메커니즘으로 자가복구.
+   */
+  lastCrawledBoxScope?: "customer" | "user";
 }
 
 export interface WatermarkFile {
@@ -165,9 +178,17 @@ export function normalizeWatermarkFile(
       }
     }
     const lastFullReconAt = (rawState as Record<string, unknown>).lastFullReconAt;
+    const lastCrawledBoxScope = (rawState as Record<string, unknown>).lastCrawledBoxScope;
     out[domain] = {
       groups,
       lastFullReconAt: typeof lastFullReconAt === "string" ? lastFullReconAt : undefined,
+      // "customer"/"user" 외 값은 손상으로 간주하고 undefined로 처리한다.
+      // undefined가 되면 다음 run에서 scope mismatch가 일어나 자동으로 full
+      // recon이 트리거되므로, 손상된 필드는 자가복구된다.
+      lastCrawledBoxScope:
+        lastCrawledBoxScope === "customer" || lastCrawledBoxScope === "user"
+          ? lastCrawledBoxScope
+          : undefined,
     };
   }
   return out;

--- a/apps/flex-cli/src/storage/index.ts
+++ b/apps/flex-cli/src/storage/index.ts
@@ -54,6 +54,15 @@ export interface CrawlReport {
    * 누락 등의 신호. 자동 tombstone은 별도 트랙. incremental 실행에선 비워둔다.
    */
   instancesMissing?: string[];
+  /**
+   * 이번 실행이 사용한 결재 문서 검색 스코프.
+   *  - "customer": `/customer-boxes/search` — 워크스페이스 전체.
+   *  - "user":     `/user-boxes/search`     — 로그인 계정 관여 문서만.
+   * "user"로 떨어지면 관리자 권한 부재로 모집단이 좁아진 상태이므로 운영자는
+   * `totalErrors`에서 `instance-scope` 항목을 함께 확인해야 한다.
+   * 인스턴스 단계가 시작 전에 실패하면 미정의일 수 있다.
+   */
+  instancesBoxScope?: "customer" | "user";
   totalErrors: CrawlError[];
 }
 

--- a/apps/flex-cli/src/storage/index.ts
+++ b/apps/flex-cli/src/storage/index.ts
@@ -70,10 +70,10 @@ export interface CrawlReport {
   /**
    * 이번 실행이 사용한 결재 문서 검색 스코프.
    *  - "customer": `/customer-boxes/search` — 워크스페이스 전체.
-   *  - "user":     `/user-boxes/search`     — 로그인 계정 관여 문서만.
-   * "user"로 떨어지면 관리자 권한 부재로 모집단이 좁아진 상태이므로 운영자는
-   * `totalErrors`에서 `instance-scope` 항목을 함께 확인해야 한다.
-   * 인스턴스 단계가 시작 전에 실패하면 미정의일 수 있다.
+   *  - "user":     `/user-boxes/search`     — 로그인 계정 관여 문서만. 관리자
+   *                권한 부재로 폴백되어 모집단이 좁아진 상태일 수 있다.
+   * 인스턴스 단계가 시작 전에 실패하면 미정의 (probe 실패는 totalErrors의
+   * `instance-list` 항목으로 별도 노출됨).
    */
   instancesBoxScope?: "customer" | "user";
   totalErrors: CrawlError[];


### PR DESCRIPTION
## Summary

Switches the instance crawler from `user-boxes/search` (logged-in account's
작성함/결재함/참조함/즐겨찾기) to `customer-boxes/search` (workspace-wide),
with a transparent fallback to `user-boxes` on 403, and **auto-triggers a
full recon when the saved watermark's box scope differs from the resolved
scope (or is absent)**.

Refs: planetarium/reflex#49

## Why

[planetarium/reflex#49] reported that ~6,665 approval documents in the
`bYG0dkR8we` workspace are missing from the import, even though the same
account that runs the crawler can find them in the flex.team UI. Logs and
data ruled out pagination/cursor bugs — every paginated cycle returned
exactly the `total` the API reported. The API itself was returning a much
smaller population than what exists in the workspace.

Attaching a browser to a logged-in flex.team session and capturing the
network calls showed:

| flex.team page | endpoint |
| --- | --- |
| 내 문서함 (`/workflow/archive/my`) | `/action/v3/approval-document/`**`user-boxes`**`/search` |
| 회사 문서함 (`/workflow/archive/all`) | `/action/v3/approval-document/`**`customer-boxes`**`/search` |

Same request body, same query string. The path segment encodes the scope:

- `user-boxes` — docs the logged-in user is involved with
- `customer-boxes` — workspace-wide; admin permission required

Route-existence was triple-confirmed:

- `GET customer-boxes/search` → 405 with `instance` echo (route exists, method
  not POSTed)
- `POST nonsense-boxes/search` → 404 with `code: COMMON_500_000`
- `POST customer-boxes/search` (non-admin) → 403 `PERM_403_000`

## What changes

- `instance.ts`: probe `customer-boxes/search` with `size=1` (wrapped in
  `withRetry`; 429/5xx/network blips retry, 4xx fast-fail) before the
  group loop; on 200 use it for the run, on 403 fall back to `user-boxes`.
  The 403 fallback is *not* pushed to `result.errors` — that would make
  `flex-ax crawl` exit code 2, making CI/cron unable to distinguish it
  from real failures. Visibility comes from `logger.warn` plus the
  `instancesBoxScope: "user"` field on the saved report. Non-403 probe
  failures (5xx/401/network after retries exhausted) propagate to the
  list-stage catch and surface as `instance-list` errors.
- **Auto-migration**: the watermark domain state now records
  `lastCrawledBoxScope`. If the resolved scope on a run differs from the
  recorded one (or the field is absent — i.e. a pre-upgrade watermark from
  the user-boxes era), the cycle is forced to `effectiveFull` regardless of
  `--mode`. Two failure modes this fixes:
    1. Deploy handoff: operators don't have to remember to pass
       `--mode=full` once for backfill. The first run after merge sees the
       missing field, treats itself as full, picks up every document the old
       user-boxes scope hid, and writes scope=customer. Subsequent runs
       return to normal incremental.
    2. Live permission flips: if admin permission is later revoked/granted,
       scope flips customer↔user and the next cycle self-heals — no operator
       intervention required.
- The scope commit is gated on `listStageOk && failureCount === 0`,
  matching the existing `lastFullReconAt` gate. Partial-failure cycles
  leave the field as-is so the self-heal path retriggers next run.
- `crawl.ts` + `storage/index.ts`: surface the resolved scope as
  `instancesBoxScope` on the saved report (omitted entirely when scope
  resolution didn't complete, so no misleading default leaks through).
  Watermark normalizer keeps only `"customer"|"user"` and drops anything
  else (corrupt values auto-recover via the same mismatch path).
- Tests: existing search-call assertions filter out the size=1 probe via a
  new `isRealSearchCall` helper. New tests cover: customer-200 success,
  403-fallback (asserting no `result.errors` push), non-403 abort,
  4xx/429 retry behavior on probe, catalog override on user-boxes URL,
  migration (missing scope → forces full), matching scope (stays
  incremental), scope flip (customer→user forces full), and
  partial-failure (no scope commit).

## Operational note

After merge, **operators don't need to do anything special** — the first
cron tick on each workspace will self-detect "missing scope field" and run
a full recon automatically. `crawl-report.json` will show
`instancesBoxScope: "customer"` (admin accounts) or `"user"` (non-admin
fallback). Non-admin runs do not fail CI — the report's scope field is the
authoritative signal that the population was narrower.

## Test plan

- [x] `bun run lint` clean
- [x] `bun test` — 115/115 pass
- [ ] Smoke: run `flex-ax crawl` (no `--mode`) against bYG0dkR8we with admin
      account; verify the first cycle logs the "스코프 변경 감지" message,
      runs full recon, and `crawl-report.json` shows
      `instancesBoxScope: "customer"` + `instances.successCount` in the
      8,000+ range (vs ~2,800 before).
- [ ] Smoke: second cycle on same workspace verifies it returns to
      incremental (no force-full, dateRange present in search bodies).
- [ ] Smoke: run with a non-admin account; verify the run exits 0,
      `instancesBoxScope: "user"`, and a single `logger.warn` line is
      emitted on the fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)